### PR TITLE
fix: redirect Filament login requests to standard login form

### DIFF
--- a/routes/fortify.php
+++ b/routes/fortify.php
@@ -45,6 +45,12 @@ Route::group(['middleware' => config('fortify.middleware', ['web'])], function (
         ->middleware('guest')
         ->name('register-store');
 
+    Route::get('/admin/login', function () {
+        return redirect(localized_route('login'));
+    })
+        ->middleware('guest')
+        ->name('filament.auth.login');
+
     Route::multilingual('/login', [AuthenticatedSessionController::class, 'create'])
         ->middleware('guest')
         ->name('login');


### PR DESCRIPTION
Filament uses a custom login screen for admin access. This is a potential source of confusion, so I've disabled it in Filament's config file: https://github.com/accessibility-exchange/platform/blob/7e8479b58c50403e961ce16fcbf01049a9702a54/config/filament.php#L90

However, attempting to navigate directly to `/admin/interpretations` was throwing a `Route 'filament.auth.login' not found` error. This PR adds a route with that name which redirects to our standard login route.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
