### PR TITLE
fix: resolve invalid status check (fixes #1272)

### DIFF
--- a/resources/views/individuals/show.blade.php
+++ b/resources/views/individuals/show.blade.php
@@ -3,7 +3,7 @@
     <x-slot name="header">
         @if (auth()->hasUser() &&
             auth()->user()->isAdministrator() &&
-            $individual->checkStatus('suspended'))
+            $individual->user->checkStatus('suspended'))
             @push('banners')
                 <div class="banner banner--error">
                     <div class="center center:wide">


### PR DESCRIPTION
When an administrator visits the page of a suspended individual, there was a bug which caused a 500 internal server error because the suspension check was being run on the individual, not the user. This PR resolves the issue by checking the user's suspended status.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
