### PR TITLE
fix: select input contrast issue (resolves #1477)

### DIFF
--- a/resources/css/_tokens.css
+++ b/resources/css/_tokens.css
@@ -1,4 +1,4 @@
-/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2023-01-19.
+/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2023-01-23.
     Tokens location: ./tailwind.config.js */
 :root {
     --space-0: 0;

--- a/resources/css/components/_input.css
+++ b/resources/css/components/_input.css
@@ -19,6 +19,10 @@ select {
     width: 100%;
 }
 
+option {
+    background-color: var(--theme-body-background);
+}
+
 input {
     height: var(--space-12);
 }


### PR DESCRIPTION
Resolves #1477 

Sets the `background-color` for the `<option>` element; which should be applied in MS Edge and Chrome on Windows. In macOS the `<select>` element uses a native element so the styling will have no effect.

### Prerequisites

If this PR changes PHP code or dependencies:

- [ ] I've run `composer format` and fixed any code formatting issues.
- [ ] I've run `composer analyze` and addressed any static analysis issues.
- [ ] I've run `php artisan test` and ensured that all tests pass.
- [ ] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
