### PR TITLE
fix: restore translatable input and textarea styles (fixes #891)

### DIFF
--- a/resources/css/_tokens.css
+++ b/resources/css/_tokens.css
@@ -1,4 +1,4 @@
-/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2022-11-22.
+/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2022-11-28.
     Tokens location: ./tailwind.config.js */
 :root {
     --color-black: #000;

--- a/resources/css/components/_expander.css
+++ b/resources/css/components/_expander.css
@@ -2,6 +2,10 @@
     position: relative;
 }
 
+.expander.field {
+    margin-inline-start: calc(-1 * var(--space-2));
+}
+
 .expander .title {
     font-size: var(--text-base);
     font-weight: var(--font-normal);
@@ -23,6 +27,16 @@
     position: relative;
     text-align: start;
     width: calc(100% + 2 * var(--space-2));
+}
+
+.expander.field .title button {
+    width: calc(100% + var(--space-2));
+}
+
+.expander.field .expander__content input,
+.expander.field .expander__content textarea {
+    margin-inline-start: var(--space-2);
+    width: calc(100% - var(--space-2));
 }
 
 .expander .title button::before {

--- a/resources/views/components/translatable-input.blade.php
+++ b/resources/views/components/translatable-input.blade.php
@@ -19,7 +19,7 @@
             @else
                 <div class="expander field @error($name . '.' . $language) field--error @enderror stack"
                     x-data="{ expanded: false, value: '{{ old($name . '.' . $language, $model ? $model->getTranslation($name, $language, false) : '') }}', badgeText: '{{ __('Content added') }}' }">
-                    <p class="expander__summary"
+                    <p class="title"
                         id="{{ Str::slug(__(':label (:locale)', ['label' => $label, 'locale' => get_language_exonym($language)])) }}">
                         <button type="button"
                             aria-describedby="{{ Str::slug(__(':label (:locale)', ['label' => $label, 'locale' => get_language_exonym($language)])) }}-status"

--- a/resources/views/components/translatable-textarea.blade.php
+++ b/resources/views/components/translatable-textarea.blade.php
@@ -19,7 +19,7 @@
             @else
                 <div class="expander field @error($name . '.' . $language) field--error @enderror stack"
                     x-data="{ expanded: false, value: '{{ old($name . '.' . $language, $model ? $model->getTranslation($name, $language, false) : '') }}', badgeText: '{{ __('Content added') }}' }">
-                    <p class="expander__summary"
+                    <p class="title"
                         id="{{ Str::slug(__(':label (:locale)', ['label' => $label, 'locale' => get_language_exonym($language)])) }}">
                         <button type="button"
                             aria-describedby="{{ Str::slug(__(':label (:locale)', ['label' => $label, 'locale' => get_language_exonym($language)])) }}-status"


### PR DESCRIPTION
Resolves #891.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
