### PR TITLE
chore: add seeders for Content Type, Format, and Topic

### DIFF
--- a/database/seeders/AccessSupportSeeder.php
+++ b/database/seeders/AccessSupportSeeder.php
@@ -99,7 +99,7 @@ class AccessSupportSeeder extends Seeder
 
         foreach ($supports as $support) {
             AccessSupport::firstOrCreate([
-                'name' => $support['name'],
+                'name->en' => $support['name'],
                 'in_person' => $support['in_person'] ?? false,
                 'virtual' => $support['virtual'] ?? false,
             ]);

--- a/database/seeders/CommunicationToolSeeder.php
+++ b/database/seeders/CommunicationToolSeeder.php
@@ -26,7 +26,7 @@ class CommunicationToolSeeder extends Seeder
 
         foreach ($tools as $tool) {
             CommunicationTool::firstOrCreate([
-                'name' => $tool,
+                'name->en' => $tool,
             ]);
         }
     }

--- a/database/seeders/CommunitySeeder.php
+++ b/database/seeders/CommunitySeeder.php
@@ -23,7 +23,7 @@ class CommunitySeeder extends Seeder
 
         foreach ($communities as $community) {
             Community::firstOrCreate([
-                'name' => $community,
+                'name->en' => $community,
             ]);
         }
     }

--- a/database/seeders/ConsultingMethodSeeder.php
+++ b/database/seeders/ConsultingMethodSeeder.php
@@ -24,7 +24,7 @@ class ConsultingMethodSeeder extends Seeder
 
         foreach ($methods as $method) {
             ConsultingMethod::firstOrCreate([
-                'name' => $method,
+                'name->en' => $method,
             ]);
         }
     }

--- a/database/seeders/ContentTypeSeeder.php
+++ b/database/seeders/ContentTypeSeeder.php
@@ -23,7 +23,7 @@ class ContentTypeSeeder extends Seeder
 
         foreach ($content_types as $content_type) {
             ContentType::firstOrCreate([
-                'name' => $content_type,
+                'name->en' => $content_type,
             ]);
         }
     }

--- a/database/seeders/FormatSeeder.php
+++ b/database/seeders/FormatSeeder.php
@@ -24,7 +24,7 @@ class FormatSeeder extends Seeder
 
         foreach ($formats as $format) {
             Format::firstOrCreate([
-                'name' => $format,
+                'name->en' => $format,
             ]);
         }
     }

--- a/database/seeders/ImpactSeeder.php
+++ b/database/seeders/ImpactSeeder.php
@@ -26,7 +26,7 @@ class ImpactSeeder extends Seeder
 
         foreach ($impacts as $impact) {
             Impact::firstOrCreate([
-                'name' => $impact,
+                'name->en' => $impact,
             ]);
         }
     }

--- a/database/seeders/LivedExperienceSeeder.php
+++ b/database/seeders/LivedExperienceSeeder.php
@@ -32,7 +32,7 @@ class LivedExperienceSeeder extends Seeder
 
         foreach ($experiences as $experience) {
             LivedExperience::firstOrCreate([
-                'name' => $experience,
+                'name->en' => $experience,
             ]);
         }
     }

--- a/database/seeders/PaymentMethodSeeder.php
+++ b/database/seeders/PaymentMethodSeeder.php
@@ -23,7 +23,7 @@ class PaymentMethodSeeder extends Seeder
 
         foreach ($methods as $method) {
             PaymentMethod::firstOrCreate([
-                'name' => $method,
+                'name->en' => $method,
             ]);
         }
     }

--- a/database/seeders/PhaseSeeder.php
+++ b/database/seeders/PhaseSeeder.php
@@ -22,7 +22,7 @@ class PhaseSeeder extends Seeder
 
         foreach ($phases as $phase) {
             Phase::firstOrCreate([
-                'name' => $phase,
+                'name->en' => $phase,
             ]);
         }
     }

--- a/database/seeders/SectorSeeder.php
+++ b/database/seeders/SectorSeeder.php
@@ -25,7 +25,7 @@ class SectorSeeder extends Seeder
 
         foreach ($sectors as $sector) {
             Sector::firstOrCreate([
-                'name' => $sector,
+                'name->en' => $sector,
             ]);
         }
     }

--- a/database/seeders/TopicSeeder.php
+++ b/database/seeders/TopicSeeder.php
@@ -24,7 +24,7 @@ class TopicSeeder extends Seeder
 
         foreach ($topics as $topic) {
             Topic::firstOrCreate([
-                'name' => $topic,
+                'name->en' => $topic,
             ]);
         }
     }


### PR DESCRIPTION
This PR moves default content for Content Type, Format, Phase and Topic models into seeders.

### Testing

1. Check out this branch.
2. Run:

```bash
sail artisan db:seed ContentTypeSeeder
sail artisan db:seed FormatSeeder
sail artisan db:seed PhaseSeeder
sail artisan db:seed TopicSeeder
```

3. Visit http://localhost/en/resources/all.
4. See that the filters match the following:

![Screen shot of default filters for topic, content type, format, and consultation phase.](https://user-images.githubusercontent.com/605361/138931942-48eda328-376b-48b7-9ac7-e033ed8dc832.png)
