### PR TITLE
feat: prompt to add payment info if needed (resolves #1648)

### DIFF
--- a/app/Policies/EngagementPolicy.php
+++ b/app/Policies/EngagementPolicy.php
@@ -146,6 +146,7 @@ class EngagementPolicy
     {
         return $user->can('requestToJoin', $engagement)
             && $engagement->confirmedParticipants->count() < $engagement->ideal_participants
+            && (! $engagement->paid || $user->individual?->paymentTypes()->count() > 0 || ! blank($user->individual->other_payment_type))
                 ? Response::allow()
                 : Response::deny();
     }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2273,6 +2273,7 @@
     "You must enter your organization name.": "You must enter your organization name.",
     "You must enter your organization name in either English or French.": "You must enter your organization name in either English or French.",
     "You must fill out the field “About your organization”.": "You must fill out the field “About your organization”.",
+    "You must fill out your [payment information](:url) before you can sign up.": "You must fill out your [payment information](:url) before you can sign up.",
     "You must identify who will be going through the results from this project and writing a report.": "You must identify who will be going through the results from this project and writing a report.",
     "You must indicate at least one way for participants to attend the meeting.": "You must indicate at least one way for participants to attend the meeting.",
     "You must indicate if the reports will be publicly available.": "You must indicate if the reports will be publicly available.",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -2273,6 +2273,7 @@
     "You must enter your organization name.": "Vous devez saisir le nom de votre organisation.",
     "You must enter your organization name in either English or French.": "Vous devez saisir le nom de votre organisation en anglais ou en français.",
     "You must fill out the field “About your organization”.": "Vous devez remplir le champ « À propos de votre organisation ».",
+    "You must fill out your [payment information](:url) before you can sign up.": "",
     "You must identify who will be going through the results from this project and writing a report.": "You must identify who will be going through the results from this project and writing a report.",
     "You must indicate at least one way for participants to attend the meeting.": "Vous devez indiquer au moins un moyen pour les personnes participantes de se joindre à la réunion.",
     "You must indicate if the reports will be publicly available.": "You must indicate if the reports will be publicly available.",

--- a/resources/lang/lsq.json
+++ b/resources/lang/lsq.json
@@ -2273,6 +2273,7 @@
     "You must enter your organization name.": "Vous devez saisir le nom de votre organisation.",
     "You must enter your organization name in either English or French.": "Vous devez saisir le nom de votre organisation en anglais ou en français.",
     "You must fill out the field “About your organization”.": "Vous devez remplir le champ « À propos de votre organisation ».",
+    "You must fill out your [payment information](:url) before you can sign up.": "",
     "You must identify who will be going through the results from this project and writing a report.": "You must identify who will be going through the results from this project and writing a report.",
     "You must indicate at least one way for participants to attend the meeting.": "Vous devez indiquer au moins un moyen pour les personnes participantes de se joindre à la réunion.",
     "You must indicate if the reports will be publicly available.": "You must indicate if the reports will be publicly available.",

--- a/resources/views/engagements/show.blade.php
+++ b/resources/views/engagements/show.blade.php
@@ -59,13 +59,21 @@
             </dl>
 
             @can('requestToJoin', $engagement)
-                <div class="flex flex-col">
+                <div class="stack flex flex-col">
                     <a class="cta mx-auto" href="{{ localized_route('engagements.sign-up', $engagement) }}"
-                        @if ($engagement->confirmedParticipants->count() >= $engagement->ideal_participants) @ariaDisabled aria-describedby="engagement-full-explanation" @endif>
+                        @cannot('join', $engagement) @ariaDisabled aria-describedby="engagement-full-explanation" @endcannot>
                         @svg('heroicon-o-clipboard-check') {{ __('Sign up') }}
                     </a>
                     @if ($engagement->confirmedParticipants->count() >= $engagement->ideal_participants)
                         <p id="engagement-full-explanation">{{ __('All participant spots have been filled.') }}</p>
+                    @elseif ($engagement->paid &&
+                        (auth()->user()->individual?->paymentTypes()->count() === 0 &&
+                            blank(auth()->user()->individual?->other_payment_type)))
+                        <p id="engagement-full-explanation">{!! Str::inlineMarkdown(
+                            __('You must fill out your [payment information](:url) before you can sign up.', [
+                                'url' => localized_route('settings.edit-payment-information'),
+                            ]),
+                        ) !!}</p>
                     @endif
                 </div>
             @endcan

--- a/tests/Feature/EngagementContractorsAndParticipantsTest.php
+++ b/tests/Feature/EngagementContractorsAndParticipantsTest.php
@@ -2,8 +2,10 @@
 
 use App\Models\AccessSupport;
 use App\Models\Engagement;
+use App\Models\Individual;
 use App\Models\Invitation;
 use App\Models\Organization;
+use App\Models\PaymentType;
 use App\Models\User;
 use App\Notifications\AccessNeedsFacilitationRequested;
 use App\Notifications\IndividualContractorInvited;
@@ -15,10 +17,12 @@ use App\Notifications\ParticipantInvited;
 use App\Notifications\ParticipantJoined;
 use App\Notifications\ParticipantLeft;
 use Database\Seeders\IdentitySeeder;
+use Database\Seeders\PaymentTypeSeeder;
 use Illuminate\Support\Carbon;
 
 beforeEach(function () {
     $this->seed(IdentitySeeder::class);
+    $this->seed(PaymentTypeSeeder::class);
 
     $this->engagement = Engagement::factory()->create(['recruitment' => 'connector', 'signup_by_date' => Carbon::now()->add(1, 'month')->format('Y-m-d')]);
     $this->project = $this->engagement->project;
@@ -44,7 +48,8 @@ beforeEach(function () {
 
     $this->participantUser = User::factory()->create();
     $this->participantUser->individual->update(['roles' => ['participant'], 'region' => 'NS', 'locality' => 'Bridgewater']);
-    $this->participant = $this->participantUser->individual->fresh();
+    $this->participantUser->individual->paymentTypes()->attach(PaymentType::first());
+    $this->participant = $this->participantUser->individual->refresh();
 
     $this->participantOrganization = Organization::factory()->create(['roles' => ['participant'], 'published_at' => now(), 'region' => 'AB', 'locality' => 'Medicine Hat']);
     $this->participantOrganizationUser = User::factory()->create(['context' => 'organization']);
@@ -605,6 +610,20 @@ test('individual participant cannot sign up to an engagement if participant list
     $response->assertForbidden();
 });
 
+test('individual participant cannot sign up to a paid engagement if their payment information is not available', function () {
+    $noPaymentUser = User::factory()->create();
+    $noPaymentUser->individual->update(['roles' => ['participant'], 'region' => 'NS', 'locality' => 'Bridgewater']);
+
+    $this->engagement->update(['recruitment' => 'open-call']);
+    $this->engagement->refresh();
+
+    $response = $this->actingAs($noPaymentUser)->get(localized_route('engagements.sign-up', $this->engagement));
+    $response->assertForbidden();
+
+    $response = $this->actingAs($noPaymentUser)->from(localized_route('engagements.sign-up', $this->engagement))->post(localized_route('engagements.join', $this->engagement));
+    $response->assertForbidden();
+});
+
 test('individual can sign up to open call engagement', function () {
     Notification::fake();
 
@@ -671,6 +690,44 @@ test('individual can sign up to open call engagement', function () {
     $engagement_individual = $this->engagement->participants->first()->pivot;
     expect($engagement_individual->status)->toBeTruthy();
     expect($engagement_individual->share_access_needs)->toBeFalsy();
+});
+
+test('individual can sign up to a volunteer engagement without their payment information set', function () {
+    $noPaymentUser = User::factory()->create();
+    $noPaymentUser->individual->update(['roles' => ['participant'], 'region' => 'NS', 'locality' => 'Bridgewater']);
+
+    $this->engagement->update([
+        'recruitment' => 'open-call',
+        'paid' => false,
+    ]);
+    $this->engagement->refresh();
+
+    $response = $this->actingAs($noPaymentUser)->get(localized_route('engagements.sign-up', $this->engagement));
+    $response->assertOk();
+
+    $response = $this->actingAs($noPaymentUser)->from(localized_route('engagements.sign-up', $this->engagement))->post(localized_route('engagements.join', $this->engagement));
+    $response->assertRedirect(localized_route('engagements.confirm-access-needs', $this->engagement));
+});
+
+test('individual can sign up to a paid engagement with other payment information', function () {
+    $otherPaymentUser = User::factory()->create();
+    $otherPaymentUser->individual->update([
+        'roles' => ['participant'],
+        'region' => 'NS',
+        'locality' => 'Bridgewater',
+        'other_payment_type' => 'Money Order',
+    ]);
+
+    $this->engagement->update([
+        'recruitment' => 'open-call',
+    ]);
+    $this->engagement->refresh();
+
+    $response = $this->actingAs($otherPaymentUser)->get(localized_route('engagements.sign-up', $this->engagement));
+    $response->assertOk();
+
+    $response = $this->actingAs($otherPaymentUser)->from(localized_route('engagements.sign-up', $this->engagement))->post(localized_route('engagements.join', $this->engagement));
+    $response->assertRedirect(localized_route('engagements.confirm-access-needs', $this->engagement));
 });
 
 test('individual can edit their access needs when signing up to an open call engagement', function () {


### PR DESCRIPTION
Resolves #1648

- Prevents sign up to paid open calls if the participant hasn't filled out their payment settings

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
