### PR TITLE
fix: restore email templates, exclude vendor views from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore vendor templates
+resources/views/vendor/**/*.blade.php

--- a/resources/views/vendor/mail/html/button.blade.php
+++ b/resources/views/vendor/mail/html/button.blade.php
@@ -1,20 +1,19 @@
-<table class="action" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-        <td align="center">
-            <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td align="center">
-                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                            <tr>
-                                <td>
-                                    <a class="button button-{{ $color ?? 'primary' }}" href="{{ $url }}"
-                                        target="_blank" rel="noopener">{{ $slot }}</a>
-                                </td>
-                            </tr>
-                        </table>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
+<table class="action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+<tr>
+<td align="center">
+<table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+<tr>
+<td align="center">
+<table border="0" cellpadding="0" cellspacing="0" role="presentation">
+<tr>
+<td>
+<a href="{{ $url }}" class="button button-{{ $color ?? 'primary' }}" target="_blank" rel="noopener">{{ $slot }}</a>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+</tr>
 </table>

--- a/resources/views/vendor/mail/html/footer.blade.php
+++ b/resources/views/vendor/mail/html/footer.blade.php
@@ -1,11 +1,11 @@
 <tr>
-    <td>
-        <table class="footer" role="presentation" align="center" width="570" cellpadding="0" cellspacing="0">
-            <tr>
-                <td class="content-cell" align="center">
-                    {{ Illuminate\Mail\Markdown::parse($slot) }}
-                </td>
-            </tr>
-        </table>
-    </td>
+<td>
+<table class="footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+<tr>
+<td class="content-cell" align="center">
+{{ Illuminate\Mail\Markdown::parse($slot) }}
+</td>
+</tr>
+</table>
+</td>
 </tr>

--- a/resources/views/vendor/mail/html/header.blade.php
+++ b/resources/views/vendor/mail/html/header.blade.php
@@ -1,11 +1,11 @@
 <tr>
-    <td class="header">
-        <a href="{{ $url }}" style="display: inline-block;">
-            @if (trim($slot) === 'Laravel')
-                <img class="logo" src="https://laravel.com/img/notification-logo.png" alt="Laravel Logo">
-            @else
-                {{ $slot }}
-            @endif
-        </a>
-    </td>
+<td class="header">
+<a href="{{ $url }}" style="display: inline-block;">
+@if (trim($slot) === 'Laravel')
+<img src="https://laravel.com/img/notification-logo.png" class="logo" alt="Laravel Logo">
+@else
+{{ $slot }}
+@endif
+</a>
+</td>
 </tr>

--- a/resources/views/vendor/mail/html/layout.blade.php
+++ b/resources/views/vendor/mail/html/layout.blade.php
@@ -1,61 +1,56 @@
-<!DOCTYPE html
-    PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
-
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="color-scheme" content="light">
-    <meta name="supported-color-schemes" content="light">
-    <style>
-        @media only screen and (max-width: 600px) {
-            .inner-body {
-                width: 100% !important;
-            }
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta name="color-scheme" content="light">
+<meta name="supported-color-schemes" content="light">
+<style>
+@media only screen and (max-width: 600px) {
+.inner-body {
+width: 100% !important;
+}
 
-            .footer {
-                width: 100% !important;
-            }
-        }
+.footer {
+width: 100% !important;
+}
+}
 
-        @media only screen and (max-width: 500px) {
-            .button {
-                width: 100% !important;
-            }
-        }
-    </style>
+@media only screen and (max-width: 500px) {
+.button {
+width: 100% !important;
+}
+}
+</style>
 </head>
-
 <body>
 
-    <table class="wrapper" role="presentation" width="100%" cellpadding="0" cellspacing="0">
-        <tr>
-            <td align="center">
-                <table class="content" role="presentation" width="100%" cellpadding="0" cellspacing="0">
-                    {{ $header ?? '' }}
+<table class="wrapper" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+<tr>
+<td align="center">
+<table class="content" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+{{ $header ?? '' }}
 
