### PR TITLE
fix: remove italics from field hints (resolve #763)

### DIFF
--- a/resources/css/_props.css
+++ b/resources/css/_props.css
@@ -63,7 +63,7 @@
     --alert-background-success: var(--theme-alert-background-success, var(--color-green-1));
     --alert-border-success: var(--theme-alert-border-success, var(--alert-background-success));
     --alert-color-success: var(--theme-alert-color-success, var(--color-graphite-8));
-    --hint-color: var(--theme-hint-color, var(--color-graphite-6));
+    --hint-color: var(--theme-hint-color, var(--color-graphite-7));
     --input-border: var(--theme-input-border, var(--color-graphite-7));
     --input-color: var(--theme-input-color, var(--color-graphite-7));
     --input-error-border: var(--theme-input-error-border, var(--color-red-8));

--- a/resources/css/components/_input.css
+++ b/resources/css/components/_input.css
@@ -223,7 +223,6 @@ legend {
 /** Hints **/
 .field__hint {
     color: var(--hint-color);
-    font-style: italic;
 }
 
 [type="radio"] ~ .field__hint {
@@ -242,7 +241,6 @@ legend {
     align-items: center;
     display: flex;
     flex-direction: row;
-    font-style: italic;
     font-weight: var(--font-semibold);
     gap: var(--space-2);
     justify-content: flex-start;


### PR DESCRIPTION
Changes field hints to non-italicized text, graphite 7.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
