### PR TITLE
fix: null value assigned to checkbox (resolves #1440)

### DIFF
--- a/resources/lang/fr/passwords.php
+++ b/resources/lang/fr/passwords.php
@@ -17,6 +17,6 @@ return [
     'sent' => 'Nous vous avons envoyé par courriel un lien de réinitialisation du mot de passe pour le site Connecteur pour l\'accessibilité. Veuillez vérifier votre courriel.',
     'throttled' => 'Veuillez patienter avant de réessayer.',
     'token' => 'Ce jeton de réinitialisation du mot de passe n\'est pas valide.',
-    'user' => "Nous ne pouvons pas trouver de compte associé à cette adresse courriel.",
+    'user' => 'Nous ne pouvons pas trouver de compte associé à cette adresse courriel.',
 
 ];

--- a/resources/views/individuals/edit/groups-you-can-connect-to.blade.php
+++ b/resources/views/individuals/edit/groups-you-can-connect-to.blade.php
@@ -57,7 +57,7 @@
                     <legend>
                         <x-required>{{ __('Please select the disability and/or Deaf groups that you can connect to.') }}</x-required>
                     </legend>
-                    <x-hearth-radio-buttons name="base_disability_type" :options="$baseDisabilityTypes" :checked="old('base_disability_type', $individual->base_disability_type ?? '')"
+                    <x-hearth-radio-buttons name="base_disability_type" :options="$baseDisabilityTypes" :checked="old('base_disability_type', $individual->base_disability_type) ?? ''"
                         x-model="baseDisabilityType" />
                     <x-hearth-error for="base_disability_type" />
                 </fieldset>

--- a/resources/views/organizations/edit/4.blade.php
+++ b/resources/views/organizations/edit/4.blade.php
@@ -32,7 +32,7 @@
             </div>
 
             <div class="field @error('contact_person_vrs') field-error @enderror">
-                <x-hearth-checkbox name="contact_person_vrs" :checked="old('contact_person_vrs', $organization->contact_person_vrs ?? false)" />
+                <x-hearth-checkbox name="contact_person_vrs" :checked="old('contact_person_vrs', $organization->contact_person_vrs) ?? false" />
                 <x-hearth-label for="contact_person_vrs" :value="__('They require Video Relay Service (VRS) for phone calls')" />
                 <x-hearth-error for="contact_person_vrs" />
             </div>

--- a/resources/views/projects/edit/2.blade.php
+++ b/resources/views/projects/edit/2.blade.php
@@ -69,7 +69,7 @@
                 </div>
 
                 <div class="field @error('contact_person_vrs') field-error @enderror">
-                    <x-hearth-checkbox name="contact_person_vrs" :checked="old('contact_person_vrs', $project->contact_person_vrs ?? false)" />
+                    <x-hearth-checkbox name="contact_person_vrs" :checked="old('contact_person_vrs', $project->contact_person_vrs) ?? false" />
                     <x-hearth-label for="contact_person_vrs" :value="__('They require Video Relay Service (VRS) for phone calls')" />
                     <x-hearth-error for="contact_person_vrs" />
                 </div>

--- a/resources/views/regulated-organizations/edit.blade.php
+++ b/resources/views/regulated-organizations/edit.blade.php
@@ -168,7 +168,7 @@
                 </div>
 
                 <div class="field @error('contact_person_vrs') field-error @enderror">
-                    <x-hearth-checkbox name="contact_person_vrs" :checked="old('contact_person_vrs', $regulatedOrganization->contact_person_vrs ?? false)" />
+                    <x-hearth-checkbox name="contact_person_vrs" :checked="old('contact_person_vrs', $regulatedOrganization->contact_person_vrs) ?? false" />
                     <x-hearth-label for="contact_person_vrs" :value="__('They require Video Relay Service (VRS) for phone calls')" />
                     <x-hearth-error for="contact_person_vrs" />
                 </div>

--- a/resources/views/settings/communication-and-consultation-preferences.blade.php
+++ b/resources/views/settings/communication-and-consultation-preferences.blade.php
@@ -47,7 +47,7 @@
                 </div>
 
                 <div class="field @error('vrs') field-error @enderror">
-                    <x-hearth-checkbox name="vrs" :checked="old('vrs', $individual->user->vrs ?? false)" wire:model="vrs" />
+                    <x-hearth-checkbox name="vrs" :checked="old('vrs', $individual->user->vrs) ?? false" wire:model="vrs" />
                     <x-hearth-label for="vrs" :value="__('I require Video Relay Service (VRS) for phone calls')" />
                     <x-hearth-error for="vrs" />
                 </div>
@@ -80,7 +80,7 @@
                 </div>
 
                 <div class="field @error('support_person_vrs') field-error @enderror">
-                    <x-hearth-checkbox name="support_person_vrs" :checked="old('support_person_vrs', $individual->user->support_person_vrs ?? false)" />
+                    <x-hearth-checkbox name="support_person_vrs" :checked="old('support_person_vrs', $individual->user->support_person_vrs) ?? false" />
                     <x-hearth-label for="support_person_vrs" :value="__('My support person requires Video Relay Service (VRS) for phone calls')" />
                     <x-hearth-error for="support_person_vrs" />
                 </div>


### PR DESCRIPTION
Resolves #1440 

When the request updates request's model attributes and explicitly sets the attribute value to `null` it will result in the `old()` method accepting the attribute. This means that the default value specified as the second argument of the `old()` will not get triggered. The guard against this, the nullish coalescing is moved outside of the `old()`.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
