### PR TITLE
ci: create seeders/replication for data added/edited via the admin interfaces (resolves #1483)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,82 @@ The project uses [Pest](http://pestphp.com) for testing. For more information ab
 - Prereleases must be tagged from the `dev` branch.
 - Releases must be tagged from the `production` branch.
 
+
+## Custom Artisan Commands
+
+### db:refresh
+
+#### Purpose
+
+(Excluded from running during tests or on production.)  
+
+* Backs up filament tables to JSON files that are included in the config **backup.filament_seeders.tables**. [optional if `--backup` is used]  
+* Runs a fresh migration that will truncate all tables and run all migrations.  
+* Runs the **DevSeeder** seeder.  
+
+### deploy:global
+
+#### Purpose
+
+Runs other console commands in order and should be commands that are only run once accross multiple deploying container.  
+
+### deploy:local
+
+#### Purpose
+
+Runs other console commands in order and should be commands that should be run on each deploying container.  
+
+### notifications:remove:old
+
+#### Purpose
+
+Removes older notifications.
+
+#### Options
+
+`--days=` - _*required_ - The number of days which notifications older than will be deleted from the notifications database table.  
+
+### db:seed:backup
+
+#### Purpose
+
+Takes filament tables and backs them up to JSON files so that they can be used by seeders to repopulate the tables.  
+
+#### Options
+
+| option | Description |
+| --- | ---- |  
+| `--a\|all` | Whether to run through all available backups/restores in config. |  
+
+* When used by itself it backups all the tables found in config **backup.filament_seeders.tables**.  
+* When used with `--restore` option it will run all seeder classed found in **backup.filament_seeders.classes**.  
+---
+
+| option | Description |  
+| --- | ---- |  
+| `--remove` | Remove backed up files |  
+
+* When used by itself it will remove all of the backed up JSON files found in **backup.filament_seeders.tables**.  
+* When used with `--table=` it will remove only the JSON files related to the table(s) (can pass multiple values, each needs to be prefixed by `--table=`.)  
+---
+
+| option | Description |  
+| --- | ---- |
+| `--restore` | Restore the filament table |  
+
+* Will not run during tests or on production.  
+* When used without options it will prompt with available classes found in **backup.filament_seeders.classes**, user can choose multiple by separating choices by commas and will run the chosen seeder classes.  
+* When used with `--all` option it will run all seeder classes found in **backup.filament_seeders.classes**.  
+---
+
+| option | Description |  
+| --- | ---- |
+| `--t\|table=` | Create/remove specific table file |  
+
+* When used by itself it will backup the specified table(s) to a JSON file (can pass multiple values, each needs to be prefixed by `--table=`.)  
+* When used with `--remove` it will remove only the JSON files related to the table(s) (can pass multiple values, each needs to be prefixed by `--table=`.)  
+
+
 ## License
 
 The Accessibility Exchange platform is available under the [BSD 3-Clause License](https://github.com/accessibility-exchange/platform/blob/main/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -304,7 +304,19 @@ Takes filament tables and backs them up to JSON files so that they can be used b
 | `--a\|all` | Whether to run through all available backups/restores in config. |  
 
 * When used by itself it backups all the tables found in config **backup.filament_seeders.tables**.  
-* When used with `--restore` option it will run all seeder classed found in **backup.filament_seeders.classes**.  
+* When used with `--restore` option it will run all seeder classed found in **backup.filament_seeders.classes**.
+
+--- 
+
+| option | Description |  
+| --- | ---- |  
+| `--env` | Override the environment tag that is being handled. |  
+
+* Available environments are found in config **backup.filament_seeders.environments**.  
+* When used by default backup it will tag the json files with environment tag.  
+* When used with `--delete` option will change the files being deleted to those tagged with the specific environment.
+* When used with `--restore` option will restore from files tagged with the environment that you specify.  
+
 ---
 
 | option | Description |  
@@ -313,6 +325,7 @@ Takes filament tables and backs them up to JSON files so that they can be used b
 
 * When used by itself it will remove all of the backed up JSON files found in **backup.filament_seeders.tables**.  
 * When used with `--table=` it will remove only the JSON files related to the table(s) (can pass multiple values, each needs to be prefixed by `--table=`.)  
+
 ---
 
 | option | Description |  
@@ -321,7 +334,16 @@ Takes filament tables and backs them up to JSON files so that they can be used b
 
 * Will not run during tests or on production.  
 * When used without options it will prompt with available classes found in **backup.filament_seeders.classes**, user can choose multiple by separating choices by commas and will run the chosen seeder classes.  
-* When used with `--all` option it will run all seeder classes found in **backup.filament_seeders.classes**.  
+* When used with `--all` option it will run all seeder classes found in **backup.filament_seeders.classes**. 
+
+---
+
+| option | Description |  
+| --- | ---- |
+| `--truncate` | Whether to truncate the table before seeding it. |  
+
+* When used with `--restore` it will truncate the tables before seeding them.  
+
 ---
 
 | option | Description |  

--- a/app/Console/Commands/DatabaseRefresh.php
+++ b/app/Console/Commands/DatabaseRefresh.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 
 class DatabaseRefresh extends Command
 {
@@ -11,7 +12,8 @@ class DatabaseRefresh extends Command
      *
      * @var string
      */
-    protected $signature = 'db:refresh';
+    protected $signature = 'db:refresh
+                            {--backup : Whether to backup first}?';
 
     /**
      * The console command description.
@@ -27,10 +29,35 @@ class DatabaseRefresh extends Command
      */
     public function handle()
     {
+        $options = $this->options();
+
         // Don't run command in production or testing environment
         if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+
+            // whether to backup seeds first
+            if ($options['backup']) {
+                $this->call('db:seed:backup', ['--all' => true]);
+            }
+
             $this->call('migrate:fresh', ['--force' => true]);
             $this->call('db:seed', ['--class' => 'DevSeeder', '--force' => true]);
+
+            print("Truncating filament tables:\r\n");
+
+            $truncate_tables = array("identities", "interpretations", "resource_collections", "resources", "topics");
+            foreach($truncate_tables as $table) {
+                printf("Truncating values in table %s.\r\n", $table);
+                DB::table($table)->delete();
+            }
+
+            print("\r\n");
+            print("Running filament seeders:\r\n");
+
+            $seeder_classes = array("IdentitySeeder", "InterpretationSeeder", "ResourceCollectionSeeder", "ResourceSeeder", "TopicSeeder");
+            foreach($seeder_classes as $seeder_class) {
+                printf("Running seeder %s.", $seeder_class);
+                $this->call('db:seed', ['--class' => $seeder_class]);
+            }
         }
 
         return 0;

--- a/app/Console/Commands/DatabaseRefresh.php
+++ b/app/Console/Commands/DatabaseRefresh.php
@@ -41,23 +41,6 @@ class DatabaseRefresh extends Command
 
             $this->call('migrate:fresh', ['--force' => true]);
             $this->call('db:seed', ['--class' => 'DevSeeder', '--force' => true]);
-
-            print("Truncating filament tables:\r\n");
-
-            $truncate_tables = array("identities", "interpretations", "resource_collections", "resources", "topics");
-            foreach($truncate_tables as $table) {
-                printf("Truncating values in table %s.\r\n", $table);
-                DB::table($table)->delete();
-            }
-
-            print("\r\n");
-            print("Running filament seeders:\r\n");
-
-            $seeder_classes = array("IdentitySeeder", "InterpretationSeeder", "ResourceCollectionSeeder", "ResourceSeeder", "TopicSeeder");
-            foreach($seeder_classes as $seeder_class) {
-                printf("Running seeder %s.", $seeder_class);
-                $this->call('db:seed', ['--class' => $seeder_class]);
-            }
         }
 
         return 0;

--- a/app/Console/Commands/DeployGlobal.php
+++ b/app/Console/Commands/DeployGlobal.php
@@ -28,6 +28,7 @@ class DeployGlobal extends Command
     public function handle(): int
     {
         $this->call('optimize:clear');
+        $this->call('event:clear');
         $this->call('icons:clear');
         $this->call('view:clear');
         $this->call('route:clear');

--- a/app/Console/Commands/DeployGlobal.php
+++ b/app/Console/Commands/DeployGlobal.php
@@ -29,8 +29,14 @@ class DeployGlobal extends Command
     {
         $this->call('optimize:clear');
         $this->call('icons:clear');
+        $this->call('view:clear');
+        $this->call('route:clear');
+        $this->call('config:clear');
         $this->call('event:cache');
         $this->call('icons:cache');
+        $this->call('view:cache');
+        $this->call('route:cache');
+        $this->call('config:cache');
         $this->call('google-fonts:fetch');
         $this->call('optimize');
         $this->call('migrate', ['--step' => true, '--force' => true]);

--- a/app/Console/Commands/NotificationsRemoveOld.php
+++ b/app/Console/Commands/NotificationsRemoveOld.php
@@ -12,7 +12,8 @@ class NotificationsRemoveOld extends Command
      *
      * @var string
      */
-    protected $signature = 'notifications:remove:old ${days}';
+    protected $signature = 'notifications:remove:old
+                            {--days= : How many days before today to delete notifications}';
 
     /**
      * The console command description.
@@ -28,7 +29,7 @@ class NotificationsRemoveOld extends Command
      */
     public function handle()
     {
-        $days = $this->argument('days');
+        $days = $this->option('days');
 
         if (is_numeric($days) && $days > 1) {
             DB::table('notifications')->where('read_at', '<', DB::raw('DATE_SUB(NOW(), INTERVAL '.$days.' day)'))->delete();

--- a/app/Console/Commands/SeederBackupData.php
+++ b/app/Console/Commands/SeederBackupData.php
@@ -17,7 +17,8 @@ class SeederBackupData extends Command
                             {--a|all : Whether to run through all available backups/restores in config}?
                             {--remove : Remove backed up files}?
                             {--restore : Restore the filament table}?
-                            {--t|table=* : Create/remove specific table file}?';
+                            {--t|table=* : Create/remove specific table file}?
+                            {--truncate : Truncate the table before restoring}';
 
     /**
      * The console command description.
@@ -36,7 +37,7 @@ class SeederBackupData extends Command
         $options = $this->options();
 
         // option to use environment to restore or backup to different environment files
-        if (isset($options['env']) && in_array($options['env'], ['production', 'staging', 'local']) === true) {
+        if (isset($options['env']) && in_array($options['env'], config('backup.filament_seeders.environments')) === true) {
             $environment = $options['env'];
         } else {
             $environment = config('app.env');
@@ -76,6 +77,7 @@ class SeederBackupData extends Command
                 $seeder_classes = config('backup.filament_seeders.classes');
 
                 config(['seeder.environment' => $environment]);
+                config(['seeder.truncate' => $options['truncate']]);
 
                 // run through all the seeder classes
                 // else provide a choice of which to restore
@@ -99,6 +101,7 @@ class SeederBackupData extends Command
                 }
 
                 config(['seeder.environment' => null]);
+                config(['seeder.truncate' => false]);
                 return 0;
             }
 

--- a/app/Console/Commands/SeederBackupData.php
+++ b/app/Console/Commands/SeederBackupData.php
@@ -17,7 +17,7 @@ class SeederBackupData extends Command
                             {--a|all : Whether to run through all available backups/restores in config}?
                             {--remove : Remove backed up files}?
                             {--restore : Restore the filament table}?
-                            {--t|table= : Create/remove specific table file}?*';
+                            {--t|table=* : Create/remove specific table file}?';
 
     /**
      * The console command description.
@@ -42,12 +42,15 @@ class SeederBackupData extends Command
             // if the table option is set only remove that tables file
             // else remove all found in the config
             if (isset($options['table'])) {
-                if (in_array($options['table'], $available_tables)) {
-                    Storage::disk('seeds')->delete($options['table'] . ".json");
-                } else {
-                    printf("You have might have misspelled the tablename.\r\nAvailable tables: %s\r\n", implode(', ', $available_tables));
-                    return 1;
+                foreach($options['table'] as $table) {
+                    if (in_array($table, $available_tables)) {
+                        Storage::disk('seeds')->delete($table . ".json");
+                    } else {
+                        printf("You have might have misspelled the tablename.\r\nTable %s not found.\r\nAvailable tables: %s\r\n", $table, implode(', ', $available_tables));
+                        return 1;
+                    }
                 }
+                return 0;
             } else {
                 foreach($available_tables as $table) {
                     Storage::disk('seeds')->delete($table . ".json");
@@ -96,14 +99,16 @@ class SeederBackupData extends Command
 
         // if table is set the default will be to backup the table
         } elseif (isset($options['table'])) {
-            if (in_array($options['table'], $available_tables)) {
-                printf("Backing up table seeder %s\r\n", $options['table']);
-                Storage::disk('seeds')->put($options['table'] . ".json", DB::table($options['table'])->get()->toJson());
-                return 0;
-            } else {
-                printf("You have might have misspelled the tablename.\r\nAvailable tables: %s\r\n", implode(', ', $available_tables));
-                return 1;
+            foreach($options['table'] as $table) {
+                if (in_array($table, $available_tables)) {
+                    printf("Backing up table seeder %s\r\n", $table);
+                    Storage::disk('seeds')->put($table . ".json", DB::table($table)->get()->toJson());
+                } else {
+                    printf("You have might have misspelled the tablename.\r\nTable %s not found.\r\nAvailable tables: %s\r\n", $table, implode(', ', $available_tables));
+                    return 1;
+                }
             }
+            return 0;
         } else {
             printf("Must use at least one option.\r\nTry php artisan help db:seed:backup\r\n");
             return 1;

--- a/app/Console/Commands/SeederBackupData.php
+++ b/app/Console/Commands/SeederBackupData.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class SeederBackupData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:seed:backup ${table}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create backup of table for seeder.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $table = $this->argument('table');
+        $available_tables = array("identities", "interpretations", "resource_collections", "resources", "topics");
+
+        if (in_array($table, $available_tables)) {
+            Storage::disk('seeds')->put($table . ".json", DB::table($table)->get()->toJson());
+
+            return 0;
+        } else {
+
+            printf("Table '%s' is not in the list of available tables to backup.\r\n", $table);
+            return 1;
+        }
+
+    }
+}

--- a/app/Console/Commands/SeederBackupData.php
+++ b/app/Console/Commands/SeederBackupData.php
@@ -13,7 +13,9 @@ class SeederBackupData extends Command
      *
      * @var string
      */
-    protected $signature = 'db:seed:backup ${table}';
+    protected $signature = 'db:seed:backup
+                            {--all : Whether to backup all available tables}?
+                            {--table= : Backup specific table}?*';
 
     /**
      * The console command description.
@@ -29,16 +31,23 @@ class SeederBackupData extends Command
      */
     public function handle()
     {
-        $table = $this->argument('table');
+        $options = $this->options();
+
         $available_tables = array("identities", "interpretations", "resource_collections", "resources", "topics");
 
-        if (in_array($table, $available_tables)) {
-            Storage::disk('seeds')->put($table . ".json", DB::table($table)->get()->toJson());
+        if ($options['all']) {
+            foreach($available_tables as $table) {
+                Storage::disk('seeds')->put($table . ".json", DB::table($table)->get()->toJson());
+            }
+
+            return 0;
+        } elseif (isset($options['table']) && in_array($options['table'], $available_tables)) {
+            Storage::disk('seeds')->put($options['table'] . ".json", DB::table($options['table'])->get()->toJson());
 
             return 0;
         } else {
 
-            printf("Table '%s' is not in the list of available tables to backup.\r\n", $table);
+            printf("Must use option --all or --table=. See --help for more details.\r\n");
             return 1;
         }
 

--- a/app/Console/Commands/SeederBackupData.php
+++ b/app/Console/Commands/SeederBackupData.php
@@ -14,8 +14,10 @@ class SeederBackupData extends Command
      * @var string
      */
     protected $signature = 'db:seed:backup
-                            {--all : Whether to backup all available tables}?
-                            {--table= : Backup specific table}?*';
+                            {--a|all : Whether to run through all available backups/restores in config}?
+                            {--remove : Remove backed up files}?
+                            {--restore : Restore the filament table}?
+                            {--t|table= : Create/remove specific table file}?*';
 
     /**
      * The console command description.
@@ -33,21 +35,77 @@ class SeederBackupData extends Command
     {
         $options = $this->options();
 
-        $available_tables = array("identities", "interpretations", "resource_collections", "resources", "topics");
+        $available_tables = config('backup.filament_seeders.tables');
 
-        if ($options['all']) {
-            foreach($available_tables as $table) {
-                Storage::disk('seeds')->put($table . ".json", DB::table($table)->get()->toJson());
+        // removes backuped up files
+        if ($options['remove']) {
+            // if the table option is set only remove that tables file
+            // else remove all found in the config
+            if (isset($options['table'])) {
+                if (in_array($options['table'], $available_tables)) {
+                    Storage::disk('seeds')->delete($options['table'] . ".json");
+                } else {
+                    printf("You have might have misspelled the tablename.\r\nAvailable tables: %s\r\n", implode(', ', $available_tables));
+                    return 1;
+                }
+            } else {
+                foreach($available_tables as $table) {
+                    Storage::disk('seeds')->delete($table . ".json");
+                }
+            }
+            return 0;
+
+        // restores backups
+        } else if ($options['restore']) {
+            if (in_array(config('app.env'), ['testing', 'production']) === true) {
+                printf("This command cannot run on environment %s\r\n", config('app.env'));
+                return 1;
+            } else {
+                $seeder_classes = config('backup.filament_seeders.classes');
+
+                // run through all the seeder classes
+                // else provide a choice of which to restore
+                if ($options['all']) {
+                    foreach($seeder_classes as $seeder_class) {
+                        printf("Running seeder %s\r\n", $seeder_class);
+                        $this->call('db:seed', ['--class' => $seeder_class]);
+                    }
+                } else {
+                    $seeder_classes = $this->choice(
+                        'Which class would you like to restore?',
+                        $seeder_classes,
+                        $defaultIndex = 1,
+                        $maxAttempts = null,
+                        $allowMultipleSelections = true
+                    );
+                    foreach($seeder_classes as $seeder_class) {
+                        printf("Running seeder %s\r\n", $seeder_class);
+                        $this->call('db:seed', ['--class' => $seeder_class]);
+                    }
+                }
+                return 0;
             }
 
+        // default --all is to backup all tables
+        } else if ($options['all']) {
+            foreach($available_tables as $table) {
+                printf("Backing up table seeder %s\r\n", $table);
+                Storage::disk('seeds')->put($table . ".json", DB::table($table)->get()->toJson());
+            }
             return 0;
-        } elseif (isset($options['table']) && in_array($options['table'], $available_tables)) {
-            Storage::disk('seeds')->put($options['table'] . ".json", DB::table($options['table'])->get()->toJson());
 
-            return 0;
+        // if table is set the default will be to backup the table
+        } elseif (isset($options['table'])) {
+            if (in_array($options['table'], $available_tables)) {
+                printf("Backing up table seeder %s\r\n", $options['table']);
+                Storage::disk('seeds')->put($options['table'] . ".json", DB::table($options['table'])->get()->toJson());
+                return 0;
+            } else {
+                printf("You have might have misspelled the tablename.\r\nAvailable tables: %s\r\n", implode(', ', $available_tables));
+                return 1;
+            }
         } else {
-
-            printf("Must use option --all or --table=. See --help for more details.\r\n");
+            printf("Must use at least one option.\r\nTry php artisan help db:seed:backup\r\n");
             return 1;
         }
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,14 +24,14 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('db:refresh') // use custom command to make sure that the commands are chained
+        $schedule->command('db:refresh --backup') // use custom command to make sure that the commands are chained
             ->daily() // Run daily at midnight
             ->environments(['staging', 'dev', 'local']) // only run for APP_ENV tagged staging, dev, or local
             ->onOneServer(); // run only on a single server at once
 
-        $schedule->command('notifications:remove:old 30') // remove notifications older than 30 days old and read
-        ->daily() // Run daily at midnight
-        ->onOneServer(); // run only on a single server at once
+        $schedule->command('notifications:remove:old --days=30') // remove notifications older than 30 days old and read
+            ->daily() // Run daily at midnight
+            ->onOneServer(); // run only on a single server at once
     }
 
     /**

--- a/config/backup.php
+++ b/config/backup.php
@@ -248,4 +248,21 @@ return [
         ],
     ],
 
+    'filament_seeders' => [
+        'tables' => [
+            'identities',
+            'interpretations',
+            'resource_collections',
+            'resources',
+            'topics',
+        ],
+        'classes' => [
+            'IdentitySeeder',
+            'InterpretationSeeder',
+            'ResourceCollectionSeeder',
+            'ResourceSeeder',
+            'TopicSeeder',
+        ]
+    ],
+
 ];

--- a/config/backup.php
+++ b/config/backup.php
@@ -263,6 +263,12 @@ return [
             // 'ResourceCollectionSeeder',
             // 'ResourceSeeder',
             'TopicSeeder',
+        ],
+        'environments' => [
+            'production',
+            'staging',
+            'local',
+            'dev',
         ]
     ],
 

--- a/config/backup.php
+++ b/config/backup.php
@@ -248,19 +248,20 @@ return [
         ],
     ],
 
+    // TODO remove resources until we write in handling of attachments to other tables
     'filament_seeders' => [
         'tables' => [
             'identities',
             'interpretations',
-            'resource_collections',
-            'resources',
+            // 'resource_collections',
+            // 'resources',
             'topics',
         ],
         'classes' => [
             'IdentitySeeder',
             'InterpretationSeeder',
-            'ResourceCollectionSeeder',
-            'ResourceSeeder',
+            // 'ResourceCollectionSeeder',
+            // 'ResourceSeeder',
             'TopicSeeder',
         ]
     ],

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -35,6 +35,11 @@ return [
             'root' => storage_path('app'),
         ],
 
+        'seeds' => [
+            'driver' => 'local',
+            'root' => storage_path('app/seeds'),
+        ],
+
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),

--- a/database/seeders/DevSeeder.php
+++ b/database/seeders/DevSeeder.php
@@ -21,6 +21,7 @@ class DevSeeder extends Seeder
             DatabaseSeeder::class,
             ResourceCollectionSeeder::class,
             ResourceSeeder::class,
+            InterpretationSeeder::class,
         ]);
 
         $user = User::factory()

--- a/database/seeders/IdentitySeeder.php
+++ b/database/seeders/IdentitySeeder.php
@@ -6,233 +6,246 @@ use App\Models\Identity;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Storage;
 
-class IdentitySeeder extends Seeder
-{
-    public function run()
-    {
-        // check if there is a JSON file that has stored data for the seeder
-        if (in_array(config('app.env'), ['testing', 'production']) !== true && Storage::disk('seeds')->exists('identities.json')) {
-            $identities = json_decode(Storage::disk('seeds')->get('identities.json'), true);
+class IdentitySeeder extends Seeder {
+    public function run() {
 
-            foreach ($identities as $identity) {
-                Identity::firstOrCreate([
-                    'name' => json_decode($identity['name'], true),
-                    'description' => json_decode($identity['description'], true),
-                    'clusters' => json_decode($identity['clusters'], true),
-                ]);
+        // option to use environment to restore or backup to different environment files
+        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), ['production', 'staging', 'local']) === true) {
+            $environment = config('seeder.environment');
+        } else {
+            $environment = config('app.env');
+        }
+
+        // check if there is a JSON file that has stored data for the seeder
+        if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+            if (Storage::disk('seeds')->exists(sprintf("identities.%s.json", $environment))) {
+
+                $identities = json_decode(Storage::disk('seeds')->get(sprintf("identities.%s.json", $environment)), true);
+
+                foreach ($identities as $identity) {
+                    Identity::firstOrCreate([
+                        'name' => json_decode($identity['name'], true),
+                        'description' => json_decode($identity['description'], true),
+                        'clusters' => json_decode($identity['clusters'], true),
+                    ]);
+                }
+            } else {
+                print("Seeder file wasn't found, using default values\r\n");
+                $identities = [
+                    [
+                        'name' => __('Children (under 15)'),
+                        'clusters' => ['age'],
+                    ],
+                    [
+                        'name' => __('Youth (15–30)'),
+                        'clusters' => ['age'],
+                    ],
+                    [
+                        'name' => __('Working age adults (15–64)'),
+                        'clusters' => ['age'],
+                    ],
+                    [
+                        'name' => __('Older people (65+)'),
+                        'clusters' => ['age'],
+                    ],
+                    [
+                        'name' => __('Urban areas'),
+                        'clusters' => ['area'],
+                    ],
+                    [
+                        'name' => __('Rural areas'),
+                        'clusters' => ['area'],
+                    ],
+                    [
+                        'name' => __('Remote areas'),
+                        'clusters' => ['area'],
+                    ],
+                    [
+                        'name' => __('Refugees'),
+                        'clusters' => ['status'],
+                    ],
+                    [
+                        'name' => __('Immigrants'),
+                        'clusters' => ['status'],
+                    ],
+                    [
+                        'name' => __('Single parents and/or guardians'),
+                        'clusters' => ['family'],
+                    ],
+                    [
+                        'name' => __('Trans people'),
+                        'clusters' => ['gender-and-sexuality'],
+                    ],
+                    [
+                        'name' => __('2SLGBTQIA+ people'),
+                        'clusters' => ['gender-and-sexuality'],
+                    ],
+                    [
+                        'name' => __('Visual disabilities'),
+                        'description' => __('Includes individuals with sight loss, blind individuals, and partially sighted individuals'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Deaf'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Hard-of-hearing'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Physical and mobility disabilities'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Pain-related disabilities'),
+                        'description' => __('Such as chronic fatigue syndrome'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Communication disabilities'),
+                        'description' => __('Includes individuals with no spoken or signed language who communicate using gestures, pictures, letter boards, communication devices or assistance from a person who knows them well'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Neurodivergence'),
+                        'description' => __('Such as Autism, ADHD'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Developmental disabilities'),
+                        'description' => __('Includes intellectual disability'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Learning disabilities'),
+                        'description' => __('Such as dyslexia'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Cognitive disabilities'),
+                        'description' => __('Includes traumatic brain injury, memory difficulties, dementia'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Mental health-related disabilities'),
+                        'description' => __('Such as dual diagnosis of a mental health barrier, substance dependence'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Multiple disabilities'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Episodic and invisible disabilities'),
+                        'description' => __('Such as environmental, HIV, migraine'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('DeafBlind'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Body differences'),
+                        'description' => __('Includes size, limb, and facial differences'),
+                        'clusters' => ['disability-and-deaf'],
+                    ],
+                    [
+                        'name' => __('Temporary disabilities'),
+                        'description' => __('Such as broken limbs, gestational diabetes'),
+                        'clusters' => ['disability-and-deaf', 'reachable-when-mixed'],
+                    ],
+                    [
+                        'name' => __('White'),
+                        'clusters' => ['ethnoracial', 'reachable-when-mixed'],
+                    ],
+                    [
+                        'name' => __('Black'),
+                        'clusters' => ['ethnoracial'],
+                    ],
+                    [
+                        'name' => __('East Asian'),
+                        'clusters' => ['ethnoracial'],
+                    ],
+                    [
+                        'name' => __('Asian'),
+                        'clusters' => ['ethnoracial'],
+                    ],
+                    [
+                        'name' => __('South Asian'),
+                        'clusters' => ['ethnoracial'],
+                    ],
+                    [
+                        'name' => __('Southeast Asian'),
+                        'clusters' => ['ethnoracial'],
+                    ],
+                    [
+                        'name' => __('Middle Eastern'),
+                        'clusters' => ['ethnoracial'],
+                    ],
+                    [
+                        'name' => __('Latin American'),
+                        'clusters' => ['ethnoracial'],
+                    ],
+                    [
+                        'name' => __('African'),
+                        'clusters' => ['ethnoracial'],
+                    ],
+                    [
+                        'name' => __('Women'),
+                        'clusters' => ['gender', 'gender-and-sexuality'],
+                    ],
+                    [
+                        'name' => __('Men'),
+                        'clusters' => ['gender', 'gender-and-sexuality', 'reachable-when-mixed'],
+                    ],
+                    [
+                        'name' => __('Non-binary people'),
+                        'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
+                    ],
+                    [
+                        'name' => __('Gender non-conforming people'),
+                        'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
+                    ],
+                    [
+                        'name' => __('Gender fluid people'),
+                        'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
+                    ],
+                    [
+                        'name' => __('First Nations'),
+                        'clusters' => ['indigenous'],
+                    ],
+                    [
+                        'name' => __('Inuit'),
+                        'clusters' => ['indigenous'],
+                    ],
+                    [
+                        'name' => __('Métis'),
+                        'clusters' => ['indigenous'],
+                    ],
+                    [
+                        'name' => __('Supporters'),
+                        'clusters' => ['lived-experience', 'reachable-when-mixed'],
+                    ],
+                ];
+
+                foreach ($identities as $identity) {
+                    Identity::firstOrCreate([
+                        'name' => [
+                            'en' => $identity['name'],
+                            'fr' => trans($identity['name'], [], 'fr'),
+                        ],
+                        'description' => [
+                            'en' => $identity['description'] ?? null,
+                            'fr' => isset($identity['description']) ? trans($identity['description'], [], 'fr') : null,
+                        ],
+                        'clusters' => $identity['clusters'] ?? [],
+                    ]);
+                }
             }
         } else {
-            $identities = [
-                [
-                    'name' => __('Children (under 15)'),
-                    'clusters' => ['age'],
-                ],
-                [
-                    'name' => __('Youth (15–30)'),
-                    'clusters' => ['age'],
-                ],
-                [
-                    'name' => __('Working age adults (15–64)'),
-                    'clusters' => ['age'],
-                ],
-                [
-                    'name' => __('Older people (65+)'),
-                    'clusters' => ['age'],
-                ],
-                [
-                    'name' => __('Urban areas'),
-                    'clusters' => ['area'],
-                ],
-                [
-                    'name' => __('Rural areas'),
-                    'clusters' => ['area'],
-                ],
-                [
-                    'name' => __('Remote areas'),
-                    'clusters' => ['area'],
-                ],
-                [
-                    'name' => __('Refugees'),
-                    'clusters' => ['status'],
-                ],
-                [
-                    'name' => __('Immigrants'),
-                    'clusters' => ['status'],
-                ],
-                [
-                    'name' => __('Single parents and/or guardians'),
-                    'clusters' => ['family'],
-                ],
-                [
-                    'name' => __('Trans people'),
-                    'clusters' => ['gender-and-sexuality'],
-                ],
-                [
-                    'name' => __('2SLGBTQIA+ people'),
-                    'clusters' => ['gender-and-sexuality'],
-                ],
-                [
-                    'name' => __('Visual disabilities'),
-                    'description' => __('Includes individuals with sight loss, blind individuals, and partially sighted individuals'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Deaf'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Hard-of-hearing'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Physical and mobility disabilities'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Pain-related disabilities'),
-                    'description' => __('Such as chronic fatigue syndrome'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Communication disabilities'),
-                    'description' => __('Includes individuals with no spoken or signed language who communicate using gestures, pictures, letter boards, communication devices or assistance from a person who knows them well'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Neurodivergence'),
-                    'description' => __('Such as Autism, ADHD'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Developmental disabilities'),
-                    'description' => __('Includes intellectual disability'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Learning disabilities'),
-                    'description' => __('Such as dyslexia'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Cognitive disabilities'),
-                    'description' => __('Includes traumatic brain injury, memory difficulties, dementia'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Mental health-related disabilities'),
-                    'description' => __('Such as dual diagnosis of a mental health barrier, substance dependence'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Multiple disabilities'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Episodic and invisible disabilities'),
-                    'description' => __('Such as environmental, HIV, migraine'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('DeafBlind'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Body differences'),
-                    'description' => __('Includes size, limb, and facial differences'),
-                    'clusters' => ['disability-and-deaf'],
-                ],
-                [
-                    'name' => __('Temporary disabilities'),
-                    'description' => __('Such as broken limbs, gestational diabetes'),
-                    'clusters' => ['disability-and-deaf', 'reachable-when-mixed'],
-                ],
-                [
-                    'name' => __('White'),
-                    'clusters' => ['ethnoracial', 'reachable-when-mixed'],
-                ],
-                [
-                    'name' => __('Black'),
-                    'clusters' => ['ethnoracial'],
-                ],
-                [
-                    'name' => __('East Asian'),
-                    'clusters' => ['ethnoracial'],
-                ],
-                [
-                    'name' => __('Asian'),
-                    'clusters' => ['ethnoracial'],
-                ],
-                [
-                    'name' => __('South Asian'),
-                    'clusters' => ['ethnoracial'],
-                ],
-                [
-                    'name' => __('Southeast Asian'),
-                    'clusters' => ['ethnoracial'],
-                ],
-                [
-                    'name' => __('Middle Eastern'),
-                    'clusters' => ['ethnoracial'],
-                ],
-                [
-                    'name' => __('Latin American'),
-                    'clusters' => ['ethnoracial'],
-                ],
-                [
-                    'name' => __('African'),
-                    'clusters' => ['ethnoracial'],
-                ],
-                [
-                    'name' => __('Women'),
-                    'clusters' => ['gender', 'gender-and-sexuality'],
-                ],
-                [
-                    'name' => __('Men'),
-                    'clusters' => ['gender', 'gender-and-sexuality', 'reachable-when-mixed'],
-                ],
-                [
-                    'name' => __('Non-binary people'),
-                    'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
-                ],
-                [
-                    'name' => __('Gender non-conforming people'),
-                    'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
-                ],
-                [
-                    'name' => __('Gender fluid people'),
-                    'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
-                ],
-                [
-                    'name' => __('First Nations'),
-                    'clusters' => ['indigenous'],
-                ],
-                [
-                    'name' => __('Inuit'),
-                    'clusters' => ['indigenous'],
-                ],
-                [
-                    'name' => __('Métis'),
-                    'clusters' => ['indigenous'],
-                ],
-                [
-                    'name' => __('Supporters'),
-                    'clusters' => ['lived-experience', 'reachable-when-mixed'],
-                ],
-            ];
-
-            foreach ($identities as $identity) {
-                Identity::firstOrCreate([
-                    'name' => [
-                        'en' => $identity['name'],
-                        'fr' => trans($identity['name'], [], 'fr'),
-                    ],
-                    'description' => [
-                        'en' => $identity['description'] ?? null,
-                        'fr' => isset($identity['description']) ? trans($identity['description'], [], 'fr') : null,
-                    ],
-                    'clusters' => $identity['clusters'] ?? [],
-                ]);
-            }
+            $environment = config('app.env');
+            printf("Seeder cannot be run on environment: %s\r\n", $environment);
         }
     }
 }

--- a/database/seeders/IdentitySeeder.php
+++ b/database/seeders/IdentitySeeder.php
@@ -11,14 +11,13 @@ class IdentitySeeder extends Seeder {
     public function run() {
 
         // option to use environment to restore or backup to different environment files
-        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), ['production', 'staging', 'local']) === true) {
+        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), config('backup.filament_seeders.environments')) === true) {
             $environment = config('seeder.environment');
         } else {
             $environment = config('app.env');
         }
 
-        // check if there is a JSON file that has stored data for the seeder
-        if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+        if (Storage::disk('seeds')->exists(sprintf("identities.%s.json", $environment))) {
 
             // if trucate was set via seeder restore command then truncate the table prior to seeding data
             if (config('seeder.truncate')) {
@@ -27,234 +26,228 @@ class IdentitySeeder extends Seeder {
                 DB::statement("SET foreign_key_checks=1");
             }
 
-            if (Storage::disk('seeds')->exists(sprintf("identities.%s.json", $environment))) {
+            $identities = json_decode(Storage::disk('seeds')->get(sprintf("identities.%s.json", $environment)), true);
 
-                $identities = json_decode(Storage::disk('seeds')->get(sprintf("identities.%s.json", $environment)), true);
-
-                foreach ($identities as $identity) {
-                    Identity::firstOrCreate([
-                        'name' => json_decode($identity['name'], true),
-                        'description' => json_decode($identity['description'], true),
-                        'clusters' => json_decode($identity['clusters'], true),
-                    ]);
-                }
-            } else {
-                print("Seeder file wasn't found, using default values\r\n");
-                $identities = [
-                    [
-                        'name' => __('Children (under 15)'),
-                        'clusters' => ['age'],
-                    ],
-                    [
-                        'name' => __('Youth (15–30)'),
-                        'clusters' => ['age'],
-                    ],
-                    [
-                        'name' => __('Working age adults (15–64)'),
-                        'clusters' => ['age'],
-                    ],
-                    [
-                        'name' => __('Older people (65+)'),
-                        'clusters' => ['age'],
-                    ],
-                    [
-                        'name' => __('Urban areas'),
-                        'clusters' => ['area'],
-                    ],
-                    [
-                        'name' => __('Rural areas'),
-                        'clusters' => ['area'],
-                    ],
-                    [
-                        'name' => __('Remote areas'),
-                        'clusters' => ['area'],
-                    ],
-                    [
-                        'name' => __('Refugees'),
-                        'clusters' => ['status'],
-                    ],
-                    [
-                        'name' => __('Immigrants'),
-                        'clusters' => ['status'],
-                    ],
-                    [
-                        'name' => __('Single parents and/or guardians'),
-                        'clusters' => ['family'],
-                    ],
-                    [
-                        'name' => __('Trans people'),
-                        'clusters' => ['gender-and-sexuality'],
-                    ],
-                    [
-                        'name' => __('2SLGBTQIA+ people'),
-                        'clusters' => ['gender-and-sexuality'],
-                    ],
-                    [
-                        'name' => __('Visual disabilities'),
-                        'description' => __('Includes individuals with sight loss, blind individuals, and partially sighted individuals'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Deaf'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Hard-of-hearing'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Physical and mobility disabilities'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Pain-related disabilities'),
-                        'description' => __('Such as chronic fatigue syndrome'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Communication disabilities'),
-                        'description' => __('Includes individuals with no spoken or signed language who communicate using gestures, pictures, letter boards, communication devices or assistance from a person who knows them well'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Neurodivergence'),
-                        'description' => __('Such as Autism, ADHD'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Developmental disabilities'),
-                        'description' => __('Includes intellectual disability'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Learning disabilities'),
-                        'description' => __('Such as dyslexia'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Cognitive disabilities'),
-                        'description' => __('Includes traumatic brain injury, memory difficulties, dementia'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Mental health-related disabilities'),
-                        'description' => __('Such as dual diagnosis of a mental health barrier, substance dependence'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Multiple disabilities'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Episodic and invisible disabilities'),
-                        'description' => __('Such as environmental, HIV, migraine'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('DeafBlind'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Body differences'),
-                        'description' => __('Includes size, limb, and facial differences'),
-                        'clusters' => ['disability-and-deaf'],
-                    ],
-                    [
-                        'name' => __('Temporary disabilities'),
-                        'description' => __('Such as broken limbs, gestational diabetes'),
-                        'clusters' => ['disability-and-deaf', 'reachable-when-mixed'],
-                    ],
-                    [
-                        'name' => __('White'),
-                        'clusters' => ['ethnoracial', 'reachable-when-mixed'],
-                    ],
-                    [
-                        'name' => __('Black'),
-                        'clusters' => ['ethnoracial'],
-                    ],
-                    [
-                        'name' => __('East Asian'),
-                        'clusters' => ['ethnoracial'],
-                    ],
-                    [
-                        'name' => __('Asian'),
-                        'clusters' => ['ethnoracial'],
-                    ],
-                    [
-                        'name' => __('South Asian'),
-                        'clusters' => ['ethnoracial'],
-                    ],
-                    [
-                        'name' => __('Southeast Asian'),
-                        'clusters' => ['ethnoracial'],
-                    ],
-                    [
-                        'name' => __('Middle Eastern'),
-                        'clusters' => ['ethnoracial'],
-                    ],
-                    [
-                        'name' => __('Latin American'),
-                        'clusters' => ['ethnoracial'],
-                    ],
-                    [
-                        'name' => __('African'),
-                        'clusters' => ['ethnoracial'],
-                    ],
-                    [
-                        'name' => __('Women'),
-                        'clusters' => ['gender', 'gender-and-sexuality'],
-                    ],
-                    [
-                        'name' => __('Men'),
-                        'clusters' => ['gender', 'gender-and-sexuality', 'reachable-when-mixed'],
-                    ],
-                    [
-                        'name' => __('Non-binary people'),
-                        'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
-                    ],
-                    [
-                        'name' => __('Gender non-conforming people'),
-                        'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
-                    ],
-                    [
-                        'name' => __('Gender fluid people'),
-                        'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
-                    ],
-                    [
-                        'name' => __('First Nations'),
-                        'clusters' => ['indigenous'],
-                    ],
-                    [
-                        'name' => __('Inuit'),
-                        'clusters' => ['indigenous'],
-                    ],
-                    [
-                        'name' => __('Métis'),
-                        'clusters' => ['indigenous'],
-                    ],
-                    [
-                        'name' => __('Supporters'),
-                        'clusters' => ['lived-experience', 'reachable-when-mixed'],
-                    ],
-                ];
-
-                foreach ($identities as $identity) {
-                    Identity::firstOrCreate([
-                        'name' => [
-                            'en' => $identity['name'],
-                            'fr' => trans($identity['name'], [], 'fr'),
-                        ],
-                        'description' => [
-                            'en' => $identity['description'] ?? null,
-                            'fr' => isset($identity['description']) ? trans($identity['description'], [], 'fr') : null,
-                        ],
-                        'clusters' => $identity['clusters'] ?? [],
-                    ]);
-                }
+            foreach ($identities as $identity) {
+                Identity::firstOrCreate([
+                    'name' => json_decode($identity['name'], true),
+                    'description' => json_decode($identity['description'], true),
+                    'clusters' => json_decode($identity['clusters'], true),
+                ]);
             }
         } else {
-            $environment = config('app.env');
-            printf("Seeder cannot be run on environment: %s\r\n", $environment);
+            print("Seeder file wasn't found, using default values\r\n");
+            $identities = [
+                [
+                    'name' => __('Children (under 15)'),
+                    'clusters' => ['age'],
+                ],
+                [
+                    'name' => __('Youth (15–30)'),
+                    'clusters' => ['age'],
+                ],
+                [
+                    'name' => __('Working age adults (15–64)'),
+                    'clusters' => ['age'],
+                ],
+                [
+                    'name' => __('Older people (65+)'),
+                    'clusters' => ['age'],
+                ],
+                [
+                    'name' => __('Urban areas'),
+                    'clusters' => ['area'],
+                ],
+                [
+                    'name' => __('Rural areas'),
+                    'clusters' => ['area'],
+                ],
+                [
+                    'name' => __('Remote areas'),
+                    'clusters' => ['area'],
+                ],
+                [
+                    'name' => __('Refugees'),
+                    'clusters' => ['status'],
+                ],
+                [
+                    'name' => __('Immigrants'),
+                    'clusters' => ['status'],
+                ],
+                [
+                    'name' => __('Single parents and/or guardians'),
+                    'clusters' => ['family'],
+                ],
+                [
+                    'name' => __('Trans people'),
+                    'clusters' => ['gender-and-sexuality'],
+                ],
+                [
+                    'name' => __('2SLGBTQIA+ people'),
+                    'clusters' => ['gender-and-sexuality'],
+                ],
+                [
+                    'name' => __('Visual disabilities'),
+                    'description' => __('Includes individuals with sight loss, blind individuals, and partially sighted individuals'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Deaf'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Hard-of-hearing'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Physical and mobility disabilities'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Pain-related disabilities'),
+                    'description' => __('Such as chronic fatigue syndrome'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Communication disabilities'),
+                    'description' => __('Includes individuals with no spoken or signed language who communicate using gestures, pictures, letter boards, communication devices or assistance from a person who knows them well'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Neurodivergence'),
+                    'description' => __('Such as Autism, ADHD'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Developmental disabilities'),
+                    'description' => __('Includes intellectual disability'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Learning disabilities'),
+                    'description' => __('Such as dyslexia'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Cognitive disabilities'),
+                    'description' => __('Includes traumatic brain injury, memory difficulties, dementia'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Mental health-related disabilities'),
+                    'description' => __('Such as dual diagnosis of a mental health barrier, substance dependence'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Multiple disabilities'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Episodic and invisible disabilities'),
+                    'description' => __('Such as environmental, HIV, migraine'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('DeafBlind'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Body differences'),
+                    'description' => __('Includes size, limb, and facial differences'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Temporary disabilities'),
+                    'description' => __('Such as broken limbs, gestational diabetes'),
+                    'clusters' => ['disability-and-deaf', 'reachable-when-mixed'],
+                ],
+                [
+                    'name' => __('White'),
+                    'clusters' => ['ethnoracial', 'reachable-when-mixed'],
+                ],
+                [
+                    'name' => __('Black'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('East Asian'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('Asian'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('South Asian'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('Southeast Asian'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('Middle Eastern'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('Latin American'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('African'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('Women'),
+                    'clusters' => ['gender', 'gender-and-sexuality'],
+                ],
+                [
+                    'name' => __('Men'),
+                    'clusters' => ['gender', 'gender-and-sexuality', 'reachable-when-mixed'],
+                ],
+                [
+                    'name' => __('Non-binary people'),
+                    'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
+                ],
+                [
+                    'name' => __('Gender non-conforming people'),
+                    'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
+                ],
+                [
+                    'name' => __('Gender fluid people'),
+                    'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
+                ],
+                [
+                    'name' => __('First Nations'),
+                    'clusters' => ['indigenous'],
+                ],
+                [
+                    'name' => __('Inuit'),
+                    'clusters' => ['indigenous'],
+                ],
+                [
+                    'name' => __('Métis'),
+                    'clusters' => ['indigenous'],
+                ],
+                [
+                    'name' => __('Supporters'),
+                    'clusters' => ['lived-experience', 'reachable-when-mixed'],
+                ],
+            ];
+
+            foreach ($identities as $identity) {
+                Identity::firstOrCreate([
+                    'name' => [
+                        'en' => $identity['name'],
+                        'fr' => trans($identity['name'], [], 'fr'),
+                    ],
+                    'description' => [
+                        'en' => $identity['description'] ?? null,
+                        'fr' => isset($identity['description']) ? trans($identity['description'], [], 'fr') : null,
+                    ],
+                    'clusters' => $identity['clusters'] ?? [],
+                ]);
+            }
         }
     }
 }

--- a/database/seeders/IdentitySeeder.php
+++ b/database/seeders/IdentitySeeder.php
@@ -4,221 +4,235 @@ namespace Database\Seeders;
 
 use App\Models\Identity;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Storage;
 
 class IdentitySeeder extends Seeder
 {
     public function run()
     {
-        $identities = [
-            [
-                'name' => __('Children (under 15)'),
-                'clusters' => ['age'],
-            ],
-            [
-                'name' => __('Youth (15–30)'),
-                'clusters' => ['age'],
-            ],
-            [
-                'name' => __('Working age adults (15–64)'),
-                'clusters' => ['age'],
-            ],
-            [
-                'name' => __('Older people (65+)'),
-                'clusters' => ['age'],
-            ],
-            [
-                'name' => __('Urban areas'),
-                'clusters' => ['area'],
-            ],
-            [
-                'name' => __('Rural areas'),
-                'clusters' => ['area'],
-            ],
-            [
-                'name' => __('Remote areas'),
-                'clusters' => ['area'],
-            ],
-            [
-                'name' => __('Refugees'),
-                'clusters' => ['status'],
-            ],
-            [
-                'name' => __('Immigrants'),
-                'clusters' => ['status'],
-            ],
-            [
-                'name' => __('Single parents and/or guardians'),
-                'clusters' => ['family'],
-            ],
-            [
-                'name' => __('Trans people'),
-                'clusters' => ['gender-and-sexuality'],
-            ],
-            [
-                'name' => __('2SLGBTQIA+ people'),
-                'clusters' => ['gender-and-sexuality'],
-            ],
-            [
-                'name' => __('Visual disabilities'),
-                'description' => __('Includes individuals with sight loss, blind individuals, and partially sighted individuals'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Deaf'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Hard-of-hearing'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Physical and mobility disabilities'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Pain-related disabilities'),
-                'description' => __('Such as chronic fatigue syndrome'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Communication disabilities'),
-                'description' => __('Includes individuals with no spoken or signed language who communicate using gestures, pictures, letter boards, communication devices or assistance from a person who knows them well'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Neurodivergence'),
-                'description' => __('Such as Autism, ADHD'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Developmental disabilities'),
-                'description' => __('Includes intellectual disability'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Learning disabilities'),
-                'description' => __('Such as dyslexia'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Cognitive disabilities'),
-                'description' => __('Includes traumatic brain injury, memory difficulties, dementia'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Mental health-related disabilities'),
-                'description' => __('Such as dual diagnosis of a mental health barrier, substance dependence'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Multiple disabilities'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Episodic and invisible disabilities'),
-                'description' => __('Such as environmental, HIV, migraine'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('DeafBlind'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Body differences'),
-                'description' => __('Includes size, limb, and facial differences'),
-                'clusters' => ['disability-and-deaf'],
-            ],
-            [
-                'name' => __('Temporary disabilities'),
-                'description' => __('Such as broken limbs, gestational diabetes'),
-                'clusters' => ['disability-and-deaf', 'reachable-when-mixed'],
-            ],
-            [
-                'name' => __('White'),
-                'clusters' => ['ethnoracial', 'reachable-when-mixed'],
-            ],
-            [
-                'name' => __('Black'),
-                'clusters' => ['ethnoracial'],
-            ],
-            [
-                'name' => __('East Asian'),
-                'clusters' => ['ethnoracial'],
-            ],
-            [
-                'name' => __('Asian'),
-                'clusters' => ['ethnoracial'],
-            ],
-            [
-                'name' => __('South Asian'),
-                'clusters' => ['ethnoracial'],
-            ],
-            [
-                'name' => __('Southeast Asian'),
-                'clusters' => ['ethnoracial'],
-            ],
-            [
-                'name' => __('Middle Eastern'),
-                'clusters' => ['ethnoracial'],
-            ],
-            [
-                'name' => __('Latin American'),
-                'clusters' => ['ethnoracial'],
-            ],
-            [
-                'name' => __('African'),
-                'clusters' => ['ethnoracial'],
-            ],
-            [
-                'name' => __('Women'),
-                'clusters' => ['gender', 'gender-and-sexuality'],
-            ],
-            [
-                'name' => __('Men'),
-                'clusters' => ['gender', 'gender-and-sexuality', 'reachable-when-mixed'],
-            ],
-            [
-                'name' => __('Non-binary people'),
-                'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
-            ],
-            [
-                'name' => __('Gender non-conforming people'),
-                'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
-            ],
-            [
-                'name' => __('Gender fluid people'),
-                'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
-            ],
-            [
-                'name' => __('First Nations'),
-                'clusters' => ['indigenous'],
-            ],
-            [
-                'name' => __('Inuit'),
-                'clusters' => ['indigenous'],
-            ],
-            [
-                'name' => __('Métis'),
-                'clusters' => ['indigenous'],
-            ],
-            [
-                'name' => __('Supporters'),
-                'clusters' => ['lived-experience', 'reachable-when-mixed'],
-            ],
-        ];
+        // check if there is a JSON file that has stored data for the seeder
+        if (Storage::disk('seeds')->exists('identities.json')) {
+            $identities = json_decode(Storage::disk('seeds')->get('identities.json'), true);
 
-        foreach ($identities as $identity) {
-            Identity::firstOrCreate([
-                'name' => [
-                    'en' => $identity['name'],
-                    'fr' => trans($identity['name'], [], 'fr'),
+            foreach ($identities as $identity) {
+                Identity::firstOrCreate([
+                    'name' => json_decode($identity['name'], true),
+                    'description' => json_decode($identity['description'], true),
+                    'clusters' => json_decode($identity['clusters'], true),
+                ]);
+            }
+        } else {
+            $identities = [
+                [
+                    'name' => __('Children (under 15)'),
+                    'clusters' => ['age'],
                 ],
-                'description' => [
-                    'en' => $identity['description'] ?? null,
-                    'fr' => isset($identity['description']) ? trans($identity['description'], [], 'fr') : null,
+                [
+                    'name' => __('Youth (15–30)'),
+                    'clusters' => ['age'],
                 ],
-                'clusters' => $identity['clusters'] ?? [],
-            ]);
+                [
+                    'name' => __('Working age adults (15–64)'),
+                    'clusters' => ['age'],
+                ],
+                [
+                    'name' => __('Older people (65+)'),
+                    'clusters' => ['age'],
+                ],
+                [
+                    'name' => __('Urban areas'),
+                    'clusters' => ['area'],
+                ],
+                [
+                    'name' => __('Rural areas'),
+                    'clusters' => ['area'],
+                ],
+                [
+                    'name' => __('Remote areas'),
+                    'clusters' => ['area'],
+                ],
+                [
+                    'name' => __('Refugees'),
+                    'clusters' => ['status'],
+                ],
+                [
+                    'name' => __('Immigrants'),
+                    'clusters' => ['status'],
+                ],
+                [
+                    'name' => __('Single parents and/or guardians'),
+                    'clusters' => ['family'],
+                ],
+                [
+                    'name' => __('Trans people'),
+                    'clusters' => ['gender-and-sexuality'],
+                ],
+                [
+                    'name' => __('2SLGBTQIA+ people'),
+                    'clusters' => ['gender-and-sexuality'],
+                ],
+                [
+                    'name' => __('Visual disabilities'),
+                    'description' => __('Includes individuals with sight loss, blind individuals, and partially sighted individuals'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Deaf'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Hard-of-hearing'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Physical and mobility disabilities'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Pain-related disabilities'),
+                    'description' => __('Such as chronic fatigue syndrome'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Communication disabilities'),
+                    'description' => __('Includes individuals with no spoken or signed language who communicate using gestures, pictures, letter boards, communication devices or assistance from a person who knows them well'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Neurodivergence'),
+                    'description' => __('Such as Autism, ADHD'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Developmental disabilities'),
+                    'description' => __('Includes intellectual disability'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Learning disabilities'),
+                    'description' => __('Such as dyslexia'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Cognitive disabilities'),
+                    'description' => __('Includes traumatic brain injury, memory difficulties, dementia'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Mental health-related disabilities'),
+                    'description' => __('Such as dual diagnosis of a mental health barrier, substance dependence'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Multiple disabilities'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Episodic and invisible disabilities'),
+                    'description' => __('Such as environmental, HIV, migraine'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('DeafBlind'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Body differences'),
+                    'description' => __('Includes size, limb, and facial differences'),
+                    'clusters' => ['disability-and-deaf'],
+                ],
+                [
+                    'name' => __('Temporary disabilities'),
+                    'description' => __('Such as broken limbs, gestational diabetes'),
+                    'clusters' => ['disability-and-deaf', 'reachable-when-mixed'],
+                ],
+                [
+                    'name' => __('White'),
+                    'clusters' => ['ethnoracial', 'reachable-when-mixed'],
+                ],
+                [
+                    'name' => __('Black'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('East Asian'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('Asian'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('South Asian'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('Southeast Asian'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('Middle Eastern'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('Latin American'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('African'),
+                    'clusters' => ['ethnoracial'],
+                ],
+                [
+                    'name' => __('Women'),
+                    'clusters' => ['gender', 'gender-and-sexuality'],
+                ],
+                [
+                    'name' => __('Men'),
+                    'clusters' => ['gender', 'gender-and-sexuality', 'reachable-when-mixed'],
+                ],
+                [
+                    'name' => __('Non-binary people'),
+                    'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
+                ],
+                [
+                    'name' => __('Gender non-conforming people'),
+                    'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
+                ],
+                [
+                    'name' => __('Gender fluid people'),
+                    'clusters' => ['gender', 'gender-and-sexuality', 'gender-diverse'],
+                ],
+                [
+                    'name' => __('First Nations'),
+                    'clusters' => ['indigenous'],
+                ],
+                [
+                    'name' => __('Inuit'),
+                    'clusters' => ['indigenous'],
+                ],
+                [
+                    'name' => __('Métis'),
+                    'clusters' => ['indigenous'],
+                ],
+                [
+                    'name' => __('Supporters'),
+                    'clusters' => ['lived-experience', 'reachable-when-mixed'],
+                ],
+            ];
+
+            foreach ($identities as $identity) {
+                Identity::firstOrCreate([
+                    'name' => [
+                        'en' => $identity['name'],
+                        'fr' => trans($identity['name'], [], 'fr'),
+                    ],
+                    'description' => [
+                        'en' => $identity['description'] ?? null,
+                        'fr' => isset($identity['description']) ? trans($identity['description'], [], 'fr') : null,
+                    ],
+                    'clusters' => $identity['clusters'] ?? [],
+                ]);
+            }
         }
     }
 }

--- a/database/seeders/IdentitySeeder.php
+++ b/database/seeders/IdentitySeeder.php
@@ -11,7 +11,7 @@ class IdentitySeeder extends Seeder
     public function run()
     {
         // check if there is a JSON file that has stored data for the seeder
-        if (Storage::disk('seeds')->exists('identities.json')) {
+        if (in_array(config('app.env'), ['testing', 'production']) !== true && Storage::disk('seeds')->exists('identities.json')) {
             $identities = json_decode(Storage::disk('seeds')->get('identities.json'), true);
 
             foreach ($identities as $identity) {

--- a/database/seeders/IdentitySeeder.php
+++ b/database/seeders/IdentitySeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Identity;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
 class IdentitySeeder extends Seeder {
@@ -18,6 +19,14 @@ class IdentitySeeder extends Seeder {
 
         // check if there is a JSON file that has stored data for the seeder
         if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+
+            // if trucate was set via seeder restore command then truncate the table prior to seeding data
+            if (config('seeder.truncate')) {
+                DB::statement("SET foreign_key_checks=0");
+                Identity::truncate();
+                DB::statement("SET foreign_key_checks=1");
+            }
+
             if (Storage::disk('seeds')->exists(sprintf("identities.%s.json", $environment))) {
 
                 $identities = json_decode(Storage::disk('seeds')->get(sprintf("identities.%s.json", $environment)), true);

--- a/database/seeders/InterpretationSeeder.php
+++ b/database/seeders/InterpretationSeeder.php
@@ -6,28 +6,43 @@ use App\Models\Interpretation;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Storage;
 
-class InterpretationSeeder extends Seeder
-{
+class InterpretationSeeder extends Seeder {
     /**
      * Run the database seeds.
      *
      * @return void
      */
-    public function run()
-    {
-        // check if there is a JSON file that has stored data for the seeder
-        if (in_array(config('app.env'), ['testing', 'production']) !== true && Storage::disk('seeds')->exists('interpretations.json')) {
-            $interpretations = json_decode(Storage::disk('seeds')->get('interpretations.json'), true);
+    public function run() {
 
-            foreach ($interpretations as $interpretation) {
-                Interpretation::firstOrCreate([
-                    'name' => $interpretation['name'],
-                    'namespace' => $interpretation['namespace'],
-                    'route' => $interpretation['route'],
-                    'route_has_params' => $interpretation['route_has_params'],
-                    'video' => json_decode($interpretation['video'], true),
-                ]);
+        // option to use environment to restore or backup to different environment files
+        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), ['production', 'staging', 'local']) === true) {
+            $environment = config('seeder.environment');
+        } else {
+            $environment = config('app.env');
+        }
+
+        // check if there is a JSON file that has stored data for the seeder
+        if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+
+            if (Storage::disk('seeds')->exists(sprintf("interpretations.%s.json", $environment))) {
+
+                $interpretations = json_decode(Storage::disk('seeds')->get(sprintf("interpretations.%s.json", $environment)), true);
+
+                foreach ($interpretations as $interpretation) {
+                    Interpretation::firstOrCreate([
+                        'name' => $interpretation['name'],
+                        'namespace' => $interpretation['namespace'],
+                        'route' => $interpretation['route'],
+                        'route_has_params' => $interpretation['route_has_params'],
+                        'video' => json_decode($interpretation['video'], true),
+                    ]);
+                }
+            } else {
+                printf("Seeder file not found interpretations.json.%s\r\n", $environment);
             }
+        } else {
+            $environment = config('app.env');
+            printf("Seeder cannot be run on environment: %s\r\n", $environment);
         }
     }
 }

--- a/database/seeders/InterpretationSeeder.php
+++ b/database/seeders/InterpretationSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Interpretation;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Storage;
+
+class InterpretationSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // check if there is a JSON file that has stored data for the seeder
+        if (Storage::disk('seeds')->exists('interpretations.json')) {
+            $interpretations = json_decode(Storage::disk('seeds')->get('interpretations.json'), true);
+
+            foreach ($interpretations as $interpretation) {
+                Interpretation::firstOrCreate([
+                    'name' => $interpretation['name'],
+                    'namespace' => $interpretation['namespace'],
+                    'route' => $interpretation['route'],
+                    'route_has_params' => $interpretation['route_has_params'],
+                    'video' => json_decode($interpretation['video'], true),
+                ]);
+            }
+        }
+    }
+}

--- a/database/seeders/InterpretationSeeder.php
+++ b/database/seeders/InterpretationSeeder.php
@@ -16,7 +16,7 @@ class InterpretationSeeder extends Seeder
     public function run()
     {
         // check if there is a JSON file that has stored data for the seeder
-        if (Storage::disk('seeds')->exists('interpretations.json')) {
+        if (in_array(config('app.env'), ['testing', 'production']) !== true && Storage::disk('seeds')->exists('interpretations.json')) {
             $interpretations = json_decode(Storage::disk('seeds')->get('interpretations.json'), true);
 
             foreach ($interpretations as $interpretation) {

--- a/database/seeders/InterpretationSeeder.php
+++ b/database/seeders/InterpretationSeeder.php
@@ -16,41 +16,35 @@ class InterpretationSeeder extends Seeder {
     public function run() {
 
         // option to use environment to restore or backup to different environment files
-        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), ['production', 'staging', 'local']) === true) {
+        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), config('backup.filament_seeders.environments')) === true) {
             $environment = config('seeder.environment');
         } else {
             $environment = config('app.env');
         }
 
-        // check if there is a JSON file that has stored data for the seeder
-        if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+        // if trucate was set via seeder restore command then truncate the table prior to seeding data
+        if (config('seeder.truncate')) {
+            DB::statement("SET foreign_key_checks=0");
+            Interpretation::truncate();
+            DB::statement("SET foreign_key_checks=1");
+        }
 
-            // if trucate was set via seeder restore command then truncate the table prior to seeding data
-            if (config('seeder.truncate')) {
-                DB::statement("SET foreign_key_checks=0");
-                Interpretation::truncate();
-                DB::statement("SET foreign_key_checks=1");
-            }
+        if (Storage::disk('seeds')->exists(sprintf("interpretations.%s.json", $environment))) {
 
-            if (Storage::disk('seeds')->exists(sprintf("interpretations.%s.json", $environment))) {
+            $interpretations = json_decode(Storage::disk('seeds')->get(sprintf("interpretations.%s.json", $environment)), true);
 
-                $interpretations = json_decode(Storage::disk('seeds')->get(sprintf("interpretations.%s.json", $environment)), true);
-
-                foreach ($interpretations as $interpretation) {
-                    Interpretation::firstOrCreate([
-                        'name' => $interpretation['name'],
-                        'namespace' => $interpretation['namespace'],
-                        'route' => $interpretation['route'],
-                        'route_has_params' => $interpretation['route_has_params'],
-                        'video' => json_decode($interpretation['video'], true),
-                    ]);
-                }
-            } else {
-                printf("Seeder file not found interpretations.json.%s\r\n", $environment);
+            foreach ($interpretations as $interpretation) {
+                Interpretation::firstOrCreate([
+                    'name' => $interpretation['name'],
+                    'namespace' => $interpretation['namespace'],
+                    'route' => $interpretation['route'],
+                    'route_has_params' => $interpretation['route_has_params'],
+                    'video' => json_decode($interpretation['video'], true),
+                ]);
             }
         } else {
             $environment = config('app.env');
-            printf("Seeder cannot be run on environment: %s\r\n", $environment);
+            printf("%s cannot be run on environment: %s\r\n", self::class, $environment);
         }
     }
 }

--- a/database/seeders/InterpretationSeeder.php
+++ b/database/seeders/InterpretationSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Interpretation;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
 class InterpretationSeeder extends Seeder {
@@ -23,6 +24,13 @@ class InterpretationSeeder extends Seeder {
 
         // check if there is a JSON file that has stored data for the seeder
         if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+
+            // if trucate was set via seeder restore command then truncate the table prior to seeding data
+            if (config('seeder.truncate')) {
+                DB::statement("SET foreign_key_checks=0");
+                Interpretation::truncate();
+                DB::statement("SET foreign_key_checks=1");
+            }
 
             if (Storage::disk('seeds')->exists(sprintf("interpretations.%s.json", $environment))) {
 

--- a/database/seeders/ProductionSeeder.php
+++ b/database/seeders/ProductionSeeder.php
@@ -22,6 +22,7 @@ class ProductionSeeder extends Seeder
             // Seed known resource collections and resources
             ResourceCollectionSeeder::class,
             ResourceSeeder::class,
+            InterpretationSeeder::class,
         ]);
     }
 }

--- a/database/seeders/ResourceCollectionSeeder.php
+++ b/database/seeders/ResourceCollectionSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\ResourceCollection;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Storage;
 
 class ResourceCollectionSeeder extends Seeder
 {
@@ -16,17 +17,30 @@ class ResourceCollectionSeeder extends Seeder
     {
         $faker = \Faker\Factory::create('en_CA');
 
-        $resourceCollections = [
-            [
-                'title' => 'The Accessible Canada Act',
-            ],
-        ];
+        // check if there is a JSON file that has stored data for the seeder
+        if (Storage::disk('seeds')->exists('resource_collections.json')) {
+            $resourceCollections = json_decode(Storage::disk('seeds')->get('resource_collections.json'), true);
 
-        foreach ($resourceCollections as $resourceCollection) {
-            ResourceCollection::firstOrCreate([
-                'title->en' => $resourceCollection['title'],
-                'description->en' => $resourceCollection['description'] ?? '',
-            ]);
+            foreach ($resourceCollections as $resourceCollection) {
+                ResourceCollection::firstOrCreate([
+                    'title' => json_decode($resourceCollection['title'], true),
+                    'slug' => json_decode($resourceCollection['slug'], true),
+                    'description' => json_decode($resourceCollection['description'], true),
+                ]);
+            }
+        } else {
+            $resourceCollections = [
+                [
+                    'title' => 'The Accessible Canada Act',
+                ],
+            ];
+
+            foreach ($resourceCollections as $resourceCollection) {
+                ResourceCollection::firstOrCreate([
+                    'title->en' => $resourceCollection['title'],
+                    'description->en' => $resourceCollection['description'] ?? '',
+                ]);
+            }
         }
     }
 }

--- a/database/seeders/ResourceCollectionSeeder.php
+++ b/database/seeders/ResourceCollectionSeeder.php
@@ -17,14 +17,14 @@ class ResourceCollectionSeeder extends Seeder {
         $faker = \Faker\Factory::create('en_CA');
 
         // option to use environment to restore or backup to different environment files
-        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), ['production', 'staging', 'local']) === true) {
+        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), config('backup.filament_seeders.environments')) === true) {
             $environment = config('seeder.environment');
         } else {
             $environment = config('app.env');
         }
 
