### PR TITLE
fix: don't show type selection for invitees (resolves #591)

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -53,7 +53,8 @@ class UserController extends Controller
     {
         $skipTo = match (Auth::user()->context) {
             'individual' => localized_route('individuals.show-role-selection'),
-            'regulated-organization' => localized_route('regulated-organizations.show-type-selection'),
+            'organization' => $user->extra_attributes->get('invitation') ? localized_route('dashboard') : localized_route('organizations.show-type-selection'),
+            'regulated-organization' => $user->extra_attributes->get('invitation') ? localized_route('dashboard') : localized_route('regulated-organizations.show-type-selection'),
             default => localized_route('dashboard'),
         };
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -51,7 +51,9 @@ class UserController extends Controller
      */
     public function showIntroduction(): View
     {
-        $skipTo = match (Auth::user()->context) {
+        $user = Auth::user();
+
+        $skipTo = match ($user->context) {
             'individual' => localized_route('individuals.show-role-selection'),
             'organization' => $user->extra_attributes->get('invitation') ? localized_route('dashboard') : localized_route('organizations.show-type-selection'),
             'regulated-organization' => $user->extra_attributes->get('invitation') ? localized_route('dashboard') : localized_route('regulated-organizations.show-type-selection'),
@@ -59,7 +61,7 @@ class UserController extends Controller
         };
 
         return view('users.show-introduction', [
-            'user' => Auth::user(),
+            'user' => $user,
             'skipTo' => $skipTo,
         ]);
     }

--- a/routes/invitations.php
+++ b/routes/invitations.php
@@ -7,11 +7,11 @@ Route::multilingual('/invitations/create', [InvitationController::class, 'create
     ->name('invitations.create');
 
 Route::get('/invitations/{invitation}', [InvitationController::class, 'accept'])
-    ->middleware(['signed'])
+    ->middleware(['signed', 'verified'])
     ->name('invitations.accept');
 
 Route::delete('/invitations/{invitation}/decline', [InvitationController::class, 'decline'])
-    ->middleware(['auth'])
+    ->middleware(['auth', 'verified'])
     ->name('invitations.decline');
 
 Route::delete('/invitations/{invitation}/cancel', [InvitationController::class, 'destroy'])

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Models\User;
-use function Pest\Faker\faker;
 
 test('users can view the introduction', function () {
     $user = User::factory()->create();
@@ -267,7 +266,7 @@ test('user’s alternate contact method can be retrieved', function () {
 test('user extra attributes and notification settings can be queried', function () {
     $users = User::factory()->count(5)->create([
         'extra_attributes' => [
-            'invited_role' => faker()->randomElement(['participant', 'consultant', 'connector']),
+            'invited_role' => 'participant',
         ],
         'notification_settings' => [
             'updates' => [
@@ -280,13 +279,17 @@ test('user extra attributes and notification settings can be queried', function 
 
     $invitedParticipants = User::withExtraAttributes('invited_role', 'participant')->get();
 
+    expect($invitedParticipants)->toHaveCount(5);
+
     foreach ($invitedParticipants as $participant) {
         expect($participant->extra_attributes->invited_role)->toEqual('participant');
     }
 
-    $updateNotificationUsers = User::withNotificationSettings(['updates' => ['channels' => 'contact']])->get();
+    $updateNotificationUsers = User::withNotificationSettings('updates->channels', '["contact"]')->get();
+
+    expect($updateNotificationUsers)->toHaveCount(5);
 
     foreach ($updateNotificationUsers as $user) {
-        expect($user->notification_settings->updates->channels)->toEqual(['contact']);
+        expect($user->notification_settings->updates['channels'])->toContain('contact');
     }
 });


### PR DESCRIPTION
Resolves #591.

### Testing

1. Invite someone to join a Regulated Organization.
2. Register via the invitation email.
3. Skip the introduction. Ensure that you are redirected to your dashboard.