### PR TITLE
fix: french fields required for individuals (resolves #1349)

### DIFF
--- a/app/Http/Requests/UpdateIndividualRequest.php
+++ b/app/Http/Requests/UpdateIndividualRequest.php
@@ -38,7 +38,9 @@ class UpdateIndividualRequest extends FormRequest
             ],
             'pronouns' => 'nullable|array:'.implode(',', $this->individual->languages),
             'bio' => 'required|array:'.implode(',', $this->individual->languages).'|required_array_keys:'.$this->individual->user->locale,
-            'bio.*' => 'required',
+            'bio.*' => 'nullable|string',
+            'bio.en' => 'required_without:bio.fr',
+            'bio.fr' => 'required_without:bio.en',
             'working_languages' => 'nullable|array',
             'consulting_services' => [
                 'nullable',
@@ -72,7 +74,9 @@ class UpdateIndividualRequest extends FormRequest
 
     public function messages(): array
     {
-        $messages = [];
+        $messages = [
+            'bio.*.required_without' => 'You must enter your :attribute.',
+        ];
 
         foreach ($this->social_links as $key => $value) {
             $messages['social_links.'.$key.'.active_url'] = __('You must enter a valid website address for :key.', ['key' => Str::studly($key)]);

--- a/resources/lang/fr/passwords.php
+++ b/resources/lang/fr/passwords.php
@@ -17,6 +17,6 @@ return [
     'sent' => 'Nous vous avons envoyé par courriel un lien de réinitialisation du mot de passe pour le site Connecteur pour l\'accessibilité. Veuillez vérifier votre courriel.',
     'throttled' => 'Veuillez patienter avant de réessayer.',
     'token' => 'Ce jeton de réinitialisation du mot de passe n\'est pas valide.',
-    'user' => "Nous ne pouvons pas trouver de compte associé à cette adresse courriel.",
+    'user' => 'Nous ne pouvons pas trouver de compte associé à cette adresse courriel.',
 
 ];


### PR DESCRIPTION
Resolves #1349 

Updates the request form validation to require at least one of French or English bio entry for an Individual's page.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
