### PR TITLE
build(config): :wrench: updated mysql configuration for development t…

### DIFF
--- a/.kube/db/values.development.yaml
+++ b/.kube/db/values.development.yaml
@@ -1,0 +1,52 @@
+primary:
+  persistence:
+    size: 10Gi
+  configuration: |-
+    [mysqld]
+    basedir=/opt/bitnami/mysql
+    bind-address=0.0.0.0
+    character-set-server=UTF8
+    collation-server=utf8_general_ci
+    datadir=/bitnami/mysql/data
+    default_authentication_plugin=mysql_native_password
+    explicit_defaults_for_timestamp
+    innodb_buffer_pool_size=1G
+    innodb_doublewrite=1
+    innodb_flush_log_at_trx_commit=1
+    innodb_flush_method=O_DIRECT
+    innodb_lock_wait_timeout=100
+    innodb_log_buffer_size=16M
+    innodb_max_dirty_pages_pct=80
+    innodb_thread_concurrency=0
+    log-error=/opt/bitnami/mysql/logs/mysqld.log
+    long_query_time=20.0
+    max_allowed_packet=16M
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+    port=3306
+    skip-name-resolve
+    slow_query_log=1
+    slow_query_log_file=/opt/bitnami/mysql/logs/mysqld.log
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    table_definition_cache=2048
+    table_open_cache=512
+    tmpdir=/opt/bitnami/mysql/tmp
+    [client]
+    default-character-set=UTF8
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    [manager]
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+secondary:
+  persistence:
+    size: 10Gi
+### Place those values in Vault
+# auth:
+#   database: ""
+#   username: ""
+#   password: ""
+#   rootPassword: ""
+#   replicationPassword: ""


### PR DESCRIPTION
To try and log which transactions are running slow and creating lock timeouts we are 
* Enables slow logging. 
* Doubles value for `innodb_lock_wait_timeout` to mitigate the error from occurring.

These settings will specifically only be deployed to just the development environment.
