### PR TITLE
chore: add composer localize command

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@ If this PR changes PHP code or dependencies:
 - [ ] I've run `composer format` and fixed any code formatting issues.
 - [ ] I've run `composer analyze` and addressed any static analysis issues.
 - [ ] I've run `php artisan test` and ensured that all tests pass.
+- [ ] I've run `composer localize` to update localization source files and committed any changes.
 
 If this PR changes CSS or JavaScript code or dependencies:
 

--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,10 @@
         ],
         "analyze": "vendor/bin/phpstan analyse",
         "format": "vendor/bin/pint",
+        "localize": [
+            "rm -f -- resources/lang/en.json",
+            "@php artisan localize en,fr"
+        ],
         "test": "php artisan test",
         "test-coverage": "php artisan test --coverage"
     }


### PR DESCRIPTION
This PR adds a `composer localize` script to update the project's localization source files, and also updates the PR template to remind contributors to do this whenever they make a change to code which may include localizable strings.
