### PR TITLE
fix: can change route_has_params in admin panel (resolves #1482)

### DIFF
--- a/app/Filament/Resources/InterpretationResource/Pages/EditInterpretation.php
+++ b/app/Filament/Resources/InterpretationResource/Pages/EditInterpretation.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\InterpretationResource\Pages;
 
 use App\Filament\Resources\InterpretationResource;
+use Filament\Forms;
 use Filament\Pages\Actions;
 use Filament\Resources\Pages\EditRecord;
 
@@ -14,6 +15,33 @@ class EditInterpretation extends EditRecord
     {
         return [
             Actions\DeleteAction::make(),
+        ];
+    }
+
+    protected function getFormSchema(): array
+    {
+        return [
+            Forms\Components\TextInput::make('name')
+                ->required()
+                ->maxLength(255)
+                ->columnSpan(2),
+            Forms\Components\TextInput::make('route')
+                ->required()
+                ->maxLength(255),
+            Forms\Components\TextInput::make('namespace')
+                ->maxLength(255),
+            Forms\Components\Toggle::make('route_has_params')
+                ->label('Route has parameters')
+                ->columnSpan(2)
+                ->disabled(),
+            Forms\Components\TextInput::make('video.asl')
+                ->label('ASL Video')
+                ->url()
+                ->maxLength(255),
+            Forms\Components\TextInput::make('video.lsq')
+                ->label('LSQ Video')
+                ->url()
+                ->maxLength(255),
         ];
     }
 }

--- a/app/Filament/Resources/InterpretationResource/Pages/EditInterpretation.php
+++ b/app/Filament/Resources/InterpretationResource/Pages/EditInterpretation.php
@@ -30,10 +30,6 @@ class EditInterpretation extends EditRecord
                 ->maxLength(255),
             Forms\Components\TextInput::make('namespace')
                 ->maxLength(255),
-            Forms\Components\Toggle::make('route_has_params')
-                ->label('Route has parameters')
-                ->columnSpan(2)
-                ->disabled(),
             Forms\Components\TextInput::make('video.asl')
                 ->label('ASL Video')
                 ->url()


### PR DESCRIPTION
Resolves #1482 

Disables the Route Has Params toggle from the sign language interpretations edit interface in the admin panel. This is so that someone can see what the state is, but not accidentally alter it into something that is broken.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
