### PR TITLE
fix: 419 error with "remember me" enabled (resolves #1512)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "spatie/laravel-login-link": "^1.1",
         "spatie/laravel-options": "^1.0",
         "spatie/laravel-schemaless-attributes": "^2.3",
-        "spatie/laravel-sql-commenter": "^1.1",
         "spatie/laravel-translatable": "^6.0",
         "spatie/valuestore": "^1.3",
         "staudenmeir/eloquent-has-many-deep": "^1.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb8c4e3dc35001ec02fb292ae2e17c69",
+    "content-hash": "e74b4b17260378739d38535ea49f8977",
     "packages": [
         {
             "name": "akaunting/laravel-money",
@@ -7830,83 +7830,6 @@
             "time": "2022-03-28T11:21:33+00:00"
         },
         {
-            "name": "spatie/laravel-sql-commenter",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/laravel-sql-commenter.git",
-                "reference": "9c5444f3463c1f65c4195dc0fe5da90ba7546363"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-sql-commenter/zipball/9c5444f3463c1f65c4195dc0fe5da90ba7546363",
-                "reference": "9c5444f3463c1f65c4195dc0fe5da90ba7546363",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/contracts": "^9.0",
-                "php": "^8.1",
-                "spatie/backtrace": "^1.2",
-                "spatie/invade": "^1.1",
-                "spatie/laravel-package-tools": "^1.12"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.8",
-                "nunomaduro/collision": "^6.2",
-                "nunomaduro/larastan": "^2.1",
-                "orchestra/testbench": "^7.6",
-                "pestphp/pest": "^1.21",
-                "pestphp/pest-plugin-laravel": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpunit/phpunit": "^9.5",
-                "spatie/laravel-ray": "^1.29"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Spatie\\SqlCommenter\\SqlCommenterServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Spatie\\SqlCommenter\\": "src",
-                    "Spatie\\SqlCommenter\\Database\\Factories\\": "database/factories"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Rias Van der Veken",
-                    "email": "rias@spatie.be",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Freek Van der Herten",
-                    "email": "freek@spatie.be",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Add comments to SQL queries made by Laravel",
-            "homepage": "https://github.com/spatie/laravel-sql-commenter",
-            "keywords": [
-                "laravel",
-                "spatie",
-                "sql-commenter",
-                "sqlcommenter"
-            ],
-            "support": {
-                "source": "https://github.com/spatie/laravel-sql-commenter/tree/1.1.1"
-            },
-            "time": "2022-07-04T09:07:24+00:00"
-        },
-        {
             "name": "spatie/laravel-translatable",
             "version": "6.3.0",
             "source": {
@@ -15547,5 +15470,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Resolves #1512 

Removes the [spatie/laravel-sql-commenter](https://github.com/spatie/laravel-sql-commenter) package which was corrupting the database request for the sessions when remember me was enabled.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [ ] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
