### PR TITLE
feat: Mount storage directory outside main app

### DIFF
--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -11,7 +11,6 @@ services:
     depends_on:
       - mysql
       - redis
-      - mailhog
 
   mysql:
     image: mysql:8.0
@@ -31,6 +30,3 @@ services:
       - ${REDIS_DIR}:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-
-  mailhog:
-    image: mailhog/mailhog:latest

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -8,6 +8,7 @@ services:
       - ${APP_PORT}:80
     volumes:
       - .:/var/www/html
+      - ${APP_STORAGE_DIR}:/var/www/html/storage
     depends_on:
       - mysql
       - redis


### PR DESCRIPTION
Laravel needs a writeable area outside in the `storage` directory. 

It's best practice to mount this as a writeable directory outside the main app code (instead of giving the app writeable access to all the contents of `/var/www/html` likes it's done in Sail), so the attack surface is minimized (e.g. attacker can't change code on the fly).

Also, remove the `mailhog` container because Laravel needs to use the proper SMTP server (using `MAIL_` env vars).