### PR TITLE
fix: translation manager doesn't open (resolves #1758)

### DIFF
--- a/resources/views/components/expander.blade.php
+++ b/resources/views/components/expander.blade.php
@@ -1,6 +1,6 @@
-@props(['level', 'summary' => '', 'type' => null])
-<div {{ $attributes->class(['expander stack', 'expander--disclosure' => $type === 'disclosure']) }}
-    x-data="{ expanded: false }">
+@props(['level', 'summary' => '', 'type' => null, 'expanded' => 'false'])
+<div {{ $attributes->class(['expander stack', 'expander--disclosure' => $type === 'disclosure'])->whereDoesntStartWith('x-data') }}
+    x-data="{ expanded: {{ $expanded }} }">
     <x-heading class="title" :level="$level">
         <button type="button" x-bind:aria-expanded="expanded.toString()" x-on:click="expanded = !expanded">
             <span>{{ $summary }}</span>

--- a/resources/views/components/language-switcher.blade.php
+++ b/resources/views/components/language-switcher.blade.php
@@ -3,7 +3,7 @@
         @svg('tae-language', 'icon--2xl') <span>{{ __('hearth::nav.languages') }}</span>
     </x-slot>
 
-    <x-slot name="content" x-data>
+    <x-slot name="content">
         @foreach ($locales as $key => $locale)
             <li>
                 <x-nav-link hreflang="{{ get_written_language_for_signed_language($key) }}" rel="alternate"

--- a/resources/views/components/theme-preview.blade.php
+++ b/resources/views/components/theme-preview.blade.php
@@ -1,4 +1,4 @@
-<svg @if ($for === 'system') x-data x-bind:data-theme="window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'" x-bind:style="if(window.matchMedia('(prefers-color-scheme: light)').matches) {
+<svg @if ($for === 'system') x-bind:data-theme="window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'" x-bind:style="if(window.matchMedia('(prefers-color-scheme: light)').matches) {
     return '--theme-body-color: var(--color-graphite-7); --theme-body-background: var(--color-grey-1);';
 }" @endif
     {{ $attributes->merge([

--- a/resources/views/components/translation-manager.blade.php
+++ b/resources/views/components/translation-manager.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <x-expander level="2" :summary="__('Edit page translations')" x-data>
+    <x-expander level="2" :summary="__('Edit page translations')">
         @foreach ($model->languages as $language)
             <div x-data="modal()">
                 <p class="repel">{{ get_language_exonym($language) }}@if (count($model->languages) > 1)

--- a/resources/views/engagements/show-language-selection.blade.php
+++ b/resources/views/engagements/show-language-selection.blade.php
@@ -27,7 +27,7 @@
         novalidate>
         <x-translation-picker />
 
-        <p class="repel" x-data>
+        <p class="repel">
             <a class="cta secondary" href="{{ localized_route('projects.manage', $project) }}">{{ __('Cancel') }}</a>
             <button>{{ __('Next') }}</button>
         </p>

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -16,7 +16,7 @@
             <x-translatable-input name="name" :label="__('Project name') . ' ' . __('(required)')" :short-label="__('project name')" :model="new App\Models\Project()" />
         </fieldset>
 
-        <p class="repel" x-data>
+        <p class="repel">
             <a class="cta secondary"
                 href="{{ localized_route('projects.show-language-selection') }}">{{ session()->has('ancestor') ? __('Back') : __('Cancel') }}</a>
             <button>{{ __('Create') }}</button>

--- a/resources/views/projects/show-language-selection.blade.php
+++ b/resources/views/projects/show-language-selection.blade.php
@@ -24,7 +24,7 @@
         </h2>
         <x-translation-picker />
 
-        <p class="repel" x-data>
+        <p class="repel">
             <a class="cta secondary"
                 href="{{ session()->has('ancestor') ? localized_route('projects.show-context-selection') : localized_route('dashboard') }}">{{ session()->has('ancestor') ? __('Back') : __('Cancel') }}</a>
             <button>{{ __('Next') }}</button>


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1758 

- Removes spurious `x-data` properties.
- Updates the expander blade component to have an `expanded` attribute and to ignore `x-data` attributes. This will prevent its own `x-data` from accidentally being over-written but also give the option to start the component in the expanded state.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
