### PR TITLE
fix: newline before the opening <?php (resolves #1552)

### DIFF
--- a/routes/organizations.php
+++ b/routes/organizations.php
@@ -1,4 +1,3 @@
-
 <?php
 
 use App\Http\Controllers\OrganizationController;

--- a/routes/resources.php
+++ b/routes/resources.php
@@ -1,4 +1,3 @@
-
 <?php
 
 use App\Http\Controllers\ResourceController;


### PR DESCRIPTION
Resolves #1552 

Removes some newlines from the start of some php files.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
