### PR TITLE
feat: add columns to users, orgs, and FROs to indicate validation

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
+            $table->timestamp('oriented_at')->nullable();
             $table->string('password');
             $table->rememberToken();
             $table->string('locale')->default('en');

--- a/database/migrations/2022_07_28_000000_create_organizations_table.php
+++ b/database/migrations/2022_07_28_000000_create_organizations_table.php
@@ -16,6 +16,8 @@ return new class extends Migration
         Schema::create('organizations', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->timestamp('oriented_at')->nullable();
+            $table->timestamp('validated_at')->nullable();
             $table->timestamp('published_at')->nullable();
             $table->json('name');
             $table->json('slug');

--- a/database/migrations/2022_07_28_000000_create_regulated_organizations_table.php
+++ b/database/migrations/2022_07_28_000000_create_regulated_organizations_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
         Schema::create('regulated_organizations', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->timestamp('validated_at')->nullable();
             $table->timestamp('published_at')->nullable();
             $table->json('name');
             $table->json('slug');


### PR DESCRIPTION
This PR adds the following database columns:

- `users`: `oriented_at`
- `organizations`: `oriented_at`, `validated_at`
- `regulated_organizations`: `validated_at`

These will support recording the orientation and validation status of these types.