### PR TITLE
fix(deploy): fixed deploy global command ordering (resolves #1323)

### DIFF
--- a/app/Console/Commands/DeployGlobal.php
+++ b/app/Console/Commands/DeployGlobal.php
@@ -27,10 +27,10 @@ class DeployGlobal extends Command
      */
     public function handle(): int
     {
-        $this->call('migrate', ['--step' => true, '--force' => true]);
         $this->call('optimize:clear');
-        $this->call('optimize');
         $this->call('event:cache');
+        $this->call('optimize');
+        $this->call('migrate', ['--step' => true, '--force' => true]);
 
         return 0;
     }


### PR DESCRIPTION
Changes the order of commands called within `deploy:global` command. 
* Order of commands that are called within this command are reordered to be.
```php
        $this->call('optimize:clear');
        $this->call('event:cache');
        $this->call('optimize');
        $this->call('migrate', ['--step' => true, '--force' => true]);
```