-        // check if there is a JSON file that has stored data for the seeder
-        if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+        // TODO need to write handling of attachments
+        if (false && Storage::disk('seeds')->exists(sprintf("resource_collections.%s.json", $environment))) {
 
             // if trucate was set via seeder restore command then truncate the table prior to seeding data
             if (config('seeder.truncate')) {
@@ -32,36 +32,30 @@ class ResourceCollectionSeeder extends Seeder {
                 ResourceCollection::truncate();
                 DB::statement("SET foreign_key_checks=1");
             }
-            // TODO need to write handling of attachments
-            if (false && Storage::disk('seeds')->exists(sprintf("resource_collections.%s.json", $environment))) {
 
-                $resourceCollections = json_decode(Storage::disk('seeds')->get(sprintf("resource_collections.%s.json", $environment)), true);
+            $resourceCollections = json_decode(Storage::disk('seeds')->get(sprintf("resource_collections.%s.json", $environment)), true);
 
-                foreach ($resourceCollections as $resourceCollection) {
-                    ResourceCollection::firstOrCreate([
-                        'title' => json_decode($resourceCollection['title'], true),
-                        'slug' => json_decode($resourceCollection['slug'], true),
-                        'description' => json_decode($resourceCollection['description'], true),
-                    ]);
-                }
-            } else {
-                print("Seeder file wasn't found, using default values\r\n");
-                $resourceCollections = [
-                    [
-                        'title' => 'The Accessible Canada Act',
-                    ],
-                ];
-
-                foreach ($resourceCollections as $resourceCollection) {
-                    ResourceCollection::firstOrCreate([
-                        'title->en' => $resourceCollection['title'],
-                        'description->en' => $resourceCollection['description'] ?? '',
-                    ]);
-                }
+            foreach ($resourceCollections as $resourceCollection) {
+                ResourceCollection::firstOrCreate([
+                    'title' => json_decode($resourceCollection['title'], true),
+                    'slug' => json_decode($resourceCollection['slug'], true),
+                    'description' => json_decode($resourceCollection['description'], true),
+                ]);
             }
         } else {
-            $environment = config('app.env');
-            printf("Seeder cannot be run on environment: %s\r\n", $environment);
+            print("Seeder file wasn't found, using default values\r\n");
+            $resourceCollections = [
+                [
+                    'title' => 'The Accessible Canada Act',
+                ],
+            ];
+
+            foreach ($resourceCollections as $resourceCollection) {
+                ResourceCollection::firstOrCreate([
+                    'title->en' => $resourceCollection['title'],
+                    'description->en' => $resourceCollection['description'] ?? '',
+                ]);
+            }
         }
     }
 }

