### PR TITLE
fix: language modal styling (resolves #1654, #1653, #1652)

### DIFF
--- a/resources/css/_tokens.css
+++ b/resources/css/_tokens.css
@@ -1,4 +1,4 @@
-/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2023-04-05.
+/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2023-04-06.
     Tokens location: ./tailwind.config.js */
 :root {
     --space-0: 0;

--- a/resources/css/components/_language-modal.css
+++ b/resources/css/components/_language-modal.css
@@ -15,6 +15,7 @@
 .language-modal .modal {
     background: transparent;
     max-height: 100vh;
+    max-width: 100vw;
     overflow-y: auto;
     padding-block: var(--space-8);
 }
@@ -47,15 +48,9 @@
 }
 
 @media (min-width: 48rem) {
-    .language-modal .modal {
-        max-width: var(--max-w-max);
-    }
-
-    .language-modal .logo {
-        height: var(--space-13);
-    }
-
     .language-modal nav {
+        display: flex;
+        justify-content: center;
         padding-block-end: var(--space-29);
     }
 
@@ -63,6 +58,8 @@
         --grid-cell-min-width: var(--space-36);
 
         margin-block-start: var(--space-16);
+        max-width: var(--max-w-6xl);
+        width: 100%;
     }
 
     .language-modal .cta {

--- a/resources/css/components/_language-modal.css
+++ b/resources/css/components/_language-modal.css
@@ -36,6 +36,10 @@
     margin-block-start: var(--space-8);
 }
 
+.language-modal .cta:focus {
+    --cta-outline: var(--color-grey-2);
+}
+
 .language-modal .signed {
     height: var(--space-8);
     min-height: var(--space-8);

--- a/resources/css/components/_language-modal.css
+++ b/resources/css/components/_language-modal.css
@@ -19,7 +19,7 @@
     padding-block: var(--space-8);
 }
 
-.language-modal .logo {
+.language-modal__logo {
     height: var(--space-14);
     min-height: var(--space-14);
     width: auto;

--- a/resources/css/themes/_dark.css
+++ b/resources/css/themes/_dark.css
@@ -272,7 +272,7 @@
     --theme-definition-shadow: 0 0 0.625rem rgb(0 0 0 / 50%);
 
     /* Cookie Consent */
-    --theme-cookie-consent-background: var(--color-graphite-7);
+    --theme-cookie-consent-background: var(--color-black);
     --theme-cookie-consent-color: var(--color-grey-1);
     --theme-cookie-consent-shadow: 0 0 10px rgb(0 0 0 / 50%);
 

--- a/resources/views/components/language-modal.blade.php
+++ b/resources/views/components/language-modal.blade.php
@@ -3,7 +3,7 @@
         <template x-teleport="body">
             <div class="modal-wrapper language-modal dark" x-show="showingModal" @keydown.escape.window="hideModal">
                 <div class="modal stack flex flex-col" @click.outside="hideModal">
-                    @svg('tae-logo-mono-no-text', ['class' => 'logo'])
+                    @svg('tae-logo-mono-no-text', ['class' => 'language-modal__logo'])
                     <h2>
                         <p class="text-center" lang="en">{{ __('Welcome to the Accessibility Exchange', [], 'en') }}</p>
                         <p class="text-center" lang="fr">{{ __('Welcome to the Accessibility Exchange', [], 'fr') }}

--- a/resources/views/components/language-modal.blade.php
+++ b/resources/views/components/language-modal.blade.php
@@ -2,7 +2,7 @@
     <div x-data="modal()" x-init="showModal();">
         <template x-teleport="body">
             <div class="modal-wrapper language-modal dark" x-show="showingModal" @keydown.escape.window="hideModal">
-                <div class="modal stack flex flex-col" @click.outside="hideModal">
+                <div class="modal stack flex flex-col">
                     @svg('tae-logo-mono-no-text', ['class' => 'language-modal__logo'])
                     <h2>
                         <p class="text-center" lang="en">{{ __('Welcome to the Accessibility Exchange', [], 'en') }}</p>

--- a/resources/views/components/language-modal.blade.php
+++ b/resources/views/components/language-modal.blade.php
@@ -29,10 +29,14 @@
                         </ul>
                     </nav>
 
-                    <p class="text-center" lang="en">
-                        {{ __('You can always change this by selecting the language menu.', [], 'en') }}</p>
-                    <p class="text-center" lang="fr">
-                        {{ __('You can always change this by selecting the language menu.', [], 'fr') }}</p>
+                    <div>
+                        <p class="text-center" lang="en">
+                            {{ __('You can always change this by selecting the language menu.', [], 'en') }}
+                        </p>
+                        <p class="text-center" lang="fr">
+                            {{ __('You can always change this by selecting the language menu.', [], 'fr') }}
+                        </p>
+                    </div>
 
                     {{--
                             Using two instances of the video player for desktop and mobile.

--- a/resources/views/components/language-modal.blade.php
+++ b/resources/views/components/language-modal.blade.php
@@ -1,7 +1,7 @@
 @unless(session()->missing('_token') || session()->has('language-confirmed'))
     <div x-data="modal()" x-init="showModal();">
         <template x-teleport="body">
-            <div class="modal-wrapper language-modal dark" x-show="showingModal" @keydown.escape.window="hideModal">
+            <div class="modal-wrapper language-modal darker" x-show="showingModal" @keydown.escape.window="hideModal">
                 <div class="modal stack flex flex-col">
                     @svg('tae-logo-mono-no-text', ['class' => 'language-modal__logo'])
                     <h2>


### PR DESCRIPTION
Resolves #1654, #1653, #1652

- Fixes spacing of text describing language menu
- Fixes scroll bar in desktop view
- Fixes focus styling for CTA language links
- Fixes logo in language modal when Dark Mode theme is on
- Removes closing the language modal when clicking in background
- Changes colour of Cookie notice in Dark Mode

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
