### PR TITLE
feat: admin panel for training modules (resolves #395, #397)

### DIFF
--- a/app/Filament/Resources/ChoiceResource.php
+++ b/app/Filament/Resources/ChoiceResource.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ChoiceResource\Pages;
+use App\Models\Choice;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+
+class ChoiceResource extends Resource
+{
+    protected static ?string $model = Choice::class;
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('label.en')
+                    ->label(__('Choice').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('label.fr'),
+                Forms\Components\TextInput::make('label.fr')
+                    ->label(__('Choice').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('label.en'),
+                Forms\Components\Select::make('question_id')
+                    ->relationship('question', 'question')
+                    ->required(),
+                Forms\Components\TextInput::make('value')
+                    ->required()
+                    ->maxLength(255),
+                Forms\Components\Toggle::make('is_answer')
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('question.id'),
+                Tables\Columns\TextColumn::make('value'),
+                Tables\Columns\TextColumn::make('label'),
+                Tables\Columns\IconColumn::make('is_answer')
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime(),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListChoices::route('/'),
+            'edit' => Pages\EditChoice::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ChoiceResource/Pages/EditChoice.php
+++ b/app/Filament/Resources/ChoiceResource/Pages/EditChoice.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\ChoiceResource\Pages;
+
+use App\Filament\Resources\ChoiceResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditChoice extends EditRecord
+{
+    protected static string $resource = ChoiceResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ChoiceResource/Pages/ListChoices.php
+++ b/app/Filament/Resources/ChoiceResource/Pages/ListChoices.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\ChoiceResource\Pages;
+
+use App\Filament\Resources\ChoiceResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListChoices extends ListRecords
+{
+    protected static string $resource = ChoiceResource::class;
+
+    protected function getActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Resources/CourseResource.php
+++ b/app/Filament/Resources/CourseResource.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\CourseResource\Pages;
+use App\Filament\Resources\CourseResource\RelationManagers;
+use App\Models\Course;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+
+class CourseResource extends Resource
+{
+    protected static ?string $model = Course::class;
+
+    protected static ?string $navigationIcon = 'heroicon-s-academic-cap';
+
+    protected static ?string $navigationGroup = 'Training';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title.en')
+                    ->label(__('Course title').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('title.fr'),
+                Forms\Components\TextInput::make('title.fr')
+                    ->label(__('Course title').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('title.en'),
+                Forms\Components\Select::make('organization_id')
+                    ->label(__('Author organization'))
+                    ->relationship('organization', 'name')
+                    ->columnSpan(2),
+                Forms\Components\TextInput::make('video.en')
+                    ->label(__('Video link').' ('.get_language_exonym('en').')')
+                    ->activeUrl()
+                    ->url()
+                    ->requiredWithout('video.fr'),
+                Forms\Components\TextInput::make('video.fr')
+                    ->label(__('Video link').' ('.get_language_exonym('fr').')')
+                    ->activeUrl()
+                    ->url()
+                    ->requiredWithout('video.en'),
+                Forms\Components\Textarea::make('introduction.en')
+                    ->label(__('Course introduction').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('introduction.fr')
+                    ->columnSpan(2),
+                Forms\Components\Textarea::make('introduction.fr')
+                    ->label(__('Course introduction').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('introduction.en')
+                    ->columnSpan(2),
+
+                Forms\Components\Fieldset::make('quiz')
+                    ->label(__('Quiz'))
+                    ->relationship('quiz')
+                    ->schema([
+                        Forms\Components\TextInput::make('title.en')
+                            ->label(__('Module title').' ('.get_language_exonym('en').')')
+                            ->requiredWithout('title.fr')
+                            ->reactive(),
+                        Forms\Components\TextInput::make('title.fr')
+                            ->label(__('Module title').' ('.get_language_exonym('fr').')')
+                            ->requiredWithout('title.en')
+                            ->reactive(),
+                        Forms\Components\TextInput::make('minimum_score')
+                            ->required()
+                            ->numeric()
+                            ->minValue(1)
+                            ->maxValue(100)
+                            ->reactive(),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                // TODO: Make this a count of users who have completed the course. Requires PR #1390
+                Tables\Columns\TextColumn::make('usersCompleted')
+                    ->formatStateUsing(fn (?string $state, Course $record): int => $record->users->count()),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('Date created'))
+                    ->dateTime(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                // TODO: Need route from PR #1390
+                // Tables\Actions\ViewAction::make()->url(fn (Course $record): string => localized_route('courses.show', $record)),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    // TODO: add a relationship to users to show who has completed the course
+    public static function getRelations(): array
+    {
+        return [
+            RelationManagers\ModulesRelationManager::class,
+            RelationManagers\QuizRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCourses::route('/'),
+            'create' => Pages\CreateCourse::route('/create'),
+            'edit' => Pages\EditCourse::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/CourseResource/Pages/CreateCourse.php
+++ b/app/Filament/Resources/CourseResource/Pages/CreateCourse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\CourseResource\Pages;
+
+use App\Filament\Resources\CourseResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateCourse extends CreateRecord
+{
+    protected static string $resource = CourseResource::class;
+}

--- a/app/Filament/Resources/CourseResource/Pages/EditCourse.php
+++ b/app/Filament/Resources/CourseResource/Pages/EditCourse.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\CourseResource\Pages;
+
+use App\Filament\Resources\CourseResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditCourse extends EditRecord
+{
+    protected static string $resource = CourseResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/CourseResource/Pages/ListCourses.php
+++ b/app/Filament/Resources/CourseResource/Pages/ListCourses.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\CourseResource\Pages;
+
+use App\Filament\Resources\CourseResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListCourses extends ListRecords
+{
+    protected static string $resource = CourseResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/CourseResource/RelationManagers/ModulesRelationManager.php
+++ b/app/Filament/Resources/CourseResource/RelationManagers/ModulesRelationManager.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Filament\Resources\CourseResource\RelationManagers;
+
+use App\Models\Module;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Resources\Table;
+use Filament\Tables;
+
+class ModulesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'modules';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title.en')
+                ->label(__('Module title').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('title.fr'),
+                Forms\Components\TextInput::make('title.fr')
+                ->label(__('Module title').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('title.en'),
+                Forms\Components\Textarea::make('description.en')
+                ->label(__('Module description').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('description.fr')
+                    ->columnSpan(2),
+                Forms\Components\Textarea::make('description.fr')
+                ->label(__('Module description').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('description.en')
+                    ->columnSpan(2),
+                Forms\Components\Textarea::make('introduction.en')
+                ->label(__('Module introduction').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('introduction.fr')
+                    ->columnSpan(2),
+                Forms\Components\Textarea::make('introduction.fr')
+                ->label(__('Module introduction').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('introduction.en')
+                    ->columnSpan(2),
+                Forms\Components\TextInput::make('video.en')
+                ->label(__('Video link').' ('.get_language_exonym('en').')')
+                    ->activeUrl()
+                    ->url()
+                    ->requiredWithout('video.fr'),
+                Forms\Components\TextInput::make('video.fr')
+                ->label(__('Video link').' ('.get_language_exonym('fr').')')
+                    ->activeUrl()
+                    ->url()
+                    ->requiredWithout('video.en'),
+            ]);
+    }
+
+    // public static function form(Form $form): Form
+    // {
+    //     return $form
+    //         ->schema([
+    //             Forms\Components\TextInput::make('title')
+    //                 ->required()
+    //                 ->maxLength(255),
+    //         ]);
+    // }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make()
+                    ->url(fn (Module $record): string => route('filament.resources.modules.edit', $record)),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/CourseResource/RelationManagers/QuizRelationManager.php
+++ b/app/Filament/Resources/CourseResource/RelationManagers/QuizRelationManager.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Resources\CourseResource\RelationManagers;
+
+use App\Models\Quiz;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Resources\Table;
+use Filament\Tables;
+
+class QuizRelationManager extends RelationManager
+{
+    protected static string $relationship = 'quiz';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title.en')
+                    ->label(__('Module title').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('title.fr'),
+                Forms\Components\TextInput::make('title.fr')
+                    ->label(__('Module title').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('title.en'),
+                Forms\Components\Select::make('course_id')
+                    ->relationship('course', 'title')
+                    ->columnSpan(2),
+                Forms\Components\TextInput::make('minimum_score')
+                    ->required()
+                    ->numeric()
+                    ->minValue(1)
+                    ->maxValue(100),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+            ])
+            ->filters([
+                //
+            ])
+            // ->headerActions([
+            //     Tables\Actions\CreateAction::make(),
+            // ])
+            ->actions([
+                Tables\Actions\EditAction::make()
+                    ->url(fn (Quiz $record): string => route('filament.resources.quizzes.edit', $record)),
+            ]);
+    }
+}

--- a/app/Filament/Resources/ModuleResource.php
+++ b/app/Filament/Resources/ModuleResource.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ModuleResource\Pages;
+use App\Models\Module;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+
+class ModuleResource extends Resource
+{
+    protected static ?string $model = Module::class;
+
+    protected static ?string $navigationIcon = 'heroicon-s-collection';
+
+    protected static ?string $navigationGroup = 'Training';
+
+    protected static ?int $navigationSort = 2;
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title.en')
+                    ->label(__('Module title').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('title.fr'),
+                Forms\Components\TextInput::make('title.fr')
+                    ->label(__('Module title').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('title.en'),
+                Forms\Components\Select::make('course_id')
+                    ->relationship('course', 'title')
+                    ->columnSpan(2),
+                Forms\Components\Textarea::make('description.en')
+                ->label(__('Module description').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('description.fr')
+                    ->columnSpan(2),
+                Forms\Components\Textarea::make('description.fr')
+                ->label(__('Module description').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('description.en')
+                    ->columnSpan(2),
+                Forms\Components\Textarea::make('introduction.en')
+                ->label(__('Module introduction').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('introduction.fr')
+                    ->columnSpan(2),
+                Forms\Components\Textarea::make('introduction.fr')
+                ->label(__('Module introduction').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('introduction.en')
+                    ->columnSpan(2),
+                Forms\Components\TextInput::make('video.en')
+                    ->label(__('Video link').' ('.get_language_exonym('en').')')
+                    ->activeUrl()
+                    ->url()
+                    ->requiredWithout('video.fr'),
+                Forms\Components\TextInput::make('video.fr')
+                    ->label(__('Video link').' ('.get_language_exonym('fr').')')
+                    ->activeUrl()
+                    ->url()
+                    ->requiredWithout('video.en'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('course.title')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('Date created'))
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('course.title')
+            ->filters([
+                Tables\Filters\SelectFilter::make('course')->relationship('course', 'title'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                // TODO: Need route from PR #1390
+                // Tables\Actions\ViewAction::make()->url(fn (Module $record): string => localized_route('modules.module-content', $record)),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListModules::route('/'),
+            'edit' => Pages\EditModule::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ModuleResource/Pages/EditModule.php
+++ b/app/Filament/Resources/ModuleResource/Pages/EditModule.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\ModuleResource\Pages;
+
+use App\Filament\Resources\ModuleResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditModule extends EditRecord
+{
+    protected static string $resource = ModuleResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ModuleResource/Pages/ListModules.php
+++ b/app/Filament/Resources/ModuleResource/Pages/ListModules.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\ModuleResource\Pages;
+
+use App\Filament\Resources\ModuleResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListModules extends ListRecords
+{
+    protected static string $resource = ModuleResource::class;
+
+    protected function getActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Resources/QuestionResource.php
+++ b/app/Filament/Resources/QuestionResource.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\QuestionResource\Pages;
+use App\Filament\Resources\QuestionResource\RelationManagers;
+use App\Models\Question;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+
+class QuestionResource extends Resource
+{
+    protected static ?string $model = Question::class;
+
+    protected static ?string $navigationIcon = 'heroicon-s-question-mark-circle';
+
+    protected static ?string $navigationGroup = 'Training';
+
+    protected static ?int $navigationSort = 4;
+
+    protected static ?string $recordTitleAttribute = 'question';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('question.en')
+                    ->label(__('Question').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('question.fr'),
+                Forms\Components\TextInput::make('question.fr')
+                    ->label(__('Question').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('question.en'),
+                Forms\Components\Select::make('quiz_id')
+                    ->relationship('quiz', 'title')
+                    ->required()
+                    ->columnSpan(2),
+                Forms\Components\TextInput::make('order')
+                    ->required()
+                    ->numeric()
+                    ->mask(
+                        fn (Forms\Components\TextInput\Mask $mask) => $mask
+                            ->numeric()
+                            ->integer()
+                            ->minValue(0)
+                    ),
+
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('question'),
+                Tables\Columns\TextColumn::make('quiz.title')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('choices_count')->counts('choices'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('Date created'))
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('quiz.title', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('quiz')->relationship('quiz', 'title'),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            RelationManagers\ChoicesRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListQuestions::route('/'),
+            'edit' => Pages\EditQuestion::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/QuestionResource/Pages/EditQuestion.php
+++ b/app/Filament/Resources/QuestionResource/Pages/EditQuestion.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\QuestionResource\Pages;
+
+use App\Filament\Resources\QuestionResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditQuestion extends EditRecord
+{
+    protected static string $resource = QuestionResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/QuestionResource/Pages/ListQuestions.php
+++ b/app/Filament/Resources/QuestionResource/Pages/ListQuestions.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\QuestionResource\Pages;
+
+use App\Filament\Resources\QuestionResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListQuestions extends ListRecords
+{
+    protected static string $resource = QuestionResource::class;
+
+    protected function getActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Resources/QuestionResource/RelationManagers/ChoicesRelationManager.php
+++ b/app/Filament/Resources/QuestionResource/RelationManagers/ChoicesRelationManager.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Filament\Resources\QuestionResource\RelationManagers;
+
+use App\Models\Choice;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Resources\Table;
+use Filament\Tables;
+
+class ChoicesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'choices';
+
+    protected static ?string $recordTitleAttribute = 'choice';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('label.en')
+                    ->label(__('Choice').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('label.fr'),
+                Forms\Components\TextInput::make('label.fr')
+                    ->label(__('Choice').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('label.en'),
+                Forms\Components\TextInput::make('value')
+                    ->required()
+                    ->maxLength(255),
+                Forms\Components\Toggle::make('is_answer')
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('label')
+                    ->label(__('Choice')),
+                Tables\Columns\IconColumn::make('is_answer')
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('Date created'))
+                    ->dateTime(),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make()
+                    ->url(fn (Choice $record): string => route('filament.resources.choices.edit', $record)),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/QuizResource.php
+++ b/app/Filament/Resources/QuizResource.php
@@ -55,7 +55,7 @@ class QuizResource extends Resource
                 Tables\Columns\TextColumn::make('title')
                     ->sortable(),
                 Tables\Columns\TextColumn::make('course.title')
-                    ->sortable('title'),
+                    ->sortable(['title']),
                 Tables\Columns\TextColumn::make('minimum_score'),
                 Tables\Columns\TextColumn::make('questions_count')->counts('questions'),
                 Tables\Columns\TextColumn::make('created_at')

--- a/app/Filament/Resources/QuizResource.php
+++ b/app/Filament/Resources/QuizResource.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\QuizResource\Pages;
+use App\Filament\Resources\QuizResource\RelationManagers;
+use App\Models\Quiz;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+
+class QuizResource extends Resource
+{
+    protected static ?string $model = Quiz::class;
+
+    protected static ?string $navigationIcon = 'heroicon-s-document-text';
+
+    protected static ?string $navigationGroup = 'Training';
+
+    protected static ?int $navigationSort = 3;
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title.en')
+                    ->label(__('Module title').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('title.fr'),
+                Forms\Components\TextInput::make('title.fr')
+                    ->label(__('Module title').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('title.en'),
+                Forms\Components\Select::make('course_id')
+                    ->relationship('course', 'title')
+                    ->columnSpan(2),
+                Forms\Components\TextInput::make('minimum_score')
+                    ->required()
+                    ->numeric()
+                    ->mask(
+                        fn (Forms\Components\TextInput\Mask $mask) => $mask
+                            ->numeric()
+                            ->minValue(0)
+                            ->maxValue(100),
+                    ),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('course.title')
+                    ->sortable('title'),
+                Tables\Columns\TextColumn::make('minimum_score'),
+                Tables\Columns\TextColumn::make('questions_count')->counts('questions'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('Date created'))
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('title')
+            ->filters([
+                Tables\Filters\SelectFilter::make('course')->relationship('course', 'title'),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            RelationManagers\QuestionsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListQuizzes::route('/'),
+            'edit' => Pages\EditQuiz::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/QuizResource/Pages/EditQuiz.php
+++ b/app/Filament/Resources/QuizResource/Pages/EditQuiz.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\QuizResource\Pages;
+
+use App\Filament\Resources\QuizResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditQuiz extends EditRecord
+{
+    protected static string $resource = QuizResource::class;
+
+    protected function getActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Resources/QuizResource/Pages/ListQuizzes.php
+++ b/app/Filament/Resources/QuizResource/Pages/ListQuizzes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\QuizResource\Pages;
+
+use App\Filament\Resources\QuizResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListQuizzes extends ListRecords
+{
+    protected static string $resource = QuizResource::class;
+
+    protected function getActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Resources/QuizResource/RelationManagers/QuestionsRelationManager.php
+++ b/app/Filament/Resources/QuizResource/RelationManagers/QuestionsRelationManager.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Filament\Resources\QuizResource\RelationManagers;
+
+use App\Models\Question;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Resources\Table;
+use Filament\Tables;
+
+class QuestionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'questions';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('question.en')
+                ->label(__('Question').' ('.get_language_exonym('en').')')
+                    ->requiredWithout('question.fr'),
+                Forms\Components\TextInput::make('question.fr')
+                ->label(__('Question').' ('.get_language_exonym('fr').')')
+                    ->requiredWithout('question.en'),
+                Forms\Components\TextInput::make('order')
+                ->required()
+                    ->numeric()
+                    ->mask(
+                        fn (Forms\Components\TextInput\Mask $mask) => $mask
+                            ->numeric()
+                            ->integer()
+                            ->minValue(0)
+                    ),
+
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('question')
+                    ->sortable(['order', 'question']),
+                Tables\Columns\TextColumn::make('choices_count')->counts('choices'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('Date created'))
+                    ->dateTime(),
+            ])
+            ->defaultSort('question')
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make()
+                    ->url(fn (Question $record): string => route('filament.resources.questions.edit', $record)),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,6 +22,7 @@ use Composer\InstalledVersions;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\NavigationItem;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\ServiceProvider;
@@ -78,6 +79,11 @@ class AppServiceProvider extends ServiceProvider
                     ->url(localized_route('admin.estimates-and-agreements'))
                     ->icon('heroicon-s-clipboard-check')
                     ->sort(-1),
+            ]);
+
+            Filament::registerNavigationGroups([
+                NavigationGroup::make()
+                    ->label('Training'),
             ]);
         });
 

--- a/resources/css/_tokens.css
+++ b/resources/css/_tokens.css
@@ -1,4 +1,4 @@
-/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2022-12-13.
+/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 12/20/2022.
     Tokens location: ./tailwind.config.js */
 :root {
     --space-0: 0;

--- a/resources/css/filament.css
+++ b/resources/css/filament.css
@@ -57,6 +57,12 @@ select:focus {
     outline-offset: 2px;
 }
 
+.filament-forms-toggle-component:focus {
+    --tw-border-opacity: 1;
+
+    border-color: rgb(38 41 106 / var(--tw-border-opacity));
+}
+
 input::placeholder,
 textarea::placeholder {
     color: #6b7280;
@@ -194,7 +200,8 @@ select {
     outline: 1px auto -webkit-focus-ring-color;
 }
 
-a.filament-button:focus {
+a.filament-button:focus,
+button.filament-button:focus {
     color: white;
 }
 
@@ -227,7 +234,8 @@ a.filament-button:focus {
 }
 
 .dark [type="checkbox"]:focus,
-.dark [type="radio"]:focus {
+.dark [type="radio"]:focus,
+.dark .filament-forms-toggle-component:focus {
     border-color: white;
 }
 

--- a/resources/lang/fr/passwords.php
+++ b/resources/lang/fr/passwords.php
@@ -17,6 +17,6 @@ return [
     'sent' => 'Nous vous avons envoyé par courriel un lien de réinitialisation du mot de passe pour le site Connecteur pour l\'accessibilité. Veuillez vérifier votre courriel.',
     'throttled' => 'Veuillez patienter avant de réessayer.',
     'token' => 'Ce jeton de réinitialisation du mot de passe n\'est pas valide.',
-    'user' => "Nous ne pouvons pas trouver de compte associé à cette adresse courriel.",
+    'user' => 'Nous ne pouvons pas trouver de compte associé à cette adresse courriel.',
 
 ];

--- a/resources/views/dashboard/administrator.blade.php
+++ b/resources/views/dashboard/administrator.blade.php
@@ -23,6 +23,9 @@
             <a href="{{ route('filament.resources.topics.index') }}">{{ __('Topics') }}</a>
         </li>
         <li>
+            <a href="{{ route('filament.resources.courses.index') }}">{{ __('Training') }}</a>
+        </li>
+        <li>
             <a href="{{ route('filament.pages.settings') }}">{{ __('Website settings') }}</a>
         </li>
     </x-quick-links>


### PR DESCRIPTION
Resolves #395 
Resolves #397

Adds the admin interface adding training modules including adding courses, modules, questions, quizzes. 

Blocked by: requires changes from #1390

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [ ] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
