### PR TITLE
fix: individual page validation messages (resolves #1751, #1752)

### DIFF
--- a/app/Http/Requests/UpdateIndividualRequest.php
+++ b/app/Http/Requests/UpdateIndividualRequest.php
@@ -64,14 +64,14 @@ class UpdateIndividualRequest extends FormRequest
     public function attributes(): array
     {
         return [
-            'bio.*' => __('bio'),
+            'region' => __('province or territory'),
         ];
     }
 
     public function messages(): array
     {
         $messages = [
-            'bio.*.required_without' => 'You must enter your :attribute.',
+            'bio.*.required_without' => 'You must enter your bio.',
         ];
 
         foreach ($this->social_links as $key => $value) {


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1751 
Resolves #1752 

- Single validation message for missing bio
- Replace "region" with "provinces and territories" in validation message for missing region

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
