### PR TITLE
fix: interpretation video source fallbacks (resolves #1320)

### DIFF
--- a/app/View/Components/Interpretation.php
+++ b/app/View/Components/Interpretation.php
@@ -54,7 +54,7 @@ class Interpretation extends Component
             null;
 
         $this->id = Str::slug($this->interpretation?->name ?? $this->name);
-        $this->videoSrc = $this->interpretation?->getTranslation('video', get_signed_language_for_written_language(locale())) ?? '';
+        $this->videoSrc = $this->interpretation?->getTranslation('video', get_signed_language_for_written_language(locale()), false) ?? '';
     }
 
     /**

--- a/tests/Feature/View/Components/InterpretationTest.php
+++ b/tests/Feature/View/Components/InterpretationTest.php
@@ -113,6 +113,62 @@ test('in French and LSQ', function () {
     $response->assertDontSee($interpretation->getTranslation('video', 'ase'));
 });
 
+test('do not fallback to ASL (ase)', function () {
+    $interpretation = Interpretation::factory()->create([
+        'name' => 'The Accessibility Exchange',
+        'video' => [
+            'ase' => 'https://vimeo.com/766454375',
+        ],
+    ]);
+
+    app()->setLocale('fr');
+
+    $user = User::factory()->create([
+        'sign_language_translations' => true,
+    ]);
+    $response = $this->actingAs($user)->get(localized_route('welcome'));
+    $response->assertStatus(200);
+
+    $toSee = [
+        '<h1 itemprop="name">',
+        'Le Connecteur pour l’accessibilité',
+        '</h1>',
+        'id="'.Str::slug('Le Connecteur pour l’accessibilité'),
+    ];
+
+    $response->assertSeeInOrder($toSee, false);
+    $response->assertDontSee('interpretation__video');
+    $response->assertDontSee($interpretation->getTranslation('video', 'ase'));
+});
+
+test('do not fallback to LSQ (fcs)', function () {
+    $interpretation = Interpretation::factory()->create([
+        'name' => 'The Accessibility Exchange',
+        'video' => [
+            'fcs' => 'https://vimeo.com/766455246',
+        ],
+    ]);
+
+    app()->setLocale('en');
+
+    $user = User::factory()->create([
+        'sign_language_translations' => true,
+    ]);
+    $response = $this->actingAs($user)->get(localized_route('welcome'));
+    $response->assertStatus(200);
+
+    $toSee = [
+        '<h1 itemprop="name">',
+        'The Accessibility Exchange',
+        '</h1>',
+        'id="'.Str::slug('The Accessibility Exchange'),
+    ];
+
+    $response->assertSeeInOrder($toSee, false);
+    $response->assertDontSee('interpretation__video');
+    $response->assertDontSee($interpretation->getTranslation('video', 'fcs'));
+});
+
 test('no Interpretation without sign language translations setting enabled', function () {
     $user = User::factory()->create([
         'sign_language_translations' => false,


### PR DESCRIPTION
Resolves #1320 

Adds third argument to `getTranslations` to prevent fallback to other sign language translations when retrieving the video source in the component.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
