### PR TITLE
fix: removed npm build from entrypoint

### DIFF
--- a/.deploy/accessibility-app/entrypoint.sh
+++ b/.deploy/accessibility-app/entrypoint.sh
@@ -22,8 +22,6 @@ then
 
   touch $FILES_PATH/../deploy.lock
 
-  npm run build
-
   php artisan deploy:global
 
 fi


### PR DESCRIPTION
Removed `npm run build` from entrypoint script.
It is run in container build as postinsall script.