### PR TITLE
1721 automate the push from GitHub to gitlab

### DIFF
--- a/.github/workflows/mirror-dev.yml
+++ b/.github/workflows/mirror-dev.yml
@@ -27,5 +27,5 @@ jobs:
 
       - name: Push to GitLab
         run: |
-          ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
+          ssh-keyscan git.kube.v1.colab.coop >> ~/.ssh/known_hosts
           git push --atomic gitlab dev:development

--- a/.github/workflows/mirror-dev.yml
+++ b/.github/workflows/mirror-dev.yml
@@ -1,0 +1,36 @@
+name: Mirror branches to GitLab
+
+on:
+  push:
+    branches:
+      - dev
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - dev
+  repository:
+    paths:
+      - 'accessibility-exchange/platform/**'
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "${{ vars.GIT_USER }}"
+          git config --global user.email "${{ vars.GIT_EMAIL }}"
+          git remote add gitlab ${{ vars.GITLAB_URL }}
+
+      - name: Push to GitLab
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.GITLAB_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
+          git push gitlab HEAD:development

--- a/.github/workflows/mirror-dev.yml
+++ b/.github/workflows/mirror-dev.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   mirror:
-    if: github.repository == 'accessibility-exchange/platform'
+    # if: github.repository == 'accessibility-exchange/platform'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/mirror-dev.yml
+++ b/.github/workflows/mirror-dev.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   mirror:
-    # if: github.repository == 'accessibility-exchange/platform'
+    if: github.repository == 'accessibility-exchange/platform'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/mirror-dev.yml
+++ b/.github/workflows/mirror-dev.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - dev
-    tags:
-      - '*'
-  pull_request:
-    branches:
-      - dev
 
 jobs:
   mirror:
@@ -31,4 +26,4 @@ jobs:
           echo "${{ secrets.GITLAB_SSH_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
-          git push gitlab HEAD:development
+          git push --atomic gitlab dev:development

--- a/.github/workflows/mirror-dev.yml
+++ b/.github/workflows/mirror-dev.yml
@@ -20,10 +20,12 @@ jobs:
           git config --global user.email "${{ vars.GIT_EMAIL }}"
           git remote add gitlab ${{ vars.GITLAB_URL }}
 
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+            ssh-private-key: ${{ secrets.GITLAB_SSH_KEY }}
+
       - name: Push to GitLab
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.GITLAB_SSH_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
           ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
           git push --atomic gitlab dev:development

--- a/.github/workflows/mirror-production.yml
+++ b/.github/workflows/mirror-production.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - production
-    tags:
-      - '*'
-  pull_request:
-    branches:
-      - production
 
 jobs:
   mirror:
@@ -25,10 +20,12 @@ jobs:
           git config --global user.email "${{ vars.GIT_EMAIL }}"
           git remote add gitlab ${{ vars.GITLAB_URL }}
 
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+            ssh-private-key: ${{ secrets.GITLAB_SSH_KEY }}
+
       - name: Push to GitLab
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.GITLAB_SSH_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
           ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
-          git push gitlab HEAD:production
+          git push gitlab production:production

--- a/.github/workflows/mirror-production.yml
+++ b/.github/workflows/mirror-production.yml
@@ -27,5 +27,5 @@ jobs:
 
       - name: Push to GitLab
         run: |
-          ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
+          ssh-keyscan git.kube.v1.colab.coop >> ~/.ssh/known_hosts
           git push gitlab production:production

--- a/.github/workflows/mirror-production.yml
+++ b/.github/workflows/mirror-production.yml
@@ -1,14 +1,14 @@
-name: Mirror dev to GitLab
+name: Mirror production to GitLab
 
 on:
   push:
     branches:
-      - dev
+      - production
     tags:
       - '*'
   pull_request:
     branches:
-      - dev
+      - production
 
 jobs:
   mirror:
@@ -31,4 +31,4 @@ jobs:
           echo "${{ secrets.GITLAB_SSH_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
-          git push gitlab HEAD:development
+          git push gitlab HEAD:production

--- a/.github/workflows/mirror-staging.yml
+++ b/.github/workflows/mirror-staging.yml
@@ -27,5 +27,5 @@ jobs:
 
       - name: Push to GitLab
         run: |
-          ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
+          ssh-keyscan git.kube.v1.colab.coop >> ~/.ssh/known_hosts
           git push gitlab staging:staging

--- a/.github/workflows/mirror-staging.yml
+++ b/.github/workflows/mirror-staging.yml
@@ -1,14 +1,14 @@
-name: Mirror dev to GitLab
+name: Mirror staging to GitLab
 
 on:
   push:
     branches:
-      - dev
+      - staging
     tags:
       - '*'
   pull_request:
     branches:
-      - dev
+      - staging
 
 jobs:
   mirror:
@@ -31,4 +31,4 @@ jobs:
           echo "${{ secrets.GITLAB_SSH_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
-          git push gitlab HEAD:development
+          git push gitlab HEAD:staging

--- a/.github/workflows/mirror-tags.yml
+++ b/.github/workflows/mirror-tags.yml
@@ -1,9 +1,9 @@
-name: Mirror staging to GitLab
+name: Mirror tags to GitLab
 
 on:
   push:
-    branches:
-      - staging
+    tags:
+      - '*'
 
 jobs:
   mirror:
@@ -25,7 +25,7 @@ jobs:
         with:
             ssh-private-key: ${{ secrets.GITLAB_SSH_KEY }}
 
-      - name: Push to GitLab
+      - name: Push tags to GitLab
         run: |
           ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
-          git push gitlab staging:staging
+          git push --atomic gitlab --tags

--- a/.github/workflows/mirror-tags.yml
+++ b/.github/workflows/mirror-tags.yml
@@ -27,5 +27,5 @@ jobs:
 
       - name: Push tags to GitLab
         run: |
-          ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
+          ssh-keyscan git.kube.v1.colab.coop >> ~/.ssh/known_hosts
           git push --atomic gitlab --tags


### PR DESCRIPTION
## Description
This pull request adds a GitHub Actions workflows to mirror the `dev`, `staging` & `production` branch and tags to GitLab.

## Changes Made
- Created a new GitHub Actions workflow file: `.github/workflows/mirror-dev.yml`.
- Created a new GitHub Actions workflow file: `.github/workflows/mirror-staging.yml`.
- Created a new GitHub Actions workflow file: `.github/workflows/mirror-production.yml`.
- Added a workflow to mirror the  `dev`, `staging` & `production` branch and tags to GitLab.
- Restricted the workflow to run only on the `accessibility-exchange/platform` repository.

## Testing
- Tested the workflow on a fork to ensure it successfully mirrors the branches to GitLab without limit for repository.
- After adding limit for repository made sure it doesn't work on fork.
- Verified that tags are mirrored as well.

## Checklist
- [x] The workflow file is located in the correct directory: `.github/workflows/mirror-staging.yml`.
- [x] The workflow is correctly restricted to the `accessibility-exchange/platform` repository.
- [ ] Git global user name and email are correctly set.
- [ ] The GitLab remote URL is correctly configured.
- [ ] SSH key setup is working and allows pushing to GitLab.
- [ ] The workflow has been tested and verified for successful execution
