### PR TITLE
fix: prevent accidental erasure of region when editing access needs (fix #1322)

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -134,8 +134,6 @@ class SettingsController extends Controller
         if (! isset($data['document_access_needs']) || (isset($data['document_access_needs']) && ! in_array($printedVersion, $data['document_access_needs']))) {
             $data['street_address'] = null;
             $data['unit_apartment_suite'] = null;
-            $data['locality'] = null;
-            $data['region'] = null;
             $data['postal_code'] = null;
         }
 

--- a/tests/Feature/UserSettingsTest.php
+++ b/tests/Feature/UserSettingsTest.php
@@ -27,6 +27,10 @@ test('individual users can manage access needs', function () {
 
     $user = User::factory()->create(['context' => 'individual']);
 
+    $individual = $user->individual;
+    $individual->update(['region' => 'NL']);
+    $individual = $individual->fresh();
+
     $response = $this->actingAs($user)->get(localized_route('settings.edit-access-needs'));
 
     $response->assertOk();
@@ -40,8 +44,9 @@ test('individual users can manage access needs', function () {
     $response->assertSessionHasNoErrors();
     $response->assertRedirect(localized_route('settings.edit-access-needs'));
 
-    $individual = $user->individual->fresh();
+    $individual = $individual->fresh();
     expect($individual->accessSupports->pluck('id')->toArray())->toContain($additionalNeeds->id);
+    expect($individual->region)->toEqual('NL');
 });
 
 test('other users cannot manage access needs', function () {


### PR DESCRIPTION
Resolves #1322.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
