### PR TITLE
fix: ensure that slugs are always created in both English and French

### DIFF
--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -110,8 +110,10 @@ class Organization extends Model
 
     public function getSlugOptions(): SlugOptions
     {
-        return SlugOptions::create()
-            ->generateSlugsFrom('name')
+        return SlugOptions::createWithLocales(['en', 'fr'])
+            ->generateSlugsFrom(function (Organization $model, $locale): string {
+                return $model->getTranslation('name', $locale);
+            })
             ->saveSlugsTo('slug');
     }
 

--- a/app/Models/RegulatedOrganization.php
+++ b/app/Models/RegulatedOrganization.php
@@ -111,8 +111,10 @@ class RegulatedOrganization extends Model
      */
     public function getSlugOptions(): SlugOptions
     {
-        return SlugOptions::create()
-            ->generateSlugsFrom('name')
+        return SlugOptions::createWithLocales(['en', 'fr'])
+            ->generateSlugsFrom(function (RegulatedOrganization $model, $locale): string {
+                return $model->getTranslation('name', $locale);
+            })
             ->saveSlugsTo('slug');
     }
 

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -47,8 +47,10 @@ class Resource extends Model
      */
     public function getSlugOptions(): SlugOptions
     {
-        return SlugOptions::create()
-            ->generateSlugsFrom('title')
+        return SlugOptions::createWithLocales(['en', 'fr'])
+            ->generateSlugsFrom(function (Resource $model, $locale): string {
+                return $model->getTranslation('title', $locale);
+            })
             ->saveSlugsTo('slug');
     }
 

--- a/app/Models/ResourceCollection.php
+++ b/app/Models/ResourceCollection.php
@@ -43,8 +43,10 @@ class ResourceCollection extends Model
      */
     public function getSlugOptions(): SlugOptions
     {
-        return SlugOptions::create()
-            ->generateSlugsFrom('title')
+        return SlugOptions::createWithLocales(['en', 'fr'])
+            ->generateSlugsFrom(function (ResourceCollection $model, $locale): string {
+                return $model->getTranslation('title', $locale);
+            })
             ->saveSlugsTo('slug');
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -58,7 +58,7 @@ class AppServiceProvider extends ServiceProvider
         StatusManager::bind(Organization::class, OrganizationStatus::class);
         StatusManager::bind(RegulatedOrganization::class, RegulatedOrganizationStatus::class);
         StatusManager::bind(Project::class, ProjectStatus::class);
-        Translatable::fallback(fallbackLocale: 'en');
+        Translatable::fallback(fallbackLocale: 'en', fallbackAny: true);
         User::observe(UserObserver::class);
     }
 }

--- a/database/factories/ResourceCollectionFactory.php
+++ b/database/factories/ResourceCollectionFactory.php
@@ -23,8 +23,8 @@ class ResourceCollectionFactory extends Factory
     public function definition()
     {
         return [
-            'title' => $this->faker->words(3, true),
-            'description' => $this->faker->sentence(),
+            'title' => ['en' => $this->faker->words(3, true)],
+            'description' => ['en' => $this->faker->sentence()],
             'user_id' => User::factory(),
         ];
     }

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -20,12 +20,10 @@ class ResourceFactory extends Factory
      *
      * @return array
      */
-    public function definition()
+    public function definition(): array
     {
-        $title = $this->faker->words(3, true);
-
         return [
-            'title' => $title,
+            'title' => ['en' => $this->faker->words(3, true)],
             'summary' => $this->faker->sentence(),
             'user_id' => User::factory(),
         ];

--- a/tests/Feature/OrganizationTest.php
+++ b/tests/Feature/OrganizationTest.php
@@ -903,3 +903,13 @@ test('organizational relationships to projects can be derived from both projects
         ->toHaveCount(1)
         ->toContain($participatingEngagementProject->id);
 });
+
+test('organizations have slugs in both languages even if only one is provided', function () {
+    $organization = Organization::factory()->create();
+    expect($organization->getTranslation('slug', 'fr', false))
+        ->toEqual($organization->getTranslation('slug', 'en', false));
+
+    $organization = Organization::factory()->create(['name' => ['fr' => 'Mon entreprise']]);
+    expect($organization->getTranslation('slug', 'en', false))
+        ->toEqual($organization->getTranslation('slug', 'fr', false));
+});

--- a/tests/Feature/RegulatedOrganizationTest.php
+++ b/tests/Feature/RegulatedOrganizationTest.php
@@ -623,3 +623,13 @@ test('user can view regulated organization in different languages', function () 
     $response = $this->actingAs($user)->get(localized_route('regulated-organizations.show', ['regulatedOrganization' => $regulatedOrganization, 'language' => 'fcs']));
     $response->assertSee('Agence du revenue du Canada');
 });
+
+test('regulated organizations have slugs in both languages even if only one is provided', function () {
+    $regulatedOrg = RegulatedOrganization::factory()->create();
+    expect($regulatedOrg->getTranslation('slug', 'fr', false))
+        ->toEqual($regulatedOrg->getTranslation('slug', 'en', false));
+
+    $regulatedOrg = RegulatedOrganization::factory()->create(['name' => ['fr' => 'Santé Canada']]);
+    expect($regulatedOrg->getTranslation('slug', 'en', false))
+        ->toEqual($regulatedOrg->getTranslation('slug', 'fr', false));
+});

--- a/tests/Feature/ResourceCollectionTest.php
+++ b/tests/Feature/ResourceCollectionTest.php
@@ -113,3 +113,13 @@ test('deleting resource belong to resource collection', function () {
         'resource_id' => $resource->id,
     ]);
 });
+
+test('resource collections have slugs in both languages even if only one is provided', function () {
+    $collection = ResourceCollection::factory()->create();
+    expect($collection->getTranslation('slug', 'fr', false))
+        ->toEqual($collection->getTranslation('slug', 'en', false));
+
+    $collection = ResourceCollection::factory()->create(['title' => ['fr' => 'Mon collecte de ressources']]);
+    expect($collection->getTranslation('slug', 'en', false))
+        ->toEqual($collection->getTranslation('slug', 'fr', false));
+});

--- a/tests/Feature/ResourceTest.php
+++ b/tests/Feature/ResourceTest.php
@@ -147,3 +147,13 @@ test('deleting resource collection with resource', function () {
         'resource_id' => $resource->id,
     ]);
 });
+
+test('resources have slugs in both languages even if only one is provided', function () {
+    $resource = Resource::factory()->create();
+    expect($resource->getTranslation('slug', 'fr', false))
+        ->toEqual($resource->getTranslation('slug', 'en', false));
+
+    $resource = Resource::factory()->create(['title' => ['fr' => 'Mon ressource']]);
+    expect($resource->getTranslation('slug', 'en', false))
+        ->toEqual($resource->getTranslation('slug', 'fr', false));
+});


### PR DESCRIPTION
Resolves 404 error while creating a community organization with only a French title while using the site in English, as well as many other potential issues as yet undiscovered.