--- a/database/seeders/ResourceCollectionSeeder.php
+++ b/database/seeders/ResourceCollectionSeeder.php
@@ -6,41 +6,54 @@ use App\Models\ResourceCollection;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Storage;
 
-class ResourceCollectionSeeder extends Seeder
-{
+class ResourceCollectionSeeder extends Seeder {
     /**
      * Run the database seeds.
      *
      * @return void
      */
-    public function run()
-    {
+    public function run() {
         $faker = \Faker\Factory::create('en_CA');
 
-        // check if there is a JSON file that has stored data for the seeder
-        if (in_array(config('app.env'), ['testing', 'production']) !== true && Storage::disk('seeds')->exists('resource_collections.json')) {
-            $resourceCollections = json_decode(Storage::disk('seeds')->get('resource_collections.json'), true);
+        // option to use environment to restore or backup to different environment files
+        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), ['production', 'staging', 'local']) === true) {
+            $environment = config('seeder.environment');
+        } else {
+            $environment = config('app.env');
+        }
 
-            foreach ($resourceCollections as $resourceCollection) {
-                ResourceCollection::firstOrCreate([
-                    'title' => json_decode($resourceCollection['title'], true),
-                    'slug' => json_decode($resourceCollection['slug'], true),
-                    'description' => json_decode($resourceCollection['description'], true),
-                ]);
+        // check if there is a JSON file that has stored data for the seeder
+        if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+            // TODO need to write handling of attachments
+            if (false && Storage::disk('seeds')->exists(sprintf("resource_collections.%s.json", $environment))) {
+
+                $resourceCollections = json_decode(Storage::disk('seeds')->get(sprintf("resource_collections.%s.json", $environment)), true);
+
+                foreach ($resourceCollections as $resourceCollection) {
+                    ResourceCollection::firstOrCreate([
+                        'title' => json_decode($resourceCollection['title'], true),
+                        'slug' => json_decode($resourceCollection['slug'], true),
+                        'description' => json_decode($resourceCollection['description'], true),
+                    ]);
+                }
+            } else {
+                print("Seeder file wasn't found, using default values\r\n");
+                $resourceCollections = [
+                    [
+                        'title' => 'The Accessible Canada Act',
+                    ],
+                ];
+
+                foreach ($resourceCollections as $resourceCollection) {
+                    ResourceCollection::firstOrCreate([
+                        'title->en' => $resourceCollection['title'],
+                        'description->en' => $resourceCollection['description'] ?? '',
+                    ]);
+                }
             }
         } else {
-            $resourceCollections = [
-                [
-                    'title' => 'The Accessible Canada Act',
-                ],
-            ];
-
-            foreach ($resourceCollections as $resourceCollection) {
-                ResourceCollection::firstOrCreate([
-                    'title->en' => $resourceCollection['title'],
-                    'description->en' => $resourceCollection['description'] ?? '',
-                ]);
-            }
+            $environment = config('app.env');
+            printf("Seeder cannot be run on environment: %s\r\n", $environment);
         }
     }
 }

