### PR TITLE
fix: don't deploy HubSpot integration beyond dev (resolves #1582)

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -37,7 +37,9 @@
     </main>
 
     @include('layouts.footer')
+    @env(['dev', 'local'])
     @include('partials.hubspot')
+    @endenv
 </body>
 
 </html>


### PR DESCRIPTION
Resolves #1582 

Restricts the HubSpot embed code to only be added when in the `local` or `dev` app environments.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
