### PR TITLE
fix: "Other" access needs not showing up (resolves #1638)

### DIFF
--- a/resources/views/engagements/access-needs-permissions.blade.php
+++ b/resources/views/engagements/access-needs-permissions.blade.php
@@ -29,10 +29,17 @@
                 <li class="border border-x-0 border-b-0 border-solid border-t-graphite-6 pt-5">{{ $support->name }}
                 </li>
             @empty
-                <li class="border border-x-0 border-b-0 border-solid border-t-graphite-6 pt-5">
-                    {{ __('No access needs found.') }}
-                </li>
+                @if (blank(Auth::user()->individual->other_access_need))
+                    <li class="border border-x-0 border-b-0 border-solid border-t-graphite-6 pt-5">
+                        {{ __('No access needs found.') }}
+                    </li>
+                @endif
             @endforelse
+            @unless(blank(Auth::user()->individual->other_access_need))
+                <li class="border border-x-0 border-b-0 border-solid border-t-graphite-6 pt-5">
+                    {{ Auth::user()->individual->other_access_need }}
+                </li>
+            @endunless
         </ul>
 
         <form class="mt-12 flex flex-row gap-6"

--- a/resources/views/engagements/confirm-access-needs.blade.php
+++ b/resources/views/engagements/confirm-access-needs.blade.php
@@ -21,9 +21,17 @@
             @forelse(Auth::user()->individual->accessSupports as $support)
                 <li class="border border-x-0 border-b-0 border-solid border-t-graphite-6 pt-5">{{ $support->name }}</li>
             @empty
-                <li class="border border-x-0 border-b-0 border-solid border-t-graphite-6 pt-5">
-                    {{ __('No access needs found.') }}</li>
+                @if (blank(Auth::user()->individual->other_access_need))
+                    <li class="border border-x-0 border-b-0 border-solid border-t-graphite-6 pt-5">
+                        {{ __('No access needs found.') }}
+                    </li>
+                @endif
             @endforelse
+            @unless(blank(Auth::user()->individual->other_access_need))
+                <li class="border border-x-0 border-b-0 border-solid border-t-graphite-6 pt-5">
+                    {{ Auth::user()->individual->other_access_need }}
+                </li>
+            @endunless
         </ul>
 
         <div class="grid">

--- a/resources/views/engagements/manage-access-needs.blade.php
+++ b/resources/views/engagements/manage-access-needs.blade.php
@@ -55,6 +55,27 @@
                         </tr>
                     @endunless
                 @endforeach
+                @foreach ($otherAccessNeeds as $otherAccessNeed)
+                    <tr>
+                        <td>{{ $otherAccessNeed }}</td>
+                        <td>
+                            <ul role="list">
+                                @foreach ($participants as $participant)
+                                    @if ($participant->other_access_need === $otherAccessNeed)
+                                        <li>
+                                            @if ($participant->pivot->share_access_needs)
+                                                <a
+                                                    href="{{ localized_route('engagements.manage-participants', $engagement) }}#participant-{{ $participant->id }}">{{ $participant->name }}</a>
+                                            @else
+                                                {{ __('Anonymous participant') }}
+                                            @endif
+                                        </li>
+                                    @endif
+                                @endforeach
+                            </ul>
+                        </td>
+                    </tr>
+                @endforeach
             </table>
         </div>
     </div>


### PR DESCRIPTION
Resolves #1638 

- Treats other access needs as a non-anonymizable access need for confirmation flow in engagement sign up
- other access needs are displayed in the engagements manage participants page along with the other access needs

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
