### PR TITLE
fix: consulting methods - error message doubled (resolves #1351)

### DIFF
--- a/app/Http/Requests/UpdateCommunicationAndConsultationPreferencesRequest.php
+++ b/app/Http/Requests/UpdateCommunicationAndConsultationPreferencesRequest.php
@@ -44,7 +44,6 @@ class UpdateCommunicationAndConsultationPreferencesRequest extends FormRequest
             'consulting_methods' => [
                 'nullable',
                 'array',
-                'min:1',
                 Rule::requiredIf(request()->user()->individual->isParticipant()),
             ],
             'consulting_methods.*' => [new Enum(EngagementFormat::class)],

--- a/tests/Feature/UserSettingsTest.php
+++ b/tests/Feature/UserSettingsTest.php
@@ -109,6 +109,18 @@ test('individual users can manage communication and consultation preferences', f
         'support_person_name' => 'Jenny Appleseed',
         'support_person_email' => 'me@here.com',
         'preferred_contact_method' => 'email',
+        'consulting_methods' => [],
+    ]);
+
+    $response->assertSessionHasErrors(['consulting_methods']);
+
+    $response = $this->actingAs($user)->put(localized_route('settings.update-communication-and-consultation-preferences'), [
+        'phone' => '902-444-4444',
+        'vrs' => '1',
+        'preferred_contact_person' => 'support-person',
+        'support_person_name' => 'Jenny Appleseed',
+        'support_person_email' => 'me@here.com',
+        'preferred_contact_method' => 'email',
         'consulting_methods' => ['survey'],
     ]);
 


### PR DESCRIPTION
Resolves #1351 

Removes the array length check, as we are requiring it in cases where it is used (when the individual is a participant).

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
