### PR TITLE
fix: undefined constant "skills" (Resolves #1260)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1543,6 +1543,7 @@
     "Single parents and\/or guardians": "Single parents and\/or guardians",
     "Site unavailable": "Site unavailable",
     "Skills and strengths": "Skills and strengths",
+    "skills and strengths": "skills and strengths",
     "Skip for now": "Skip for now",
     "Skip to:": "Skip to:",
     "Skip to content": "Skip to content",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -1559,6 +1559,7 @@
     "Single parents and\/or guardians": "Single parents and\/or guardians",
     "Site unavailable": "Service indisponible",
     "Skills and strengths": "Compétences et forces",
+    "skills and strengths": "",
     "Skip for now": "Ignorer pour l'instant",
     "Skip to:": "Passer à :",
     "Skip to content": "Passer au contenu",

--- a/resources/views/individuals/edit/experiences.blade.php
+++ b/resources/views/individuals/edit/experiences.blade.php
@@ -41,7 +41,7 @@
 
                 <div class="field @error('skills_and_strengths') field--error @enderror">
                     <x-translatable-textarea name="skills_and_strengths" :model="$individual" :label="__('What are your skills and strengths?') . ' ' . __('(optional)')"
-                        :shortLabel="skills and strengths" />
+                        :shortLabel="__('skills and strengths')" />
                     <x-hearth-error for="skills_and_strengths" />
                 </div>
 


### PR DESCRIPTION
Resolves #1260 

Corrects some text that should have been wrapped in the localization function `__()`.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
