### PR TITLE
fix: don't allow premature estimate requests (resolves #1142)

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -9,7 +9,6 @@ use App\Http\Requests\StoreProjectLanguagesRequest;
 use App\Http\Requests\StoreProjectRequest;
 use App\Http\Requests\UpdateProjectRequest;
 use App\Http\Requests\UpdateProjectTeamRequest;
-use App\Models\Engagement;
 use App\Models\Impact;
 use App\Models\Individual;
 use App\Models\Project;
@@ -223,8 +222,6 @@ class ProjectController extends Controller
 
     public function manageEstimatesAndAgreements(Project $project): View
     {
-        // TODO: Restrict access to publishable projects with at least one publishable engagement.
-
         return view('projects.manage-estimates-and-agreements', [
             'project' => $project,
             'engagements' => $project->engagements->filter(fn ($engagement) => $engagement->hasProvidedRequiredInformation()),

--- a/resources/views/components/notification/agreement-received.blade.php
+++ b/resources/views/components/notification/agreement-received.blade.php
@@ -2,6 +2,7 @@
     <x-slot name="title">{{ $title }}</x-slot>
     <x-slot name="body">{{ $body }}</x-slot>
     <x-slot name="actions">
-        <a class="cta secondary" href="{{ localized_route('projects.manage', $project) }}">{{ __('Manage project') }}</a>
+        <a class="cta secondary"
+            href="{{ localized_route('projects.manage-estimates-and-agreements', $project) }}">{{ __('Manage project') }}</a>
     </x-slot>
 </x-notification>

--- a/resources/views/components/notification/estimate-returned.blade.php
+++ b/resources/views/components/notification/estimate-returned.blade.php
@@ -2,6 +2,7 @@
     <x-slot name="title">{{ $title }}</x-slot>
     <x-slot name="body">{{ $body }}</x-slot>
     <x-slot name="actions">
-        <a class="cta secondary" href="{{ localized_route('projects.manage', $project) }}">{{ __('Manage project') }}</a>
+        <a class="cta secondary"
+            href="{{ localized_route('projects.manage-estimates-and-agreements', $project) }}">{{ __('Manage project') }}</a>
     </x-slot>
 </x-notification>

--- a/resources/views/mail/agreement-received.blade.php
+++ b/resources/views/mail/agreement-received.blade.php
@@ -1,7 +1,7 @@
 @component('mail::message')
 {{ __('Your agreement has been received for **:project**. You can now publish your project page and engagement details.', ['project' => $project->name]) }}
 
-@component('mail::button', ['url' => localized_route('projects.manage', $project)])
+@component('mail::button', ['url' => localized_route('projects.manage-estimates-and-agreements', $project)])
 {{ __('Manage project') }}
 @endcomponent
 @endcomponent

--- a/resources/views/mail/estimate-returned.blade.php
+++ b/resources/views/mail/estimate-returned.blade.php
@@ -1,7 +1,7 @@
 @component('mail::message')
 {{ __('Your estimate for **:project**, along with a project agreement for you to sign, has been sent to [:contact](mailto::contact).', ['project' => $project->name, 'contact' => $project->contact_person_email]) }}
 
-@component('mail::button', ['url' => localized_route('projects.manage', $project)])
+@component('mail::button', ['url' => localized_route('projects.manage-estimates-and-agreements', $project)])
 {{ __('Manage project') }}
 @endcomponent
 @endcomponent

--- a/resources/views/projects/manage-estimates-and-agreements.blade.php
+++ b/resources/views/projects/manage-estimates-and-agreements.blade.php
@@ -41,12 +41,27 @@
                     </span>
                 </p>
                 <h4>{{ __('New estimate request') }}</h4>
-                @include('projects.partials.included-engagements')
-                <x-hearth-alert class="bg-grey-1" x-show="true" :dismissable="false" :title="__('Missing an engagement?')">
-                    <p>{{ __('To include an engagement in a quote request, you must have filled out the engagement invitation.') }}
-                    </p>
-                </x-hearth-alert>
-                <livewire:estimate-requester :model="$project" />
+                @if ($project->isPublishable() && $engagements->count())
+                    @include('projects.partials.included-engagements')
+                    <x-hearth-alert class="bg-grey-1" x-show="true" :dismissable="false" :title="__('Missing an engagement?')">
+                        <p>{{ __('To include an engagement in a quote request, you must have filled out the engagement details (and meeting information for workshops and focus groups).') }}
+                        </p>
+                    </x-hearth-alert>
+                    <livewire:estimate-requester :model="$project" />
+                @else
+                    @if (!$project->isPublishable())
+                        <x-hearth-alert type="warning" x-show="true" :dismissable="false" :title="__('No engagements found')">
+                            <p>{{ __('To request an estimate, you must have created your project’s page.') }}
+                            </p>
+                        </x-hearth-alert>
+                    @endif
+                    @if (!$engagements->count())
+                        <x-hearth-alert type="warning" x-show="true" :dismissable="false" :title="__('No engagements found')">
+                            <p>{{ __('To request an estimate, you must have filled out your project’s engagement details (and meeting information for workshops and focus groups).') }}
+                            </p>
+                        </x-hearth-alert>
+                    @endif
+                @endif
             @endif
         </div>
         <div class="stack w-full md:w-1/2">

--- a/resources/views/projects/partials/included-engagements.blade.php
+++ b/resources/views/projects/partials/included-engagements.blade.php
@@ -1,8 +1,6 @@
 <p><strong>{{ __('This estimate includes the following engagements:') }}</strong></p>
 <ul>
-    @forelse($engagements as $engagement)
+    @foreach ($engagements as $engagement)
         <li>{{ $engagement->name }}</li>
-    @empty
-        <li>{{ __('None found.') }}</li>
-    @endforelse
+    @endforeach
 </ul>


### PR DESCRIPTION
Estimate request button will not be shown unless project is publishable and has at least one publishable engagement.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
