### PR TITLE
fix: tts light mode page read wrong focus styling (resolves #1384)

### DIFF
--- a/resources/css/_tokens.css
+++ b/resources/css/_tokens.css
@@ -1,4 +1,4 @@
-/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2022-12-06.
+/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 12/7/2022.
     Tokens location: ./tailwind.config.js */
 :root {
     --color-black: #000;

--- a/resources/css/components/_button.css
+++ b/resources/css/components/_button.css
@@ -90,10 +90,12 @@ button.destructive:focus:active:not([aria-disabled="true"]) {
 
 .dark button:focus {
     --bg: var(--content-dark-background);
+    --btn-primary-outline: var(--theme-btn-primary-outline, var(--btn-dark-primary-background));
 }
 
 .darker button:focus {
     --bg: var(--content-darker-background);
+    --btn-primary-outline: var(--theme-btn-primary-outline, var(--btn-dark-primary-background));
 }
 
 .dark button:active:not([aria-disabled="true"]),


### PR DESCRIPTION
Resolves #1384 

Updates the focus outline styling for buttons on dark and darker background.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
