### PR TITLE
fix: use default working languages when the property is not specified (resolves #865)

### DIFF
--- a/resources/views/individuals/partials/about.blade.php
+++ b/resources/views/individuals/partials/about.blade.php
@@ -11,9 +11,12 @@
             <li>{{ get_language_exonym($language) }}</li>
         @endforeach
     @else
-        @foreach ($individual->languages as $language)
-            <li>{{ get_language_exonym($language) }}</li>
-        @endforeach
+        <li>{{ get_language_exonym($individual->user->locale) }}
+            @if ($individual->user->singed_language)
+                @foreach ($individual->user->singed_language as $language)
+        <li>{{ get_language_exonym($language) }}</li>
+    @endforeach
+    @endif
     @endif
 </ul>
 

--- a/resources/views/individuals/partials/about.blade.php
+++ b/resources/views/individuals/partials/about.blade.php
@@ -13,9 +13,7 @@
     @else
         <li>{{ get_language_exonym($individual->user->locale) }}</li>
         @if ($individual->user->singed_language)
-            @foreach ($individual->user->singed_language as $language)
-                <li>{{ get_language_exonym($language) }}</li>
-            @endforeach
+            <li>{{ get_language_exonym($language) }}</li>
         @endif
     @endif
 </ul>

--- a/resources/views/individuals/partials/about.blade.php
+++ b/resources/views/individuals/partials/about.blade.php
@@ -12,8 +12,8 @@
         @endforeach
     @else
         <li>{{ get_language_exonym($individual->user->locale) }}</li>
-        @if ($individual->user->singed_language)
-            <li>{{ get_language_exonym($individual->user->singed_language) }}</li>
+        @if ($individual->user->signed_language)
+            <li>{{ get_language_exonym($individual->user->signed_language) }}</li>
         @endif
     @endif
 </ul>

--- a/resources/views/individuals/partials/about.blade.php
+++ b/resources/views/individuals/partials/about.blade.php
@@ -13,7 +13,7 @@
     @else
         <li>{{ get_language_exonym($individual->user->locale) }}</li>
         @if ($individual->user->singed_language)
-            <li>{{ get_language_exonym($language) }}</li>
+            <li>{{ get_language_exonym($individual->user->singed_language) }}</li>
         @endif
     @endif
 </ul>

--- a/resources/views/individuals/partials/about.blade.php
+++ b/resources/views/individuals/partials/about.blade.php
@@ -11,12 +11,12 @@
             <li>{{ get_language_exonym($language) }}</li>
         @endforeach
     @else
-        <li>{{ get_language_exonym($individual->user->locale) }}
-            @if ($individual->user->singed_language)
-                @foreach ($individual->user->singed_language as $language)
-        <li>{{ get_language_exonym($language) }}</li>
-    @endforeach
-    @endif
+        <li>{{ get_language_exonym($individual->user->locale) }}</li>
+        @if ($individual->user->singed_language)
+            @foreach ($individual->user->singed_language as $language)
+                <li>{{ get_language_exonym($language) }}</li>
+            @endforeach
+        @endif
     @endif
 </ul>
 

--- a/resources/views/individuals/partials/about.blade.php
+++ b/resources/views/individuals/partials/about.blade.php
@@ -6,9 +6,15 @@
     {{ __('Languages :name uses', ['name' => $individual->first_name]) }}</h3>
 
 <ul>
-    @foreach ($individual->working_languages as $language)
-        <li>{{ get_language_exonym($language) }}</li>
-    @endforeach
+    @if ($individual->working_languages)
+        @foreach ($individual->working_languages as $language)
+            <li>{{ get_language_exonym($language) }}</li>
+        @endforeach
+    @else
+        @foreach ($individual->languages as $language)
+            <li>{{ get_language_exonym($language) }}</li>
+        @endforeach
+    @endif
 </ul>
 
 @if ($individual->isConsultant())


### PR DESCRIPTION
See issue #865 for details.