-                    <!-- Email Body -->
-                    <tr>
-                        <td class="body" width="100%" cellpadding="0" cellspacing="0">
-                            <table class="inner-body" role="presentation" align="center" width="570" cellpadding="0"
-                                cellspacing="0">
-                                <!-- Body content -->
-                                <tr>
-                                    <td class="content-cell">
-                                        {{ Illuminate\Mail\Markdown::parse($slot) }}
+<!-- Email Body -->
+<tr>
+<td class="body" width="100%" cellpadding="0" cellspacing="0">
+<table class="inner-body" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+<!-- Body content -->
+<tr>
+<td class="content-cell">
+{{ Illuminate\Mail\Markdown::parse($slot) }}
 
-                                        {{ $subcopy ?? '' }}
-                                    </td>
-                                </tr>
-                            </table>
-                        </td>
-                    </tr>
+{{ $subcopy ?? '' }}
+</td>
+</tr>
+</table>
+</td>
+</tr>
 
-                    {{ $footer ?? '' }}
-                </table>
-            </td>
-        </tr>
-    </table>
+{{ $footer ?? '' }}
+</table>
+</td>
+</tr>
+</table>
 </body>
-
 </html>

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -1,27 +1,27 @@
 @component('mail::layout')
-    {{-- Header --}}
-    @slot('header')
-        @component('mail::header', ['url' => config('app.url')])
-            {{ config('app.name') }}
-        @endcomponent
-    @endslot
+{{-- Header --}}
+@slot('header')
+@component('mail::header', ['url' => config('app.url')])
+{{ config('app.name') }}
+@endcomponent
+@endslot
 
-    {{-- Body --}}
-    {{ $slot }}
+{{-- Body --}}
+{{ $slot }}
 
-    {{-- Subcopy --}}
-    @isset($subcopy)
-        @slot('subcopy')
-            @component('mail::subcopy')
-                {{ $subcopy }}
-            @endcomponent
-        @endslot
-    @endisset
+{{-- Subcopy --}}
+@isset($subcopy)
+@slot('subcopy')
+@component('mail::subcopy')
+{{ $subcopy }}
+@endcomponent
+@endslot
+@endisset
 
-    {{-- Footer --}}
-    @slot('footer')
-        @component('mail::footer')
-            © {{ date('Y') }} {{ config('app.name') }}. @lang('All rights reserved.')
-        @endcomponent
-    @endslot
+{{-- Footer --}}
+@slot('footer')
+@component('mail::footer')
+© {{ date('Y') }} {{ config('app.name') }}. @lang('All rights reserved.')
+@endcomponent
+@endslot
 @endcomponent

--- a/resources/views/vendor/mail/html/panel.blade.php
+++ b/resources/views/vendor/mail/html/panel.blade.php
@@ -1,13 +1,14 @@
-<table class="panel" role="presentation" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-        <td class="panel-content">
-            <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td class="panel-item">
-                        {{ Illuminate\Mail\Markdown::parse($slot) }}
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
+<table class="panel" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+<tr>
+<td class="panel-content">
+<table width="100%" cellpadding="0" cellspacing="0" role="presentation">
+<tr>
+<td class="panel-item">
+{{ Illuminate\Mail\Markdown::parse($slot) }}
+</td>
+</tr>
 </table>
+</td>
+</tr>
+</table>
+

--- a/resources/views/vendor/mail/html/subcopy.blade.php
+++ b/resources/views/vendor/mail/html/subcopy.blade.php
@@ -1,7 +1,7 @@
-<table class="subcopy" role="presentation" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-        <td>
-            {{ Illuminate\Mail\Markdown::parse($slot) }}
-        </td>
-    </tr>
+<table class="subcopy" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+<tr>
+<td>
+{{ Illuminate\Mail\Markdown::parse($slot) }}
+</td>
+</tr>
 </table>

