### PR TITLE
ci(deploy): added different path for views cache (resolves #1762)

### DIFF
--- a/.kube/app/entrypoint.sh
+++ b/.kube/app/entrypoint.sh
@@ -8,7 +8,7 @@ mkdir -p $FILES_PATH
 # mkdir -p $CACHE_PATH removed per https://github.com/accessibility-exchange/platform/issues/1596
 
 ## fix permissions before syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1226
-chown -R www-data:root /app/storage /app/bootstrap/cache $FILES_PATH # $CACHE_PATH removed per https://github.com/accessibility-exchange/platform/issues/1596
+chown -R www-data:root /app/storage /app/bootstrap/cache $FILES_PATH $VIEW_COMPILED_PATH # $CACHE_PATH removed per https://github.com/accessibility-exchange/platform/issues/1596
 
 ## sync files from container storage to permanent storage then remove container storage
 rsync -a /app/storage/ $FILES_PATH

--- a/.kube/app/values.development.yaml
+++ b/.kube/app/values.development.yaml
@@ -18,6 +18,8 @@ env:
   SESSION_LIFETIME: "120"
   SAIL_XDEBUG_MODE: "develop,debug,coverage"
   FILES_PATH: "/opt/data/storage"
+  VIEW_COMPILED_PATH: "/app/bootstrap/views"
+
   # CACHE_PATH: "/opt/data/cache" removed per https://github.com/accessibility-exchange/platform/issues/1596
 ### Place those values in Vault
 # secrets:

--- a/.kube/app/values.production.yaml
+++ b/.kube/app/values.production.yaml
@@ -23,6 +23,7 @@ env:
   SESSION_LIFETIME: "120"
   SAIL_XDEBUG_MODE: "develop,debug,coverage"
   FILES_PATH: "/opt/data/storage"
+  VIEW_COMPILED_PATH: "/app/bootstrap/views"
   # CACHE_PATH: "/opt/data/cache" removed per https://github.com/accessibility-exchange/platform/issues/1596
 ### Place those values in Vault
 # secrets:

--- a/.kube/app/values.staging.yaml
+++ b/.kube/app/values.staging.yaml
@@ -18,6 +18,7 @@ env:
   SESSION_LIFETIME: "120"
   SAIL_XDEBUG_MODE: "develop,debug,coverage"
   FILES_PATH: "/opt/data/storage"
+  VIEW_COMPILED_PATH: "/app/bootstrap/views"
   # CACHE_PATH: "/opt/data/cache" removed per https://github.com/accessibility-exchange/platform/issues/1596
 ### Place those values in Vault
 # secrets:


### PR DESCRIPTION
Revised the path for the views cache to be outside the shared storage folder. It will now be created from the environment variable `VIEW_COMPILED_PATH`.

* [x] Tested re-deploying on local version and the views were cached appropriately in the new path.
* [x] Added new variables to the environments `values.yml` files so that the path will be changes when merges happen.
* [x] Created path to make sure there isn't a path missing error.
* [x] Made sure ownership is adjusted by entrypoint.