### PR TITLE
fix: enforce password rules in all environments (fix #680, fix #1060)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ assignees: ''
 - [ ] I've [searched](https://github.com/accessibility-exchange/platform/issues) for existing issues
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -22,10 +22,10 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Details**
 - Device: 
@@ -34,4 +34,4 @@ If applicable, add screenshots to help explain your problem.
 - Link to affected page: 
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,13 +8,13 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Explain what this PR does.
+<!-- Explain what this PR does. -->
 
 ### Prerequisites
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -66,11 +66,7 @@ class AuthServiceProvider extends ServiceProvider
         });
 
         Password::defaults(function () {
-            $rule = Password::min(8);
-
-            return $this->app->isProduction()
-                ? $rule->mixedCase()->numbers()->symbols()->uncompromised()
-                : $rule;
+            return Password::min(8)->mixedCase()->numbers()->symbols()->uncompromised();
         });
     }
 }

--- a/tests/Feature/IndividualTest.php
+++ b/tests/Feature/IndividualTest.php
@@ -96,8 +96,8 @@ test('users can create individual pages', function () {
         'email' => 'test@example.com',
         'context' => 'individual',
     ])->post(localized_route('register-store'), [
-        'password' => 'password',
-        'password_confirmation' => 'password',
+        'password' => 'correctHorse-batteryStaple7',
+        'password_confirmation' => 'correctHorse-batteryStaple7',
     ]);
 
     $this->assertAuthenticated();

--- a/tests/Feature/PasswordResetTest.php
+++ b/tests/Feature/PasswordResetTest.php
@@ -46,8 +46,8 @@ test('password can be reset with valid token', function () {
     Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
         $response = $this->post(localized_route('password.update', ['token' => $notification->token]), [
             'email' => $user->email,
-            'password' => 'password',
-            'password_confirmation' => 'password',
+            'password' => 'correctHorse-batteryStaple7',
+            'password_confirmation' => 'correctHorse-batteryStaple7',
         ]);
 
         $response->assertRedirect();

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -70,8 +70,8 @@ test('new users can register', function () {
         'email' => 'test@example.com',
         'context' => 'individual',
     ])->post(localized_route('register-store'), [
-        'password' => 'password',
-        'password_confirmation' => 'password',
+        'password' => 'correctHorse-batteryStaple7',
+        'password_confirmation' => 'correctHorse-batteryStaple7',
     ]);
 
     $this->assertAuthenticated();
@@ -123,8 +123,8 @@ test('users can register via invitation to (regulated) organization', function (
         'context' => 'regulated-organization',
         'invitation' => 1,
     ])->post(localized_route('register-store'), [
-        'password' => 'password',
-        'password_confirmation' => 'password',
+        'password' => 'correctHorse-batteryStaple7',
+        'password_confirmation' => 'correctHorse-batteryStaple7',
     ]);
 
     $this->assertAuthenticated();
@@ -187,8 +187,8 @@ test('users can register via invitation to engagement', function () {
         'invitation' => 1,
         'invited_role' => 'participant',
     ])->post(localized_route('register-store'), [
-        'password' => 'password',
-        'password_confirmation' => 'password',
+        'password' => 'correctHorse-batteryStaple7',
+        'password_confirmation' => 'correctHorse-batteryStaple7',
     ]);
 
     $this->assertAuthenticated();

--- a/tests/Feature/UserSettingsTest.php
+++ b/tests/Feature/UserSettingsTest.php
@@ -439,8 +439,8 @@ test('password can be updated', function () {
         ->actingAs($user)
         ->put(localized_route('user-password.update'), [
             'current_password' => 'password',
-            'password' => 'new_password',
-            'password_confirmation' => 'new_password',
+            'password' => 'correctHorse-batteryStaple7',
+            'password_confirmation' => 'correctHorse-batteryStaple7',
         ]);
 
     $response->assertSessionHasNoErrors();


### PR DESCRIPTION
Implement password requirements in all environments.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
