### PR TITLE
feat: remove old database notifications (resolves #1080)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn-error.log
 _ide_helper*
 /public/build/assets/
 /public/build/manifest.json
+.env.local-dev

--- a/app/Console/Commands/NotificationsRemoveOld.php
+++ b/app/Console/Commands/NotificationsRemoveOld.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class NotificationsRemoveOld extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'notifications:remove:old ${days}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Deletes user notifications over n days old.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $days = $this->argument('days');
+
+        if (is_numeric($days) && $days > 1) {
+            DB::table('notifications')->where('read_at', '<', DB::raw('DATE_SUB(NOW(), INTERVAL '.$days.' day)'))->delete();
+
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -28,6 +28,10 @@ class Kernel extends ConsoleKernel
             ->daily() // Run daily at midnight
             ->environments(['staging', 'dev', 'local']) // only run for APP_ENV tagged staging, dev, or local
             ->onOneServer(); // run only on a single server at once
+
+        $schedule->command('notifications:remove:old 30') // remove notifications older than 30 days old and read
+        ->daily() // Run daily at midnight
+        ->onOneServer(); // run only on a single server at once
     }
 
     /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
             XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
         volumes:
             - '.:/var/www/html'
+            - 'app-logs:/app/storage/logs'
         networks:
             - sail
         depends_on:
@@ -93,3 +94,4 @@ volumes:
         driver: local
     sail-meilisearch:
         driver: local
+    app-logs:


### PR DESCRIPTION
Created new command for use `notifications:remove:old`. Which when passed **n** days, all notifications `read_at` older than **n** days will be deleted.
Created scheduled task that runs the command daily and passes in parameter **30** so notifications that were `read_at` is older than 30 days are deleted.

### Prerequisites

If this PR changes PHP code or dependencies:

- [X] I've run `composer format` and fixed any code formatting issues.
- [X] I've run `composer analyze` and addressed any static analysis issues.
- [ ] I've run `php artisan test` and ensured that all tests pass.
  - Many tests on my local are failing I will probably need help setting up my local to better run these tests.
- [X] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [X] I've run `npm run lint` and fixed any linting issues.
- [X] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
