### PR TITLE
ci(deploy): permissions fix after syncing files to storage

### DIFF
--- a/.deploy/accessibility-app/entrypoint.sh
+++ b/.deploy/accessibility-app/entrypoint.sh
@@ -6,7 +6,7 @@ mkdir -p $FILES_PATH
 mkdir -p $CACHE_PATH
 
 ## fix permissions before syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1226
-chown -R www-data:www-data /app/storage /app/bootstrap/cache 
+chown -R www-data:www-data $FILES_PATH $CACHE_PATH
 
 ## sync files from container storage to permanent storage then remove container storage
 rsync -a /app/storage/ $FILES_PATH
@@ -19,6 +19,9 @@ rm -rf /app/bootstrap/cache
 ## create symlinks from permanent storage & cache to application directory folders
 ln -s $FILES_PATH /app/storage
 ln -s $CACHE_PATH /app/bootstrap/cache
+
+## fix permissions after syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1236
+chown -R www-data:www-data $FILES_PATH $CACHE_PATH
 
 if [ ! -f $FILES_PATH/../deploy.lock ]
 then

--- a/.deploy/accessibility-app/entrypoint.sh
+++ b/.deploy/accessibility-app/entrypoint.sh
@@ -6,7 +6,7 @@ mkdir -p $FILES_PATH
 mkdir -p $CACHE_PATH
 
 ## fix permissions before syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1226
-chown -R www-data:www-data $FILES_PATH $CACHE_PATH
+chown -R www-data:www-data /app/storage /app/bootstrap/cache $FILES_PATH $CACHE_PATH
 
 ## sync files from container storage to permanent storage then remove container storage
 rsync -a /app/storage/ $FILES_PATH


### PR DESCRIPTION
* Repairs file ownership prior to syncing for existing files in permanent storage as well.
* Repairs file ownership after syncing and linking permanent storage. 
