### PR TITLE
fix: roles and permissions access (resolves #848)

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -392,6 +392,9 @@ class SettingsController extends Controller
     public function editRolesAndPermissions(): View
     {
         $user = Auth::user();
+
+        $this->authorize('editRolesAndPermissions', $user);
+
         $roles = [];
 
         foreach (config('hearth.organizations.roles') as $role) {
@@ -416,6 +419,9 @@ class SettingsController extends Controller
     public function inviteToInvitationable(): View|RedirectResponse
     {
         $user = Auth::user();
+
+        $this->authorize('editRolesAndPermissions', $user);
+
         $invitationable = match ($user->context) {
             'organization' => $user->organization ?? null,
             'regulated-organization' => $user->regulatedOrganization ?? null,

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -16,4 +16,16 @@ class UserPolicy
             ? Response::allow()
             : Response::deny(__('You cannot select a role.'));
     }
+
+    public function editRolesAndPermissions(User $user): Response
+    {
+        return ($user->context == 'regulated-organization' && $user->regulatedOrganization) || ($user->context == 'organization' && $user->organization)
+            ? Response::allow()
+            : Response::deny(__('You must belong to an :organization in order to manage its roles and permissions.', [
+                'organization' => match ($user->context) {
+                    'regulated-organization' => __('regulated organization'),
+                    default => __('organization.singular_name')
+                },
+            ]));
+    }
 }

--- a/tests/Feature/UserSettingsTest.php
+++ b/tests/Feature/UserSettingsTest.php
@@ -355,7 +355,7 @@ test('users can edit roles and permissions', function () {
     $response->assertOk();
 });
 
-test('users can invite new members to their organization or regulated organization', function () {
+test('users belong to an organization can invite new members to their organization or regulated organization', function () {
     $regulatedOrganizationUser = User::factory()->create(['context' => 'regulated-organization']);
     $regulatedOrganization = RegulatedOrganization::factory()
         ->hasAttached($regulatedOrganizationUser, ['role' => 'admin'])
@@ -378,7 +378,7 @@ test('users can invite new members to their organization or regulated organizati
 
     $individualUser = User::factory()->create();
     $response = $this->actingAs($individualUser)->get(localized_route('settings.invite-to-invitationable'));
-    $response->assertRedirect(localized_route('settings.edit-roles-and-permissions'));
+    $response->assertForbidden();
 });
 
 test('guests can not edit roles and permissions', function () {


### PR DESCRIPTION
Add a new policy in UserPolicy to give access to /roles-and-permissions page for users belongs to an organization.

This will resolve the issue #848. 

