### PR TITLE
fix: date picker improvements

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,7 +6,7 @@ import mask from "@alpinejs/mask";
 import "wicg-inert";
 
 import confirmPassword from "./confirmPassword.js";
-import dateInput from "./dateInput.js";
+import datePicker from "./datePicker.js";
 import enhancedCheckboxes from "./enhancedCheckboxes.js";
 import modal from "./modal.js";
 import "./vimeoPlayer.js";
@@ -14,7 +14,7 @@ import "./vimeoPlayer.js";
 window.Alpine = Alpine;
 Alpine.plugin(mask);
 Alpine.data("confirmPassword", confirmPassword);
-Alpine.data("dateInput", dateInput);
+Alpine.data("datePicker", datePicker);
 Alpine.data("enhancedCheckboxes", enhancedCheckboxes);
 Alpine.data("modal", modal);
 Alpine.start();

--- a/resources/js/datePicker.js
+++ b/resources/js/datePicker.js
@@ -8,9 +8,9 @@ export default (initial = "") => ({
     init() {
         this.date = initial;
         let [y, m, d] = this.date.split("-");
-        this.year = y;
-        this.month = m;
-        this.day = d;
+        this.year = y ?? "";
+        this.month = m ?? "";
+        this.day = d ?? "";
     },
     getDate() {
         if (this.year || (this.year !== "" && this.month) || (this.month !== "" && this.day) || this.day !== "") {

--- a/resources/js/datePicker.js
+++ b/resources/js/datePicker.js
@@ -7,10 +7,10 @@ export default (initial = "") => ({
     validationError: "",
     init() {
         this.date = initial;
-        let [y, m, d] = this.date.split("-");
-        this.year = y ?? "";
-        this.month = m ?? "";
-        this.day = d ?? "";
+        let [y = "", m = "", d = ""] = this.date.split("-");
+        this.year = y;
+        this.month = m;
+        this.day = d;
     },
     getDate() {
         if (this.year || (this.year !== "" && this.month) || (this.month !== "" && this.day) || this.day !== "") {

--- a/resources/views/components/date-picker.blade.php
+++ b/resources/views/components/date-picker.blade.php
@@ -8,7 +8,7 @@
 ])
 
 <fieldset class="field @error($name) field--error @enderror" id="{{ $name }}"
-    aria-describedby="{{ $name }}-hint {{ $name }}-output" x-data="dateInput('{{ $value }}')">
+    aria-describedby="{{ $name }}-hint {{ $name }}-output" x-data="datePicker('{{ $value }}')">
     <legend>
         {{ $label ?? __('forms.label_date') }}
     </legend>

--- a/resources/views/engagements/edit.blade.php
+++ b/resources/views/engagements/edit.blade.php
@@ -42,8 +42,8 @@
             <hr class="divider--thick" />
             <h2>{{ __('Date range') }}</h2>
             <p>{{ __('Interviews can happen between the following dates:') }}</p>
-            <x-date-picker name="window_start_date" :label="__('Start date') . ' ' . __('(required)')" minimumYear="2022" :value="old('window_start_date', $engagement->window_start_date?->format('Y-m-d') ?? null)" />
-            <x-date-picker name="window_end_date" :label="__('End date') . ' ' . __('(required)')" minimumYear="2022" :value="old('window_end_date', $engagement->window_end_date?->format('Y-m-d') ?? null)" />
+            <x-date-picker name="window_start_date" :label="__('Start date') . ' ' . __('(required)')" :value="old('window_start_date', $engagement->window_start_date?->format('Y-m-d') ?? '')" />
+            <x-date-picker name="window_end_date" :label="__('End date') . ' ' . __('(required)')" :value="old('window_end_date', $engagement->window_end_date?->format('Y-m-d') ?? '')" />
 
             <hr class="divider--thick" />
             <h2>{{ __('Ways to participate') }}</h2>
@@ -204,8 +204,8 @@
             <p>{{ __('Some participants may not be able to meet in real-time. For them, you can send out a list of questions, and participants can respond to them in formats you accept.') }}
             </p>
             <h4>{{ __('Dates') }}</h4>
-            <x-date-picker name="materials_by_date" :label="__('Questions are sent to participants by:')" minimumYear="2022" :value="old('materials_by_date', $engagement->materials_by_date?->format('Y-m-d') ?? null)" />
-            <x-date-picker name="complete_by_date" :label="__('Responses are due by:')" minimumYear="2022" :value="old('complete_by_date', $engagement->complete_by_date?->format('Y-m-d') ?? null)" />
+            <x-date-picker name="materials_by_date" :label="__('Questions are sent to participants by:')" :value="old('materials_by_date', $engagement->materials_by_date?->format('Y-m-d') ?? '')" />
+            <x-date-picker name="complete_by_date" :label="__('Responses are due by:')" :value="old('complete_by_date', $engagement->complete_by_date?->format('Y-m-d') ?? '')" />
             <fieldset
                 class="field @error('accepted_formats') field--error @enderror @error('other_accepted_formats') field--error @enderror @error('other_accepted_format') field--error @enderror stack"
                 x-data="{ otherAcceptedFormats: {{ old('other_accepted_formats', !empty($engagement->other_accepted_format)) ? 1 : 'null' }} }">
@@ -239,8 +239,8 @@
             <h2>{{ $engagement->format === 'survey' ? __('Survey materials') : __('Materials') }}
             </h2>
             <h3>{{ __('Date') }}</h3>
-            <x-date-picker name="materials_by_date" :label="__('Materials are sent to participants by') . ' ' . __('(required)') . ':'" minimumYear="2022" :value="old('materials_by_date', $engagement->materials_by_date?->format('Y-m-d') ?? null)" />
-            <x-date-picker name="complete_by_date" :label="__('Completed materials are due by') . ' ' . __('(required)') . ':'" minimumYear="2022" :value="old('complete_by_date', $engagement->complete_by_date?->format('Y-m-d') ?? null)" />
+            <x-date-picker name="materials_by_date" :label="__('Materials are sent to participants by') . ' ' . __('(required)') . ':'" minimumYear="2022" :value="old('materials_by_date', $engagement->materials_by_date?->format('Y-m-d') ?? '')" />
+            <x-date-picker name="complete_by_date" :label="__('Completed materials are due by') . ' ' . __('(required)') . ':'" minimumYear="2022" :value="old('complete_by_date', $engagement->complete_by_date?->format('Y-m-d') ?? '')" />
             <hr />
             <fieldset class="field @error('document_languages') field--error @enderror">
                 <legend>
@@ -281,7 +281,7 @@
                     : __('Participants must respond to their invitation by the following date') .
                         ' ' .
                         __('(required)') .
-                        ':'" :minimumYear="date('Y')" :value="old('signup_by_date', $engagement->signup_by_date?->format('Y-m-d') ?? null)" />
+                        ':'" :value="old('signup_by_date', $engagement->signup_by_date?->format('Y-m-d') ?? '')" />
             </div>
         @endif
         <hr class="divider--thick" />

--- a/resources/views/livewire/team-trainings.blade.php
+++ b/resources/views/livewire/team-trainings.blade.php
@@ -11,8 +11,8 @@
                     </div>
 
                     <div class="field @error("team_trainings.{$i}.date") field-error @enderror">
-                        <x-date-picker :wire:key="'training-'.$i" :label="__('Date of training')" :minimumYear="date('Y') - 25" :maximumYear="date('Y')"
-                            :name="'team_trainings[' . $i . '][date]'" :value="old('team_trainings_' . $i . '_date', $training['date'] ?? null)" />
+                        <x-date-picker :wire:key="'training-'.$i" :label="__('Date of training')" :name="'team_trainings[' . $i . '][date]'"
+                            :value="old('team_trainings_' . $i . '_date', $training['date'] ?? '')" />
                         <x-hearth-error :for="'team_trainings_' . $i . '_date'" :field="'team_trainings.' . $i . '.date'" />
                     </div>
 

--- a/resources/views/meetings/edit.blade.php
+++ b/resources/views/meetings/edit.blade.php
@@ -29,7 +29,7 @@
         <h2>{{ __('Time and date') }}</h2>
 
         <div class="field">
-            <x-date-picker name="date" :label="__('Date') . ' ' . __('(required)')" :minimumYear="date('Y')" :value="old('date', $meeting->date?->format('Y-m-d'))" />
+            <x-date-picker name="date" :label="__('Date') . ' ' . __('(required)')" :value="old('date', $meeting->date?->format('Y-m-d') ?? '')" />
         </div>
         <fieldset class="mt-12">
             <legend>{{ __('Time') . ' ' . __('(required)') }}</legend>

--- a/resources/views/projects/edit/1.blade.php
+++ b/resources/views/projects/edit/1.blade.php
@@ -58,9 +58,11 @@
 
             <h3>{{ __('Project timeframe') }}</h3>
 
-            <x-date-picker name="start_date" :label="__('Project start date') . ' ' . __('(required)')" minimumYear="2021" :value="old('start_date', $project->start_date?->format('Y-m-d') ?? null)" />
+            <x-date-picker name="start_date" :label="__('Project start date') . ' ' . __('(required)')" :value="old('start_date', $project->start_date?->format('Y-m-d') ?? '')" />
+            <x-hearth-error for="start_date" />
 
-            <x-date-picker name="end_date" :label="__('Project end date') . ' ' . __('(required)')" minimumYear="2021" :value="old('end_date', $project->end_date?->format('Y-m-d') ?? null)" />
+            <x-date-picker name="end_date" :label="__('Project end date') . ' ' . __('(required)')" :value="old('end_date', $project->end_date?->format('Y-m-d') ?? '')" />
+            <x-hearth-error for="end_date" />
 
             <h3>{{ __('Project outcome') }}</h3>
 


### PR DESCRIPTION
- if value is null, set y/m/d to empty strings
- remove minimum year attributes

Hasn't addressed #1311 as I can't reproduce, but if I can figure out what's happening there I will add the changes to this PR.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
