### PR TITLE
fix: call to function isConsultant() on null (resolves #1710)

### DIFF
--- a/app/Http/Controllers/UserProjectsController.php
+++ b/app/Http/Controllers/UserProjectsController.php
@@ -6,14 +6,23 @@ use App\Enums\ProjectInvolvement;
 use App\Enums\UserContext;
 use App\Models\User;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 
 class UserProjectsController extends Controller
 {
-    public function show(): Response|View
+    public function show(): Response|View|RedirectResponse
     {
         $user = Auth::user();
+
+        if ($user->context === UserContext::Organization->value && ! $user->organization) {
+            return redirect(localized_route('organizations.show-type-selection'));
+        }
+
+        if ($user->context === UserContext::RegulatedOrganization->value && ! $user->regulatedOrganization) {
+            return redirect(localized_route('regulated-organizations.show-type-selection'));
+        }
 
         if ($user->regulated_organization) {
             $projectable = $user->regulated_organization;
@@ -80,7 +89,7 @@ class UserProjectsController extends Controller
     {
         $user = Auth::user();
 
-        if (in_array($user->context, [UserContext::Organization->value, UserContext::RegulatedOrganization->value])) {
+        if (in_array($user->context, [UserContext::Organization->value, UserContext::RegulatedOrganization->value]) && $user->{$user->context}) {
             return view('projects.my-projects', [
                 'user' => $user,
                 'projectable' => $user->regulated_organization ?? $user->organization,

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -267,6 +267,31 @@ test('users can view projects', function () {
     $response->assertOk();
 });
 
+test('incomplete users cannot view projects page', function ($context, $redirectRoute) {
+    $user = User::factory()->create(['context' => $context]);
+
+    $response = $this->actingAs($user)->get(localized_route('projects.my-projects'));
+    $response->assertRedirect(localized_route($redirectRoute));
+
+    $response = $this->actingAs($user)->get(localized_route('projects.my-contracted-projects'));
+    $response->assertNotFound();
+
+    $response = $this->actingAs($user)->get(localized_route('projects.my-participating-projects'));
+    $response->assertNotFound();
+
+    $response = $this->actingAs($user)->get(localized_route('projects.my-running-projects'));
+    $response->assertNotFound();
+})->with([
+    'organization context' => [
+        'organization',
+        'organizations.show-type-selection',
+    ],
+    'regulated-organization context' => [
+        'regulated-organization',
+        'regulated-organizations.show-type-selection',
+    ],
+]);
+
 test('notifications can be routed for projects', function () {
     $project = Project::factory()->create([
         'contact_person_name' => faker()->name(),


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1710 

If user has an organization/regulated-organization context but no attached org/fro the projects page will redirect back to the type selection page. The projects/running page will return a 404 as the other sub pages do.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
