### PR TITLE
fix: resolve conflict between Livewire and the expander component (resolves #1149)

### DIFF
--- a/resources/views/components/expander.blade.php
+++ b/resources/views/components/expander.blade.php
@@ -1,15 +1,11 @@
-<div class="stack" x-data="{ expanded: false, initialized: false }" x-init="$refs.expander.classList.add('expander');
-initialized = true;" x-ref="expander">
+<div class="expander stack" x-data="{ expanded: false }">
     <x-heading class="title" :level="$level">
-        <span x-show="!initialized">{{ $summary }}</span>
-        <template x-if="initialized">
-            <button type="button" x-bind:aria-expanded="expanded.toString()" x-on:click="expanded = !expanded">
-                {{ $summary }}
-                <x-heroicon-o-chevron-down class="indicator" aria-hidden="true" />
-            </button>
-        </template>
+        <button type="button" x-bind:aria-expanded="expanded.toString()" x-on:click="expanded = !expanded">
+            {{ $summary }}
+            <x-heroicon-o-chevron-down class="indicator" aria-hidden="true" />
+        </button>
     </x-heading>
-    <div class="stack" x-show="initialized ? expanded : true">
+    <div class="stack" x-show="expanded">
         {!! $slot ?? '' !!}
     </div>
 </div>


### PR DESCRIPTION
Resolves #1149. I tested in the context of #1153. I don't think there are other uses of the expander in a Livewire view but you could try copying the change from this into #1153 to verify that it works for you, @chosww.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
