### PR TITLE
fix: engagements missing on project page for admin (resolves #1691)

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -107,7 +107,7 @@ class ProjectController extends Controller
         return view('projects.show', [
             'language' => $language ?? locale(),
             'project' => $project,
-            'engagements' => $user->can('manage', $project) ? $project->allEngagements : $project->engagements,
+            'engagements' => $user->can('manage', $project) || $user->isAdministrator() ? $project->allEngagements : $project->engagements,
         ]);
     }
 

--- a/app/Policies/EngagementPolicy.php
+++ b/app/Policies/EngagementPolicy.php
@@ -36,8 +36,14 @@ class EngagementPolicy
             ]));
         }
 
-        // Drafts cannot be viewed.
+        // Previewable drafts can be viewed by their team members or platform administrators.
         if ($engagement->checkStatus('draft')) {
+            if ($engagement->isPreviewable()) {
+                return $user->isMemberOf($engagement->project->projectable) || $user->isAdministrator()
+                    ? Response::allow()
+                    : Response::denyAsNotFound();
+            }
+
             return Response::denyAsNotFound();
         }
 

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2154,6 +2154,7 @@
     "You are now able to publish your page and take part in consultations.": "You are now able to publish your page and take part in consultations.",
     "You are now able to sign up for projects.": "You are now able to sign up for projects.",
     "You are previewing your": "You are previewing your",
+    "You are previewing your engagement page.": "You are previewing your engagement page.",
     "You are previewing your organization’s page.": "You are previewing your organization’s page.",
     "You are previewing your project page.": "You are previewing your project page.",
     "You are previewing your public page.": "You are previewing your public page.",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -2154,6 +2154,7 @@
     "You are now able to publish your page and take part in consultations.": "Vous êtes maintenant en mesure de publier votre page et de participer à des consultations.",
     "You are now able to sign up for projects.": "You are now able to sign up for projects.",
     "You are previewing your": "You are previewing your",
+    "You are previewing your engagement page.": "",
     "You are previewing your organization’s page.": "Vous prévisualisez actuellement la page de votre organisation.",
     "You are previewing your project page.": "Vous prévisualisez actuellement la page de votre projet.",
     "You are previewing your public page.": "Vous prévisualisez actuellement votre page publique.",

--- a/resources/lang/lsq.json
+++ b/resources/lang/lsq.json
@@ -2154,6 +2154,7 @@
     "You are now able to publish your page and take part in consultations.": "Vous êtes maintenant en mesure de publier votre page et de participer à des consultations.",
     "You are now able to sign up for projects.": "You are now able to sign up for projects.",
     "You are previewing your": "You are previewing your",
+    "You are previewing your engagement page.": "",
     "You are previewing your organization’s page.": "Vous prévisualisez actuellement la page de votre organisation.",
     "You are previewing your project page.": "Vous prévisualisez actuellement la page de votre projet.",
     "You are previewing your public page.": "Vous prévisualisez actuellement votre page publique.",

--- a/resources/views/engagements/edit.blade.php
+++ b/resources/views/engagements/edit.blade.php
@@ -6,7 +6,7 @@
             <li><a
                     href="{{ localized_route('projects.show', $engagement->project) }}">{{ $engagement->project->name }}</a>
             </li>
-            <li><a href="{{ localized_route('engagements.show', $engagement) }}">{{ $engagement->name }}</a></li>
+            <li><a href="{{ localized_route('engagements.manage', $engagement) }}">{{ $engagement->name }}</a></li>
         </ol>
         <h1>
             {{ __('Edit engagement details') }}

--- a/resources/views/engagements/manage.blade.php
+++ b/resources/views/engagements/manage.blade.php
@@ -88,7 +88,7 @@
                                         __(
                                             'You have completed your engagement details, **but you won’t be able to publish them until you [get an estimate](:get_estimate) for this project and approve it**.',
                                             [
-                                                'get_estimate' => localized_route('projects.manage', $project),
+                                                'get_estimate' => localized_route('projects.manage-estimates-and-agreements', $project),
                                             ],
                                         ),
                                     ) !!}

--- a/resources/views/engagements/show.blade.php
+++ b/resources/views/engagements/show.blade.php
@@ -8,6 +8,11 @@
                 <x-banner type="error" icon="heroicon-s-ban">{{ __('This account has been suspended.') }}</x-banner>
             @endpush
         @endif
+        @if ($engagement->checkStatus('draft'))
+            @push('banners')
+                <x-banner type="warning" icon="">{{ __('You are previewing your engagement page.') }}</x-banner>
+            @endpush
+        @endif
         <ol class="breadcrumbs" role="list">
             <li><a href="{{ localized_route('projects.my-projects') }}">{{ __('My projects') }}</a></li>
             <li>


### PR DESCRIPTION
Resolves #1691 

- Draft Engagements are visible for Org and Site admins
- Fixed link to "get estimate" from engagement page
- Fixed breadcrumb from edit engagement details back to engagement. Was going to 404 page

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