--- a/database/seeders/ResourceCollectionSeeder.php
+++ b/database/seeders/ResourceCollectionSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\ResourceCollection;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
 class ResourceCollectionSeeder extends Seeder {
@@ -24,6 +25,13 @@ class ResourceCollectionSeeder extends Seeder {
 
         // check if there is a JSON file that has stored data for the seeder
         if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+
+            // if trucate was set via seeder restore command then truncate the table prior to seeding data
+            if (config('seeder.truncate')) {
+                DB::statement("SET foreign_key_checks=0");
+                ResourceCollection::truncate();
+                DB::statement("SET foreign_key_checks=1");
+            }
             // TODO need to write handling of attachments
             if (false && Storage::disk('seeds')->exists(sprintf("resource_collections.%s.json", $environment))) {
 

--- a/database/seeders/ResourceCollectionSeeder.php
+++ b/database/seeders/ResourceCollectionSeeder.php
@@ -18,7 +18,7 @@ class ResourceCollectionSeeder extends Seeder
         $faker = \Faker\Factory::create('en_CA');
 
         // check if there is a JSON file that has stored data for the seeder
-        if (Storage::disk('seeds')->exists('resource_collections.json')) {
+        if (in_array(config('app.env'), ['testing', 'production']) !== true && Storage::disk('seeds')->exists('resource_collections.json')) {
             $resourceCollections = json_decode(Storage::disk('seeds')->get('resource_collections.json'), true);
 
             foreach ($resourceCollections as $resourceCollection) {

--- a/database/seeders/ResourceSeeder.php
+++ b/database/seeders/ResourceSeeder.php
@@ -11,105 +11,119 @@ use App\Models\Organization;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Storage;
 
-class ResourceSeeder extends Seeder
-{
+class ResourceSeeder extends Seeder {
     /**
      * Run the database seeds.
      *
      * @return void
      */
-    public function run()
-    {
+    public function run() {
+
+        // option to use environment to restore or backup to different environment files
+        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), ['production', 'staging', 'local']) === true) {
+            $environment = config('seeder.environment');
+        } else {
+            $environment = config('app.env');
+        }
 
         // check if there is a JSON file that has stored data for the seeder
-        if (in_array(config('app.env'), ['testing', 'production']) !== true && Storage::disk('seeds')->exists('resources.json')) {
-            $resources = json_decode(Storage::disk('seeds')->get('resources.json'), true);
+        if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+            // TODO need to write handling of attachments
+            if (false && Storage::disk('seeds')->exists(sprintf("resources.%s.json", $environment))) {
 
-            foreach ($resources as $resource) {
-                if ($resource['content_type_id']) {
-                    if (ContentType::where('id', $resource['content_type_id'])->doesntExist()) {
-                        printf("Skipping insert because content type with id %s is missing \r\n", $resource['content_type_id']);
-                        continue;
+                $resources = json_decode(Storage::disk('seeds')->get(sprintf("resources.%s.json", $environment)), true);
+
+
+                foreach ($resources as $resource) {
+                    if ($resource['content_type_id']) {
+                        if (ContentType::where('id', $resource['content_type_id'])->doesntExist()) {
+                            printf("Skipping insert because content type with id %s is missing \r\n", $resource['content_type_id']);
+                            continue;
+                        }
+                    }
+                    if ($resource['organization_id']) {
+                        if (Organization::where('id', $resource['organization_id'])->doesntExist()) {
+                            printf("Skipping insert because organization with id %s is missing \r\n", $resource['organization_id']);
+                            continue;
+                        }
+                    }
+                    $item = Resource::firstOrCreate([
+                        'title' => json_decode($resource['title'], true),
+                        'slug' => json_decode($resource['slug'], true),
+                        'summary' => json_decode($resource['summary'], true),
+                        'url' => json_decode($resource['url'], true),
+                        'formats' => json_decode($resource['formats'], true),
+                        'phases' => json_decode($resource['phases'], true),
+                        'author' => json_decode($resource['author'], true),
+                        'content_type_id' => $resource['content_type_id'],
+                        'organization_id' => $resource['organization_id'],
+                    ]);
+                }
+            } else {
+                print("Seeder file wasn't found, using default values\r\n");
+                $resources = [
+                    [
+                        'title' => ['en' => 'The Accessible Canada Act, Accessibility Regulations and Standards'],
+                        'author' => ['en' => 'ARCH Disability Law Centre'],
+                        'url' => [
+                            'en' => 'https://archdisabilitylaw.ca/the-accessible-canada-act-accessibility-regulations-and-standards/',
+                            'asl' => 'https://www.youtube.com/watch?v=CE8OFr9jdXw',
+                            'fr' => 'https://archdisabilitylaw.ca/fr/la-loi-canadienne-sur-laccessibilite-les-reglements-daccessibilite-et-les-normes-daccessibilite/',
+                            'lsq' => 'https://www.youtube.com/watch?v=D5D6J8QFyX4',
+                        ],
+                        'phases' => ['design'],
+                        'type' => ContentType::firstWhere('name->en', 'Guidelines and best practices'),
+                        'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
+                        'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
+                        'topics' => [],
+                        'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
+                    ],
+                    [
+                        'title' => ['en' => 'An Introduction To The Accessible Canada Act'],
+                        'author' => ['en' => 'ARCH Disability Law Centre'],
+                        'url' => ['en' => 'https://archdisabilitylaw.ca/an-introduction-to-the-accessible-canada-act/'],
+                        'phases' => ['design'],
+                        'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
+                        'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
+                        'topics' => [],
+                        'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
+                    ],
+                ];
+
+                foreach ($resources as $resource) {
+                    $item = Resource::firstOrCreate([
+                        'title' => $resource['title'],
+                        'author' => $resource['author'] ?? '',
+                        'summary' => $resource['summary'] ?? '',
+                        'url' => $resource['url'],
+                        'phases' => $resource['phases'] ?? [],
+                    ]);
+
+                    if (isset($resource['type'])) {
+                        $item->contentType()->associate($resource['type']);
+                        $item->save();
+                    }
+
+                    if (isset($resource['sectors'])) {
+                        $item->sectors()->attach($resource['sectors']);
+                    }
+
+                    if (isset($resource['impacts'])) {
+                        $item->impacts()->attach($resource['impacts']);
+                    }
+
+                    if (isset($resource['topics'])) {
+                        $item->topics()->attach($resource['topics']);
+                    }
+
+                    if (isset($resource['resourceCollections'])) {
+                        $item->resourceCollections()->attach($resource['resourceCollections']);
                     }
                 }
-                if ($resource['organization_id']) {
-                    if (Organization::where('id', $resource['organization_id'])->doesntExist()) {
-                        printf("Skipping insert because organization with id %s is missing \r\n", $resource['organization_id']);
-                        continue;
-                    }
-                }
-                $item = Resource::firstOrCreate([
-                    'title' => json_decode($resource['title'], true),
-                    'slug' => json_decode($resource['slug'], true),
-                    'summary' => json_decode($resource['summary'], true),
-                    'url' => json_decode($resource['url'], true),
-                    'formats' => json_decode($resource['formats'], true),
-                    'phases' => json_decode($resource['phases'], true),
-                    'author' => json_decode($resource['author'], true),
-                    'content_type_id' => $resource['content_type_id'],
-                    'organization_id' => $resource['organization_id'],
-                ]);
             }
         } else {
-            $resources = [
-                [
-                    'title' => ['en' => 'The Accessible Canada Act, Accessibility Regulations and Standards'],
-                    'author' => ['en' => 'ARCH Disability Law Centre'],
-                    'url' => [
-                        'en' => 'https://archdisabilitylaw.ca/the-accessible-canada-act-accessibility-regulations-and-standards/',
-                        'asl' => 'https://www.youtube.com/watch?v=CE8OFr9jdXw',
-                        'fr' => 'https://archdisabilitylaw.ca/fr/la-loi-canadienne-sur-laccessibilite-les-reglements-daccessibilite-et-les-normes-daccessibilite/',
-                        'lsq' => 'https://www.youtube.com/watch?v=D5D6J8QFyX4',
-                    ],
-                    'phases' => ['design'],
-                    'type' => ContentType::firstWhere('name->en', 'Guidelines and best practices'),
-                    'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
-                    'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
-                    'topics' => [],
-                    'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
-                ],
-                [
-                    'title' => ['en' => 'An Introduction To The Accessible Canada Act'],
-                    'author' => ['en' => 'ARCH Disability Law Centre'],
-                    'url' => ['en' => 'https://archdisabilitylaw.ca/an-introduction-to-the-accessible-canada-act/'],
-                    'phases' => ['design'],
-                    'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
-                    'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
-                    'topics' => [],
-                    'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
-                ],
-            ];
-
-            foreach ($resources as $resource) {
-                $item = Resource::firstOrCreate([
-                    'title' => $resource['title'],
-                    'author' => $resource['author'] ?? '',
-                    'summary' => $resource['summary'] ?? '',
-                    'url' => $resource['url'],
-                    'phases' => $resource['phases'] ?? [],
-                ]);
-
-                if (isset($resource['type'])) {
-                    $item->contentType()->associate($resource['type']);
-                    $item->save();
-                }
-
-                if (isset($resource['sectors'])) {
-                    $item->sectors()->attach($resource['sectors']);
-                }
-
-                if (isset($resource['impacts'])) {
-                    $item->impacts()->attach($resource['impacts']);
-                }
-
-                if (isset($resource['topics'])) {
-                    $item->topics()->attach($resource['topics']);
-                }
-
-                if (isset($resource['resourceCollections'])) {
-                    $item->resourceCollections()->attach($resource['resourceCollections']);
-                }
-            }
+            $environment = config('app.env');
+            printf("Seeder cannot be run on environment: %s\r\n", $environment);
         }
     }
 }

--- a/database/seeders/ResourceSeeder.php
+++ b/database/seeders/ResourceSeeder.php
@@ -8,6 +8,7 @@ use App\Models\Resource;
 use App\Models\ResourceCollection;
 use App\Models\Sector;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Storage;
 
 class ResourceSeeder extends Seeder
 {
@@ -18,63 +19,84 @@ class ResourceSeeder extends Seeder
      */
     public function run()
     {
-        $resources = [
-            [
-                'title' => ['en' => 'The Accessible Canada Act, Accessibility Regulations and Standards'],
-                'author' => ['en' => 'ARCH Disability Law Centre'],
-                'url' => [
-                    'en' => 'https://archdisabilitylaw.ca/the-accessible-canada-act-accessibility-regulations-and-standards/',
-                    'asl' => 'https://www.youtube.com/watch?v=CE8OFr9jdXw',
-                    'fr' => 'https://archdisabilitylaw.ca/fr/la-loi-canadienne-sur-laccessibilite-les-reglements-daccessibilite-et-les-normes-daccessibilite/',
-                    'lsq' => 'https://www.youtube.com/watch?v=D5D6J8QFyX4',
+
+        // check if there is a JSON file that has stored data for the seeder
+        if (Storage::disk('seeds')->exists('resources.json')) {
+            $resources = json_decode(Storage::disk('seeds')->get('resources.json'), true);
+
+            foreach ($resources as $resource) {
+                $item = Resource::firstOrCreate([
+                    'title' => json_decode($resource['title'], true),
+                    'slug' => json_decode($resource['slug'], true),
+                    'summary' => json_decode($resource['summary'], true),
+                    'url' => json_decode($resource['url'], true),
+                    'formats' => json_decode($resource['formats'], true),
+                    'phases' => json_decode($resource['phases'], true),
+                    'author' => json_decode($resource['author'], true),
+                    'content_type_id' => $resource['content_type_id'],
+                    'organization_id' => $resource['organization_id'],
+                ]);
+            }
+        } else {
+            $resources = [
+                [
+                    'title' => ['en' => 'The Accessible Canada Act, Accessibility Regulations and Standards'],
+                    'author' => ['en' => 'ARCH Disability Law Centre'],
+                    'url' => [
+                        'en' => 'https://archdisabilitylaw.ca/the-accessible-canada-act-accessibility-regulations-and-standards/',
+                        'asl' => 'https://www.youtube.com/watch?v=CE8OFr9jdXw',
+                        'fr' => 'https://archdisabilitylaw.ca/fr/la-loi-canadienne-sur-laccessibilite-les-reglements-daccessibilite-et-les-normes-daccessibilite/',
+                        'lsq' => 'https://www.youtube.com/watch?v=D5D6J8QFyX4',
+                    ],
+                    'phases' => ['design'],
+                    'type' => ContentType::firstWhere('name->en', 'Guidelines and best practices'),
+                    'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
+                    'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
+                    'topics' => [],
+                    'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
                 ],
-                'phases' => ['design'],
-                'type' => ContentType::firstWhere('name->en', 'Guidelines and best practices'),
-                'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
-                'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
-                'topics' => [],
-                'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
-            ],
-            [
-                'title' => ['en' => 'An Introduction To The Accessible Canada Act'],
-                'author' => ['en' => 'ARCH Disability Law Centre'],
-                'url' => ['en' => 'https://archdisabilitylaw.ca/an-introduction-to-the-accessible-canada-act/'],
-                'phases' => ['design'],
-                'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
-                'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
-                'topics' => [],
-                'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
-            ],
-        ];
+                [
+                    'title' => ['en' => 'An Introduction To The Accessible Canada Act'],
+                    'author' => ['en' => 'ARCH Disability Law Centre'],
+                    'url' => ['en' => 'https://archdisabilitylaw.ca/an-introduction-to-the-accessible-canada-act/'],
+                    'phases' => ['design'],
+                    'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
+                    'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
+                    'topics' => [],
+                    'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
+                ],
+            ];
 
-        foreach ($resources as $resource) {
-            $item = Resource::firstOrCreate([
-                'title' => $resource['title'],
-                'author' => $resource['author'] ?? '',
-                'summary' => $resource['summary'] ?? '',
-                'url' => $resource['url'],
-                'phases' => $resource['phases'] ?? [],
-            ]);
+            foreach ($resources as $resource) {
+                $item = Resource::firstOrCreate([
+                    'title' => $resource['title'],
+                    'author' => $resource['author'] ?? '',
+                    'summary' => $resource['summary'] ?? '',
+                    'url' => $resource['url'],
+                    'phases' => $resource['phases'] ?? [],
+                ]);
 
-            if (isset($resource['type'])) {
-                $item->contentType()->associate($resource['type']);
-                $item->save();
-            }
+                // TODO how do we save and do the connected values?
+                if (isset($resource['type'])) {
+                    $item->contentType()->associate($resource['type']);
+                    $item->save();
+                }
 
-            if (isset($resource['sectors'])) {
-                $item->sectors()->attach($resource['sectors']);
-            }
+                if (isset($resource['sectors'])) {
+                    $item->sectors()->attach($resource['sectors']);
+                }
 
-            if (isset($resource['impacts'])) {
-                $item->impacts()->attach($resource['impacts']);
-            }
+                if (isset($resource['impacts'])) {
+                    $item->impacts()->attach($resource['impacts']);
+                }
 
-            if (isset($resource['topics'])) {
-                $item->topics()->attach($resource['topics']);
-            }
+                if (isset($resource['topics'])) {
+                    $item->topics()->attach($resource['topics']);
+                }
 
-            if (isset($resource['resourceCollections'])) {
-                $item->resourceCollections()->attach($resource['resourceCollections']);
+                if (isset($resource['resourceCollections'])) {
+                    $item->resourceCollections()->attach($resource['resourceCollections']);
+                }
             }
         }
     }

--- a/database/seeders/ResourceSeeder.php
+++ b/database/seeders/ResourceSeeder.php
@@ -21,14 +21,14 @@ class ResourceSeeder extends Seeder {
     public function run() {
 
         // option to use environment to restore or backup to different environment files
-        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), ['production', 'staging', 'local']) === true) {
+        if (config('seeder.environment') !== null && in_array(config('seeder.environment'), config('backup.filament_seeders.environments')) === true) {
             $environment = config('seeder.environment');
         } else {
             $environment = config('app.env');
         }
 
-        // check if there is a JSON file that has stored data for the seeder
-        if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+        // TODO need to write handling of attachments
+        if (false && Storage::disk('seeds')->exists(sprintf("resources.%s.json", $environment))) {
 
             // if trucate was set via seeder restore command then truncate the table prior to seeding data
             if (config('seeder.truncate')) {
@@ -37,102 +37,95 @@ class ResourceSeeder extends Seeder {
                 DB::statement("SET foreign_key_checks=1");
             }
 
-            // TODO need to write handling of attachments
-            if (false && Storage::disk('seeds')->exists(sprintf("resources.%s.json", $environment))) {
-
-                $resources = json_decode(Storage::disk('seeds')->get(sprintf("resources.%s.json", $environment)), true);
+            $resources = json_decode(Storage::disk('seeds')->get(sprintf("resources.%s.json", $environment)), true);
 
 
-                foreach ($resources as $resource) {
-                    if ($resource['content_type_id']) {
-                        if (ContentType::where('id', $resource['content_type_id'])->doesntExist()) {
-                            printf("Skipping insert because content type with id %s is missing \r\n", $resource['content_type_id']);
-                            continue;
-                        }
-                    }
-                    if ($resource['organization_id']) {
-                        if (Organization::where('id', $resource['organization_id'])->doesntExist()) {
-                            printf("Skipping insert because organization with id %s is missing \r\n", $resource['organization_id']);
-                            continue;
-                        }
-                    }
-                    $item = Resource::firstOrCreate([
-                        'title' => json_decode($resource['title'], true),
-                        'slug' => json_decode($resource['slug'], true),
-                        'summary' => json_decode($resource['summary'], true),
-                        'url' => json_decode($resource['url'], true),
-                        'formats' => json_decode($resource['formats'], true),
-                        'phases' => json_decode($resource['phases'], true),
-                        'author' => json_decode($resource['author'], true),
-                        'content_type_id' => $resource['content_type_id'],
-                        'organization_id' => $resource['organization_id'],
-                    ]);
-                }
-            } else {
-                print("Seeder file wasn't found, using default values\r\n");
-                $resources = [
-                    [
-                        'title' => ['en' => 'The Accessible Canada Act, Accessibility Regulations and Standards'],
-                        'author' => ['en' => 'ARCH Disability Law Centre'],
-                        'url' => [
-                            'en' => 'https://archdisabilitylaw.ca/the-accessible-canada-act-accessibility-regulations-and-standards/',
-                            'asl' => 'https://www.youtube.com/watch?v=CE8OFr9jdXw',
-                            'fr' => 'https://archdisabilitylaw.ca/fr/la-loi-canadienne-sur-laccessibilite-les-reglements-daccessibilite-et-les-normes-daccessibilite/',
-                            'lsq' => 'https://www.youtube.com/watch?v=D5D6J8QFyX4',
-                        ],
-                        'phases' => ['design'],
-                        'type' => ContentType::firstWhere('name->en', 'Guidelines and best practices'),
-                        'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
-                        'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
-                        'topics' => [],
-                        'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
-                    ],
-                    [
-                        'title' => ['en' => 'An Introduction To The Accessible Canada Act'],
-                        'author' => ['en' => 'ARCH Disability Law Centre'],
-                        'url' => ['en' => 'https://archdisabilitylaw.ca/an-introduction-to-the-accessible-canada-act/'],
-                        'phases' => ['design'],
-                        'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
-                        'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
-                        'topics' => [],
-                        'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
-                    ],
-                ];
-
-                foreach ($resources as $resource) {
-                    $item = Resource::firstOrCreate([
-                        'title' => $resource['title'],
-                        'author' => $resource['author'] ?? '',
-                        'summary' => $resource['summary'] ?? '',
-                        'url' => $resource['url'],
-                        'phases' => $resource['phases'] ?? [],
-                    ]);
-
-                    if (isset($resource['type'])) {
-                        $item->contentType()->associate($resource['type']);
-                        $item->save();
-                    }
-
-                    if (isset($resource['sectors'])) {
-                        $item->sectors()->attach($resource['sectors']);
-                    }
-
-                    if (isset($resource['impacts'])) {
-                        $item->impacts()->attach($resource['impacts']);
-                    }
-
-                    if (isset($resource['topics'])) {
-                        $item->topics()->attach($resource['topics']);
-                    }
-
-                    if (isset($resource['resourceCollections'])) {
-                        $item->resourceCollections()->attach($resource['resourceCollections']);
+            foreach ($resources as $resource) {
+                if ($resource['content_type_id']) {
+                    if (ContentType::where('id', $resource['content_type_id'])->doesntExist()) {
+                        printf("Skipping insert because content type with id %s is missing \r\n", $resource['content_type_id']);
+                        continue;
                     }
                 }
+                if ($resource['organization_id']) {
+                    if (Organization::where('id', $resource['organization_id'])->doesntExist()) {
+                        printf("Skipping insert because organization with id %s is missing \r\n", $resource['organization_id']);
+                        continue;
+                    }
+                }
+                $item = Resource::firstOrCreate([
+                    'title' => json_decode($resource['title'], true),
+                    'slug' => json_decode($resource['slug'], true),
+                    'summary' => json_decode($resource['summary'], true),
+                    'url' => json_decode($resource['url'], true),
+                    'formats' => json_decode($resource['formats'], true),
+                    'phases' => json_decode($resource['phases'], true),
+                    'author' => json_decode($resource['author'], true),
+                    'content_type_id' => $resource['content_type_id'],
+                    'organization_id' => $resource['organization_id'],
+                ]);
             }
         } else {
-            $environment = config('app.env');
-            printf("Seeder cannot be run on environment: %s\r\n", $environment);
+            print("Seeder file wasn't found, using default values\r\n");
+            $resources = [
+                [
+                    'title' => ['en' => 'The Accessible Canada Act, Accessibility Regulations and Standards'],
+                    'author' => ['en' => 'ARCH Disability Law Centre'],
+                    'url' => [
+                        'en' => 'https://archdisabilitylaw.ca/the-accessible-canada-act-accessibility-regulations-and-standards/',
+                        'asl' => 'https://www.youtube.com/watch?v=CE8OFr9jdXw',
+                        'fr' => 'https://archdisabilitylaw.ca/fr/la-loi-canadienne-sur-laccessibilite-les-reglements-daccessibilite-et-les-normes-daccessibilite/',
+                        'lsq' => 'https://www.youtube.com/watch?v=D5D6J8QFyX4',
+                    ],
+                    'phases' => ['design'],
+                    'type' => ContentType::firstWhere('name->en', 'Guidelines and best practices'),
+                    'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
+                    'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
+                    'topics' => [],
+                    'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
+                ],
+                [
+                    'title' => ['en' => 'An Introduction To The Accessible Canada Act'],
+                    'author' => ['en' => 'ARCH Disability Law Centre'],
+                    'url' => ['en' => 'https://archdisabilitylaw.ca/an-introduction-to-the-accessible-canada-act/'],
+                    'phases' => ['design'],
+                    'sectors' => [Sector::firstWhere('name->en', 'Federal government programs and services')->id],
+                    'impacts' => [Impact::firstWhere('name->en', 'Programs and services')->id, Impact::firstWhere('name->en', 'Communication, other than information and communication technologies')->id],
+                    'topics' => [],
+                    'resourceCollections' => [ResourceCollection::firstWhere('title->en', 'The Accessible Canada Act')->id],
+                ],
+            ];
+
+            foreach ($resources as $resource) {
+                $item = Resource::firstOrCreate([
+                    'title' => $resource['title'],
+                    'author' => $resource['author'] ?? '',
+                    'summary' => $resource['summary'] ?? '',
+                    'url' => $resource['url'],
+                    'phases' => $resource['phases'] ?? [],
+                ]);
+
+                if (isset($resource['type'])) {
+                    $item->contentType()->associate($resource['type']);
+                    $item->save();
+                }
+
+                if (isset($resource['sectors'])) {
+                    $item->sectors()->attach($resource['sectors']);
+                }
+
+                if (isset($resource['impacts'])) {
+                    $item->impacts()->attach($resource['impacts']);
+                }
+
+                if (isset($resource['topics'])) {
+                    $item->topics()->attach($resource['topics']);
+                }
+
+                if (isset($resource['resourceCollections'])) {
+                    $item->resourceCollections()->attach($resource['resourceCollections']);
+                }
+            }
         }
     }
 }

--- a/database/seeders/ResourceSeeder.php
+++ b/database/seeders/ResourceSeeder.php
@@ -9,6 +9,7 @@ use App\Models\ResourceCollection;
 use App\Models\Sector;
 use App\Models\Organization;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
 class ResourceSeeder extends Seeder {
@@ -28,6 +29,14 @@ class ResourceSeeder extends Seeder {
 
         // check if there is a JSON file that has stored data for the seeder
         if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+
+            // if trucate was set via seeder restore command then truncate the table prior to seeding data
+            if (config('seeder.truncate')) {
+                DB::statement("SET foreign_key_checks=0");
+                Resource::truncate();
+                DB::statement("SET foreign_key_checks=1");
+            }
+
             // TODO need to write handling of attachments
             if (false && Storage::disk('seeds')->exists(sprintf("resources.%s.json", $environment))) {
 

--- a/database/seeders/TopicSeeder.php
+++ b/database/seeders/TopicSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Topic;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
 class TopicSeeder extends Seeder {
@@ -23,6 +24,14 @@ class TopicSeeder extends Seeder {
 
         // check if there is a JSON file that has stored data for the seeder
         if (in_array(config('app.env'), ['testing', 'production']) !== true) {
+
+            // if trucate was set via seeder restore command then truncate the table prior to seeding data
+            if (config('seeder.truncate')) {
+                DB::statement("SET foreign_key_checks=0");
+                Topic::truncate();
+                DB::statement("SET foreign_key_checks=1");
+            }
+
             if (Storage::disk('seeds')->exists(sprintf("topics.%s.json", $environment))) {
 
                 $topics = json_decode(Storage::disk('seeds')->get(sprintf("topics.%s.json", $environment)), true);

--- a/database/seeders/TopicSeeder.php
+++ b/database/seeders/TopicSeeder.php
@@ -16,7 +16,7 @@ class TopicSeeder extends Seeder
     public function run()
     {
         // check if there is a JSON file that has stored data for the seeder
-        if (Storage::disk('seeds')->exists('topics.json')) {
+        if (in_array(config('app.env'), ['testing', 'production']) !== true && Storage::disk('seeds')->exists('topics.json')) {
             $topics = json_decode(Storage::disk('seeds')->get('topics.json'), true);
 
             foreach ($topics as $topic) {

--- a/database/seeders/TopicSeeder.php
+++ b/database/seeders/TopicSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Topic;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Storage;
 
 class TopicSeeder extends Seeder
 {
@@ -14,19 +15,30 @@ class TopicSeeder extends Seeder
      */
     public function run()
     {
-        $topics = [
-            __('Accessible consultation'),
-            __('Intersectional outreach'),
-            __('Contracts'),
-            __('Privacy'),
-            __('Disability knowledge'),
-        ];
+        // check if there is a JSON file that has stored data for the seeder
+        if (Storage::disk('seeds')->exists('topics.json')) {
+            $topics = json_decode(Storage::disk('seeds')->get('topics.json'), true);
 
-        foreach ($topics as $topic) {
-            Topic::firstOrCreate([
-                'name->en' => $topic,
-                'name->fr' => trans($topic, [], 'fr'),
-            ]);
+            foreach ($topics as $topic) {
+                Topic::firstOrCreate([
+                    'name' => json_decode($topic['name'], true),
+                ]);
+            }
+        } else {
+            $topics = [
+                __('Accessible consultation'),
+                __('Intersectional outreach'),
+                __('Contracts'),
+                __('Privacy'),
+                __('Disability knowledge'),
+            ];
+
+            foreach ($topics as $topic) {
+                Topic::firstOrCreate([
+                    'name->en' => $topic,
+                    'name->fr' => trans($topic, [], 'fr'),
+                ]);
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves #1483 

- Creates new filesystem disk on permanent storage `storage/app/seeds`.
- Created new artisan command `db:seed:backup` which you can pass a table to backup the tables as a JSON file into `storage/app/seeds`.
- Updated seeders for the tables to first try and pull from the stored file if it exists in order to seed the table.
- Added new seeder for the **interpretations** table.
- Add cache/clear for event, view, route, and config.

## Tests

- [x] Pull the following tables from staging identities, interpretations, resource_collections, resources, topics.
- [x] Deploy those tables to local mysql deployment.
- [x] Run the command `php artisan db:seed:backup` for each table and make sure that the table file is stored correctly.
- [x] Run the command `php artisan db:seed --class=` for each of the filament table seeders.
- [x] Check tables values before and after seeder is run.