### PR TITLE
fix: type in breadcrumb

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -96,7 +96,6 @@
     "A :type with this name already exists.": "A :type with this name already exists.",
     "about": "about",
     "About": "About",
-    "About the Accessbility Exchange": "About the Accessbility Exchange",
     "About the Accessibility Exchange": "About the Accessibility Exchange",
     "About the organization": "About the organization",
     "About the project team": "About the project team",

--- a/resources/views/about/for-community-organizations.blade.php
+++ b/resources/views/about/for-community-organizations.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="title">{{ __('How this works for Community Organizations') }}</x-slot>
     <x-slot name="header">
         <ol class="breadcrumbs" role="list">
-            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessbility Exchange') }}</a></li>
+            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessibility Exchange') }}</a></li>
         </ol>
         <h1>
             <span class="font-medium">{{ __('How this works for') }}</span><br />

--- a/resources/views/about/for-individuals.blade.php
+++ b/resources/views/about/for-individuals.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="title">{{ __('How this works for Individuals with Disabilities and Deaf Individuals') }}</x-slot>
     <x-slot name="header">
         <ol class="breadcrumbs" role="list">
-            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessbility Exchange') }}</a></li>
+            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessibility Exchange') }}</a></li>
         </ol>
         <h1>
             <span class="font-medium">{{ __('How this works for') }}</span><br />

--- a/resources/views/about/for-regulated-organizations.blade.php
+++ b/resources/views/about/for-regulated-organizations.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="title">{{ __('How this works for Federally Regulated Organizations') }}</x-slot>
     <x-slot name="header">
         <ol class="breadcrumbs" role="list">
-            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessbility Exchange') }}</a></li>
+            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessibility Exchange') }}</a></li>
         </ol>
         <h1>
             <span class="font-medium">{{ __('How this works for') }}</span><br />

--- a/resources/views/about/pricing.blade.php
+++ b/resources/views/about/pricing.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="title">{{ __('Pricing') }}</x-slot>
     <x-slot name="header">
         <ol class="breadcrumbs" role="list">
-            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessbility Exchange') }}</a></li>
+            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessibility Exchange') }}</a></li>
         </ol>
         <h1>
             {{ __('Pricing') }}

--- a/resources/views/about/privacy-policy.blade.php
+++ b/resources/views/about/privacy-policy.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="title">{{ __('Privacy Policy') }}</x-slot>
     <x-slot name="header">
         <ol class="breadcrumbs" role="list">
-            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessbility Exchange') }}</a></li>
+            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessibility Exchange') }}</a></li>
         </ol>
         <h1>
             {{ __('Privacy Policy') }}

--- a/resources/views/about/roles/accessibility-consultant-details.blade.php
+++ b/resources/views/about/roles/accessibility-consultant-details.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="title">{{ __('What information do we ask for?') }}</x-slot>
     <x-slot name="header">
         <ol class="breadcrumbs" role="list">
-            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessbility Exchange') }}</a></li>
+            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessibility Exchange') }}</a></li>
             <li><a href="{{ localized_route('about.for-individuals') }}">{{ __('How this works for individuals') }}</a>
             </li>
             <li><a

--- a/resources/views/about/roles/community-connector-details.blade.php
+++ b/resources/views/about/roles/community-connector-details.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="title">{{ __('What information do we ask for?') }}</x-slot>
     <x-slot name="header">
         <ol class="breadcrumbs" role="list">
-            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessbility Exchange') }}</a></li>
+            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessibility Exchange') }}</a></li>
             <li><a href="{{ localized_route('about.for-individuals') }}">{{ __('How this works for individuals') }}</a>
             </li>
             <li><a

--- a/resources/views/about/roles/consultation-participant-details.blade.php
+++ b/resources/views/about/roles/consultation-participant-details.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="title">{{ __('What information do we ask for?') }}</x-slot>
     <x-slot name="header">
         <ol class="breadcrumbs" role="list">
-            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessbility Exchange') }}</a></li>
+            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessibility Exchange') }}</a></li>
             <li><a href="{{ localized_route('about.for-individuals') }}">{{ __('How this works for individuals') }}</a>
             </li>
             <li><a

--- a/resources/views/about/terms-of-service.blade.php
+++ b/resources/views/about/terms-of-service.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="title">{{ __('Terms of Service') }}</x-slot>
     <x-slot name="header">
         <ol class="breadcrumbs" role="list">
-            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessbility Exchange') }}</a></li>
+            <li><a href="{{ localized_route('welcome') }}">{{ __('About the Accessibility Exchange') }}</a></li>
         </ol>
         <h1>
             {{ __('Terms of Service') }}


### PR DESCRIPTION
Fixes a typo in the breadcrumb; "About the Accessbility Exchange" -> "About the Accessibility Exchange"

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
