### PR TITLE
fix: run composer install when deploying

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -34,6 +34,7 @@ jobs:
             cd /srv/$PROJECT_ID && \
             git checkout dev && \
             git pull && \
+            composer install --no-dev --optimize-autoloader && \
             /usr/local/bin/docker-compose -f docker-compose.cloud.yml up -d --force-recreate && \
             /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec -T app ./artisan migrate --force
 


### PR DESCRIPTION
The current deploy won't receive new dependencies via Composer, so I've added an optimized `composer install` command to the deploy workflow.