### PR TITLE
fix: no error for invalid engagement date ranges (resolves #1777)

### DIFF
--- a/app/Http/Requests/UpdateEngagementRequest.php
+++ b/app/Http/Requests/UpdateEngagementRequest.php
@@ -41,24 +41,28 @@ class UpdateEngagementRequest extends FormRequest
                 Rule::excludeIf($this->engagement->format !== 'interviews'),
                 Rule::requiredIf($this->engagement->format === 'interviews'),
                 'date',
+                'before:window_end_date',
             ],
             'window_end_date' => [
                 'nullable',
                 Rule::excludeIf($this->engagement->format !== 'interviews'),
                 Rule::requiredIf($this->engagement->format === 'interviews'),
                 'date',
+                'after:window_start_date',
             ],
             'window_start_time' => [
                 'nullable',
                 Rule::excludeIf($this->engagement->format !== 'interviews'),
                 Rule::requiredIf($this->engagement->format === 'interviews'),
                 'date_format:G:i',
+                'before:window_end_time',
             ],
             'window_end_time' => [
                 'nullable',
                 Rule::excludeIf($this->engagement->format !== 'interviews'),
                 Rule::requiredIf($this->engagement->format === 'interviews'),
                 'date_format:G:i',
+                'after:window_start_time',
             ],
             'timezone' => [
                 'nullable',
@@ -164,12 +168,14 @@ class UpdateEngagementRequest extends FormRequest
                 Rule::excludeIf(! in_array($this->engagement->format, ['interviews', 'survey', 'other-async'])),
                 Rule::requiredIf(in_array($this->engagement->format, ['interviews', 'survey', 'other-async'])),
                 'date',
+                'before:complete_by_date',
             ],
             'complete_by_date' => [
                 'nullable',
                 Rule::excludeIf(! in_array($this->engagement->format, ['interviews', 'survey', 'other-async'])),
                 Rule::requiredIf(in_array($this->engagement->format, ['interviews', 'survey', 'other-async'])),
                 'date',
+                'after:materials_by_date',
             ],
             'document_languages' => [
                 'nullable',
@@ -232,6 +238,14 @@ class UpdateEngagementRequest extends FormRequest
 
         $validator->sometimes('other_accepted_format.fr', 'required_without:other_accepted_format.en', function ($input) {
             return ! $input->other_accepted_formats === false;
+        });
+
+        $validator->sometimes('signup_by_date', 'before:window_start_date', function ($input) {
+            return ! blank($input->window_start_date);
+        });
+
+        $validator->sometimes('signup_by_date', 'before:materials_by_date', function ($input) {
+            return ! blank($input->materials_by_date);
         });
     }
 

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -342,6 +342,7 @@ test('users with regulated organization admin role can edit engagements', functi
         'materials_by_date' => '2022-11-01',
         'complete_by_date' => '2022-11-15',
         'accepted_formats' => ['writing', 'audio', 'video'],
+        'signup_by_date' => '2022-10-31',
     ]));
 
     $response->assertSessionHasNoErrors();


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1777 

- validates that start dates come before end dates
- validates that start times come before end times
- validates that sign up date comes before start time

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
