### PR TITLE
fix: 'Correct answer' on quiz result isn't themed (resolves #1590)

### DIFF
--- a/resources/css/_tokens.css
+++ b/resources/css/_tokens.css
@@ -1,4 +1,4 @@
-/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2023-03-08.
+/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 3/20/2023.
     Tokens location: ./tailwind.config.js */
 :root {
     --space-0: 0;

--- a/resources/css/components/_quiz.css
+++ b/resources/css/components/_quiz.css
@@ -1,17 +1,11 @@
-.correct-answer {
-    color: var(--color-green-7);
-}
-
+.correct-answer,
 .correct-answer svg {
-    color: var(--fg, var(--color-green-7));
+    color: var(--theme-color-success, var(--color-green-7));
 }
 
-.wrong-answer {
-    color: var(--color-red-8);
-}
-
+.wrong-answer,
 .wrong-answer svg {
-    color: var(--fg, var(--color-red-8));
+    color: var(--theme-color-error, var(--color-red-8));
 }
 
 .question > .banner p {


### PR DESCRIPTION
Resolves #1590 

Uses the theme success and error colours for the `.correct-answer` and `.wrong-answer` styles.

### Prerequisites

If this PR changes PHP code or dependencies:

- [ ] I've run `composer format` and fixed any code formatting issues.
- [ ] I've run `composer analyze` and addressed any static analysis issues.
- [ ] I've run `php artisan test` and ensured that all tests pass.
- [ ] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
