### PR TITLE
feat!: check that FRO page is publishable (Resolves #596)

### DIFF
--- a/app/Policies/RegulatedOrganizationPolicy.php
+++ b/app/Policies/RegulatedOrganizationPolicy.php
@@ -54,8 +54,7 @@ class RegulatedOrganizationPolicy
 
     public function publish(User $user, RegulatedOrganization $regulatedOrganization): Response
     {
-        // TODO: Ensure model is ready for publishing first.
-        return $user->isAdministratorOf($regulatedOrganization)
+        return $user->isAdministratorOf($regulatedOrganization) && $regulatedOrganization->isPublishable()
             ? Response::allow()
             : Response::deny(__('You cannot publish this regulated organization.'));
     }

--- a/resources/views/regulated-organizations/edit.blade.php
+++ b/resources/views/regulated-organizations/edit.blade.php
@@ -34,7 +34,7 @@
                         <p class="stack">
                             <x-hearth-input class="secondary" name="preview" type="submit"
                                 value="{{ __('Preview page') }}" />
-                            <x-hearth-input name="publish" type="submit" value="{{ __('Publish page') }}" />
+                            <x-hearth-input name="publish" type="submit" :value="__('Publish page')" :disabled="!Auth::user()->can('publish', $regulatedOrganization)" />
                         </p>
                         <p>{{ __('Once you publish your page, other users on this website can access your page.') }}</p>
                     @else

--- a/tests/Datasets/RegulatedOrganizationIsPublishable.php
+++ b/tests/Datasets/RegulatedOrganizationIsPublishable.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Enums\ProvinceOrTerritory;
+
+dataset('regulatedOrganizationIsPublishable', function () {
+    $baseModel = [
+        'about' => 'test regulated organization about',
+        'accessibility_and_inclusion_links' => [
+            'en' => [
+                'title' => 'test title',
+                'url' => 'http://example.com/en/',
+            ],
+        ],
+        'contact_person_phone' => '4165555555',
+        'locality' => 'Toronto',
+        'preferred_contact_method' => 'email',
+        'region' => [ProvinceOrTerritory::Ontario->value],
+        'service_areas' => [ProvinceOrTerritory::Ontario->value],
+    ];
+
+    return [
+        'not publishable when missing about' => [
+            false,
+            array_replace_recursive($baseModel, ['about' => null]),
+            ['sector'],
+        ],
+        'not publishable when missing accessibility_and_inclusion_links.*.title' => [
+            false,
+            array_replace_recursive($baseModel, [
+                'accessibility_and_inclusion_links' => [
+                    'en' => [
+                        'title' => null,
+                    ],
+                ],
+            ]),
+            ['sector'],
+        ],
+        'not publishable when missing accessibility_and_inclusion_links.*.url' => [
+            false,
+            array_replace_recursive($baseModel, [
+                'accessibility_and_inclusion_links' => [
+                    'en' => [
+                        'url' => null,
+                    ],
+                ],
+            ]),
+            ['sector'],
+        ],
+        'not publishable when missing contact_person_email' => [
+            false,
+            array_replace_recursive($baseModel, [
+                'contact_person_email' => null,
+                'contact_person_phone' => null,
+            ]),
+            ['sector'],
+        ],
+        'not publishable when missing contact_person_name' => [
+            false,
+            array_replace_recursive($baseModel, ['contact_person_name' => null]),
+            ['sector'],
+        ],
+        'not publishable when missing contact_person_phone' => [
+            false,
+            array_replace_recursive($baseModel, [
+                'contact_person_phone' => null,
+                'contact_person_vrs' => true,
+            ]),
+            ['sector'],
+        ],
+        'not publishable when missing languages' => [
+            false,
+            array_replace_recursive($baseModel, ['languages' => null]),
+            ['sector'],
+        ],
+        'not publishable when missing locality' => [
+            false,
+            array_replace_recursive($baseModel, ['locality' => null]),
+            ['sector'],
+        ],
+        'not publishable when missing name' => [
+            false,
+            array_replace_recursive($baseModel, ['name' => null]),
+            ['sector'],
+        ],
+        'not publishable when missing preferred_contact_method' => [
+            false,
+            array_replace_recursive($baseModel, ['preferred_contact_method' => null]),
+            ['sector'],
+        ],
+        'not publishable when missing region' => [
+            false,
+            array_replace_recursive($baseModel, ['region' => null]),
+            ['sector'],
+        ],
+        'not publishable when missing service_areas' => [
+            false,
+            array_replace_recursive($baseModel, ['service_areas' => null]),
+            ['sector'],
+        ],
+        'not publishable when missing type' => [
+            false,
+            array_replace_recursive($baseModel, ['type' => null]),
+            ['sector'],
+        ],
+        'not publishable when missing sector' => [
+            false,
+            $baseModel,
+        ],
+        'publishable with all expected values' => [
+            true,
+            $baseModel,
+            ['sector'],
+        ],
+        'publishable without accessibility_and_inclusion_links' => [
+            true,
+            array_replace_recursive($baseModel, [
+                'accessibility_and_inclusion_links' => null,
+            ]),
+            ['sector'],
+        ],
+        'publishable with only e-mail contact' => [
+            true,
+            array_replace_recursive($baseModel, [
+                'contact_person_phone' => null,
+            ]),
+            ['sector'],
+        ],
+        'publishable with only phone contact' => [
+            true,
+            array_replace_recursive($baseModel, [
+                'contact_person_email' => null,
+            ]),
+            ['sector'],
+        ],
+    ];
+});


### PR DESCRIPTION
Ensures that an FRO page is publishable by providing an isPublishable method and adding it to the policy. 

Resolves #596 

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
