### PR TITLE
fix: branches not pushed to gitlab (resolves #1745)

### DIFF
--- a/.github/workflows/mirror-dev.yml
+++ b/.github/workflows/mirror-dev.yml
@@ -12,7 +12,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Git
         run: |
@@ -28,4 +30,4 @@ jobs:
       - name: Push to GitLab
         run: |
           ssh-keyscan git.kube.v1.colab.coop >> ~/.ssh/known_hosts
-          git push --atomic gitlab dev:development
+          git push gitlab dev:development

--- a/.github/workflows/mirror-production.yml
+++ b/.github/workflows/mirror-production.yml
@@ -12,7 +12,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Git
         run: |

--- a/.github/workflows/mirror-staging.yml
+++ b/.github/workflows/mirror-staging.yml
@@ -12,7 +12,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Git
         run: |

--- a/.github/workflows/mirror-tags.yml
+++ b/.github/workflows/mirror-tags.yml
@@ -12,7 +12,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Git
         run: |
@@ -28,4 +30,4 @@ jobs:
       - name: Push tags to GitLab
         run: |
           ssh-keyscan git.kube.v1.colab.coop >> ~/.ssh/known_hosts
-          git push --atomic gitlab --tags
+          git push gitlab --tags


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1745 

- Removes atomic pushes as pushes all contain a single operation
- Fetches the complete history for mirroring instead of just the last sha.

### Prerequisites

If this PR changes PHP code or dependencies:

- [ ] I've run `composer format` and fixed any code formatting issues.
- [ ] I've run `composer analyze` and addressed any static analysis issues.
- [ ] I've run `php artisan test` and ensured that all tests pass.
- [ ] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
