### PR TITLE
fix: link to CC projects showing for AC only users (resolves #1678)

### DIFF
--- a/resources/views/dashboard/individual.blade.php
+++ b/resources/views/dashboard/individual.blade.php
@@ -1,8 +1,6 @@
 <div class="with-sidebar with-sidebar:2/3">
     <x-quick-links>
-        @if ($user->individual->isConnector() ||
-            $user->individual->isConsultant() ||
-            $user->individual->inProgressContractedProjects()->count())
+        @if ($user->individual->isConnector() || $user->individual->isConsultant())
             <li>
                 @if ($user->individual->checkStatus('published'))
                     <a href="{{ localized_route('individuals.show', $user->individual) }}">{{ __('My public page') }}</a>
@@ -11,13 +9,15 @@
                         href="{{ localized_route('individuals.edit', $user->individual) }}">{{ __('Edit my public page') }}</a>
                 @endif
             </li>
-            @can('viewAny', App\Models\Project::class)
+        @endif
+        @can('viewAny', App\Models\Project::class)
+            @if ($user->individual->isConnector() || $user->individual->inProgressContractedProjects()->count())
                 <li>
                     <a
                         href="{{ localized_route('projects.my-contracted-projects') }}">{{ __('Projects involved in as a Community Connector') }}</a>
                 </li>
-            @endcan
-        @endif
+            @endif
+        @endcan
         @if (!$user->oriented_at)
             <li>
                 <a href="{{ orientation_link($user->context) }}">{{ __('Sign up for an orientation session') }}</a>

--- a/resources/views/dashboard/organization.blade.php
+++ b/resources/views/dashboard/organization.blade.php
@@ -26,9 +26,7 @@
             </li>
         @endif
         @can('viewAny', App\Models\Project::class)
-            @if ($memberable->isConnector() ||
-                $memberable->isConsultant() ||
-                $memberable->inProgressContractedProjects()->count())
+            @if ($memberable->isConnector() || $memberable->inProgressContractedProjects()->count())
                 <li>
                     <a
                         href="{{ localized_route('projects.my-contracted-projects') }}">{{ __('Projects involved in as a Community Connector') }}</a>


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1678 

If an individual or community org user only has an AC role, the Quick Link to the Community Connector related projects is only shown if they are still participating in a project as a community connector (e.g. if they were added as a CC before their role was changed to AC only).

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
