### PR TITLE
feat: add docker-compose cloud configuration

### DIFF
--- a/.github/workflows/dev-cleanup.yml
+++ b/.github/workflows/dev-cleanup.yml
@@ -30,10 +30,10 @@ jobs:
           proxy_port:     ${{ secrets.SSH_PROXY_PORT }}
           envs:     PROJECT_ID
           script: |
-            cd /srv/$PROJECT_ID                            && \
-            git checkout dev                               && \
-            git pull                                       && \
-            ./vendor/bin/sail artisan migrate:fresh --seed
+            cd /srv/$PROJECT_ID && \
+            git checkout dev && \
+            git pull && \
+            /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec app ./artisan migrate:fresh --seed
 
       - name: Wait
         run: sleep 15

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -31,11 +31,11 @@ jobs:
           proxy_port:     ${{ secrets.SSH_PROXY_PORT }}
           envs:     PROJECT_ID
           script: |
-            cd /srv/$PROJECT_ID                       && \
-            git checkout dev                          && \
-            git pull                                  && \
-            ./vendor/bin/sail up -d --force-recreate  && \
-            ./vendor/bin/sail artisan migrate
+            cd /srv/$PROJECT_ID && \
+            git checkout dev && \
+            git pull && \
+            /usr/local/bin/docker-compose -f docker-compose.cloud.yml up -d --force-recreate && \
+            /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec app ./artisan migrate
 
       - name: Wait
         run: sleep 15

--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -1,0 +1,46 @@
+FROM ubuntu:20.04
+
+WORKDIR /var/www/html
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV TZ=UTC
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
+    && mkdir -p ~/.gnupg \
+    && chmod 600 ~/.gnupg \
+    && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+    && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E5267A6C \
+    && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C300EE8C \
+    && echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu focal main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
+    && apt-get update \
+    && apt-get install -y php8.0-cli php8.0-dev \
+       php8.0-pgsql php8.0-sqlite3 php8.0-gd \
+       php8.0-curl php8.0-memcached \
+       php8.0-imap php8.0-mysql php8.0-mbstring \
+       php8.0-xml php8.0-zip php8.0-bcmath php8.0-soap \
+       php8.0-intl php8.0-readline \
+       php8.0-msgpack php8.0-igbinary php8.0-ldap \
+       php8.0-redis \
+    && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
+    && curl -sL https://deb.nodesource.com/setup_15.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get install -y yarn \
+    && apt-get install -y mysql-client \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
+
+COPY docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY docker/php.ini /etc/php/8.0/cli/conf.d/99-sail.ini
+
+EXPOSE 80
+
+ENTRYPOINT ["/usr/bin/supervisord"]

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -1,0 +1,36 @@
+version: '3'
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.cloud
+    ports:
+      - ${APP_PORT}:80
+    volumes:
+      - .:/var/www/html
+    depends_on:
+      - mysql
+      - redis
+      - mailhog
+
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: ${DB_DATABASE}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - ${DB_DIR}:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping"]
+
+  redis:
+    image: redis:alpine
+    volumes:
+      - ${REDIS_DIR}:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+
+  mailhog:
+    image: mailhog/mailhog:latest

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,0 +1,4 @@
+[PHP]
+post_max_size = 250M
+upload_max_filesize = 250M
+variables_order = EGPCS

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,10 @@
+[supervisord]
+nodaemon=true
+
+[program:php]
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
+user=www-data
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
@greatislander This extracts the Dockerfile (and auxiliary files) from Sail and adds a separate docker-compose file useful only for cloud deployments. I feel like this avoids introducing incompatibilities with Sail so people can still use it and the instructions don't change.

I don't like working with Docker volumes because they are hard to backup so I introduced two new variables DB_DIR and REDIS_DIR to specify the path where the data directories should be mounted from.

I'm also not exposing MySQL or Redis (through FORWARD_ variables) because that's not necessary in the cloud deployment. If the time comes that we need to connect inside them to run ad-hoc commands, we just `docker exec` into them.

Please let me know if you have any suggestions. This largely follows the scheme used for the SJRK websites.