### PR TITLE
fix: restore invitation email formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 # Ignore vendor templates
-resources/views/vendor/**/*.blade.php
+resources/views/mail/**/*.blade.php
+resources/views/vendor/mail/**/*.blade.php
+resources/views/vendor/notifications/**/*.blade.php

--- a/resources/views/mail/invitation.blade.php
+++ b/resources/views/mail/invitation.blade.php
@@ -1,24 +1,24 @@
 @component('mail::message')
-    {{ __('You have been invited to join the :invitationable team!', ['invitationable' => $invitation->invitationable->name]) }}
+{{ __('You have been invited to join the :invitationable team!', ['invitationable' => $invitation->invitationable->name]) }}
 
-    {{ __('If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the invitation:') }}
+{{ __('If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the invitation:') }}
 
-    @component('mail::button',
-        [
-            'url' => localized_route('register', [
-                'invitation' => 1,
-                'context' => context_from_model($invitation->invitationable),
-                'email' => $invitation->email,
-            ]),
-        ])
-        {{ __('Create Account') }}
-    @endcomponent
+@component('mail::button',
+    [
+        'url' => localized_route('register', [
+            'invitation' => 1,
+            'context' => context_from_model($invitation->invitationable),
+            'email' => $invitation->email,
+        ]),
+    ])
+{{ __('Create Account') }}
+@endcomponent
 
-    {{ __('If you already have an account, you may accept this invitation by clicking the button below:') }}
+{{ __('If you already have an account, you may accept this invitation by clicking the button below:') }}
 
-    @component('mail::button', ['url' => $acceptUrl])
-        {{ __('Accept Invitation') }}
-    @endcomponent
+@component('mail::button', ['url' => $acceptUrl])
+{{ __('Accept Invitation') }}
+@endcomponent
 
-    {{ __('If you did not expect to receive an invitation to this team, you may discard this email.') }}
+{{ __('If you did not expect to receive an invitation to this team, you may discard this email.') }}
 @endcomponent


### PR DESCRIPTION
Fixes regression in invitation emails from #960 (see https://github.com/accessibility-exchange/platform/pull/961#issuecomment-1230766142).

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.