### PR TITLE
fix: cache icons on deploy (resolves #988)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -44,6 +44,8 @@ jobs:
             /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec -T app ./artisan db:seed DevSeeder --force && \
             /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec -T app ./artisan view:clear && \
             /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec -T app ./artisan storage:link && \
+            /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec -T app ./artisan icons:clear && \
+            /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec -T app ./artisan icons:cache && \
             /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec -T app ./artisan google-fonts:fetch && \
             /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec -T app ./artisan route:cache && \
             /usr/local/bin/docker-compose -f docker-compose.cloud.yml exec -T app ./artisan config:cache

--- a/app/Console/Commands/DeployLocal.php
+++ b/app/Console/Commands/DeployLocal.php
@@ -29,6 +29,8 @@ class DeployLocal extends Command
     {
         $this->call('storage:link');
         $this->call('google-fonts:fetch');
+        $this->call('icons:clear');
+        $this->call('icons:cache');
 
         return 0;
     }


### PR DESCRIPTION
Updating icons requires that the cache is cleared and recreated: https://github.com/blade-ui-kit/blade-icons#caching

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.