### PR TITLE
ci(deploy): fix permissions before syncing to permanent storage

### DIFF
--- a/.deploy/accessibility-app/entrypoint.sh
+++ b/.deploy/accessibility-app/entrypoint.sh
@@ -5,17 +5,20 @@ set -e
 mkdir -p $FILES_PATH
 mkdir -p $CACHE_PATH
 
+## fix permissions before syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1226
+chown -R www-data:www-data /app/storage /app/bootstrap/cache 
+
+## sync files from container storage to permanent storage then remove container storage
 rsync -a /app/storage/ $FILES_PATH
 rm -rf /app/storage
 
+## sync files from container cache to permanent storage then remove container cache
 rsync -a /app/bootstrap/cache/ $CACHE_PATH
 rm -rf /app/bootstrap/cache
 
+## create symlinks from permanent storage & cache to application directory folders
 ln -s $FILES_PATH /app/storage
-chown www-data:root $FILES_PATH/ -R
-
 ln -s $CACHE_PATH /app/bootstrap/cache
-chown www-data:root $CACHE_PATH/ -R
 
 if [ ! -f $FILES_PATH/../deploy.lock ]
 then


### PR DESCRIPTION
On container deployment.

Fixes file ownership of the storage and cache files/folders before syncing to the permanent storage directories.
This should prevent permission issues if an existing container might attempt to save in the deployment process of another container.

!! Since it is CI related I have branched from **staging** and suggesting merging into **staging**.