### PR TITLE
Ci/remove linking to shared permanent storage cache

### DIFF
--- a/.deploy/accessibility-app/entrypoint.sh
+++ b/.deploy/accessibility-app/entrypoint.sh
@@ -2,29 +2,33 @@
 
 set -e
 
+# TODO permanent remove cache lines once testing on per/pod caching is tested
+
 mkdir -p $FILES_PATH
-mkdir -p $CACHE_PATH
+# mkdir -p $CACHE_PATH removed per https://github.com/accessibility-exchange/platform/issues/1596
 
 ## fix permissions before syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1226
-chown -R www-data:root /app/storage /app/bootstrap/cache $FILES_PATH $CACHE_PATH
+chown -R www-data:root /app/storage /app/bootstrap/cache $FILES_PATH # $CACHE_PATH removed per https://github.com/accessibility-exchange/platform/issues/1596
 
 ## sync files from container storage to permanent storage then remove container storage
 rsync -a /app/storage/ $FILES_PATH
 rm -rf /app/storage
 
 ## sync files from container cache to permanent storage then remove container cache
-rsync -a /app/bootstrap/cache/ $CACHE_PATH
-rm -rf /app/bootstrap/cache
+## removed syncing to shared/permenant storage https://github.com/accessibility-exchange/platform/issues/1596
+# rsync -a /app/bootstrap/cache/ $CACHE_PATH
+# rm -rf /app/bootstrap/cache
 
 ## create symlinks from permanent storage & cache to application directory folders
 ln -s $FILES_PATH /app/storage
-ln -s $CACHE_PATH /app/bootstrap/cache
+## removed linked to shared/permenant storage https://github.com/accessibility-exchange/platform/issues/1596
+# ln -s $CACHE_PATH /app/bootstrap/cache
 
 php artisan deploy:local
 
-flock -n -E 0 /opt/data/cache -c "php artisan deploy:global" # run exclusively on a single instance at once
+flock -n -E 0 /opt/data -c "php artisan deploy:global" # run exclusively on a single instance at once
 
 ## fix permissions after syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1236
-chown -R www-data:root $FILES_PATH $CACHE_PATH
+chown -R www-data:root /app/bootstrap/cache $FILES_PATH # $CACHE_PATH removed per and added path to cache in the pod https://github.com/accessibility-exchange/platform/issues/1596
 
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/.deploy/accessibility-app/values.production.yaml
+++ b/.deploy/accessibility-app/values.production.yaml
@@ -23,7 +23,7 @@ env:
   SESSION_LIFETIME: "120"
   SAIL_XDEBUG_MODE: "develop,debug,coverage"
   FILES_PATH: "/opt/data/storage"
-  CACHE_PATH: "/opt/data/cache"
+  # CACHE_PATH: "/opt/data/cache" removed per https://github.com/accessibility-exchange/platform/issues/1596
 ### Place those values in Vault
 # secrets:
 #   APP_KEY: ""

--- a/.deploy/accessibility-app/values.staging.yaml
+++ b/.deploy/accessibility-app/values.staging.yaml
@@ -18,7 +18,7 @@ env:
   SESSION_LIFETIME: "120"
   SAIL_XDEBUG_MODE: "develop,debug,coverage"
   FILES_PATH: "/opt/data/storage"
-  CACHE_PATH: "/opt/data/cache"
+  # CACHE_PATH: "/opt/data/cache" removed per https://github.com/accessibility-exchange/platform/issues/1596
 ### Place those values in Vault
 # secrets:
 #   APP_KEY: ""

--- a/app/Console/Commands/DeployGlobal.php
+++ b/app/Console/Commands/DeployGlobal.php
@@ -27,19 +27,8 @@ class DeployGlobal extends Command
      */
     public function handle(): int
     {
-        $this->call('optimize:clear');
-        $this->call('event:clear');
-        $this->call('icons:clear');
-        $this->call('view:clear');
-        $this->call('route:clear');
-        $this->call('config:clear');
-        $this->call('event:cache');
-        $this->call('icons:cache');
         $this->call('view:cache');
-        $this->call('route:cache');
-        $this->call('config:cache');
         $this->call('google-fonts:fetch');
-        $this->call('optimize');
         $this->call('migrate', ['--step' => true, '--force' => true]);
 
         return 0;

--- a/app/Console/Commands/DeployLocal.php
+++ b/app/Console/Commands/DeployLocal.php
@@ -28,7 +28,12 @@ class DeployLocal extends Command
     public function handle(): int
     {
         $this->call('storage:link');
-
+        $this->call('optimize:clear');
+        $this->call('icons:clear');
+        $this->call('icons:cache');
+        $this->call('event:cache');
+        $this->call('optimize');
+        $this->call('livewire:discover')
         return 0;
     }
 }

--- a/app/Console/Commands/DeployLocal.php
+++ b/app/Console/Commands/DeployLocal.php
@@ -33,7 +33,7 @@ class DeployLocal extends Command
         $this->call('icons:cache');
         $this->call('event:cache');
         $this->call('optimize');
-        $this->call('livewire:discover')
+        $this->call('livewire:discover');
         return 0;
     }
 }


### PR DESCRIPTION
* Removes linking of local pod file caching link from permanent/shared storage in entrypoint.
* Moves artisan commands that create files within cache directory from `deploy:global` to `deploy:local`.
* Added artisan command `livewire:discover` to create livewire components cache, a file I found that is created in cache but no generated by other commands.

This PR was branched from **staging** and being pushed back to **staging** since it is build related.