--- a/resources/views/vendor/mail/html/table.blade.php
+++ b/resources/views/vendor/mail/html/table.blade.php
@@ -1,3 +1,3 @@
 <div class="table">
-    {{ Illuminate\Mail\Markdown::parse($slot) }}
+{{ Illuminate\Mail\Markdown::parse($slot) }}
 </div>

--- a/resources/views/vendor/mail/text/layout.blade.php
+++ b/resources/views/vendor/mail/text/layout.blade.php
@@ -2,7 +2,8 @@
 
 {!! strip_tags($slot) !!}
 @isset($subcopy)
-    {!! strip_tags($subcopy) !!}
+
+{!! strip_tags($subcopy) !!}
 @endisset
 
 {!! strip_tags($footer) !!}

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -1,56 +1,61 @@
 @component('mail::message')
-    {{-- Greeting --}}
-    @if (!empty($greeting))
-        # {{ $greeting }}
-    @else
-        @if ($level === 'error')
-            # @lang('mail.error')
-        @else
-            # @lang('mail.greeting')
-        @endif
-    @endif
+{{-- Greeting --}}
+@if (! empty($greeting))
+# {{ $greeting }}
+@else
+@if ($level === 'error')
+# @lang('mail.error')
+@else
+# @lang('mail.greeting')
+@endif
+@endif
 
-    {{-- Intro Lines --}}
-    @foreach ($introLines as $line)
-        {{ $line }}
-    @endforeach
+{{-- Intro Lines --}}
+@foreach ($introLines as $line)
+{{ $line }}
 
-    {{-- Action Button --}}
-    @isset($actionText)
-        <?php
-        switch ($level) {
-            case 'success':
-            case 'error':
-                $color = $level;
-                break;
-            default:
-                $color = 'primary';
-        }
-        ?>
-        @component('mail::button', ['url' => $actionUrl, 'color' => $color])
-            {{ $actionText }}
-        @endcomponent
-    @endisset
+@endforeach
 
-    {{-- Outro Lines --}}
-    @foreach ($outroLines as $line)
-        {{ $line }}
-    @endforeach
+{{-- Action Button --}}
+@isset($actionText)
+<?php
+    switch ($level) {
+        case 'success':
+        case 'error':
+            $color = $level;
+            break;
+        default:
+            $color = 'primary';
+    }
+?>
+@component('mail::button', ['url' => $actionUrl, 'color' => $color])
+{{ $actionText }}
+@endcomponent
+@endisset
 
-    {{-- Salutation --}}
-    @if (!empty($salutation))
-        {{ $salutation }}
-    @else
-        @lang('mail.salutation'),<br>
-        {{ config('app.name') }}
-    @endif
+{{-- Outro Lines --}}
+@foreach ($outroLines as $line)
+{{ $line }}
 
-    {{-- Subcopy --}}
-    @isset($actionText)
-        @slot('subcopy')
-            @lang('mail.link_guidance', [
-                'actionText' => $actionText,
-            ]) <span class="break-all">[{{ $displayableActionUrl }}]({{ $actionUrl }})</span>
-        @endslot
-    @endisset
+@endforeach
+
+{{-- Salutation --}}
+@if (! empty($salutation))
+{{ $salutation }}
+@else
+@lang('mail.salutation'),<br>
+{{ config('app.name') }}
+@endif
+
+{{-- Subcopy --}}
+@isset($actionText)
+@slot('subcopy')
+@lang(
+    'mail.link_guidance',
+    [
+        'actionText' => $actionText,
+    ]
+) <span class="break-all">[{{ $displayableActionUrl }}]({{ $actionUrl }})</span>
+@endslot
+@endisset
 @endcomponent


### PR DESCRIPTION
Partially reverts commit d31e9fbb14068a3ee28d0850104ffb08661d970f.

Fixes a formatting regression in mail templates introduced in #960.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.