### PR TITLE
fix: validation error adding page translation lang (resolves #1770)

### DIFF
--- a/app/Http/Requests/UpdateEngagementLanguagesRequest.php
+++ b/app/Http/Requests/UpdateEngagementLanguagesRequest.php
@@ -17,7 +17,7 @@ class UpdateEngagementLanguagesRequest extends FormRequest
         return [
             'languages' => 'required|array|min:1',
             'languages.*' => [
-                Rule::in(array_keys(get_available_languages())),
+                Rule::in(array_keys(get_available_languages(true, false))),
             ],
         ];
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -43,9 +43,8 @@ if (! function_exists('get_available_languages')) {
                 $languages,
                 function ($language) {
                     return
-                        (! str_starts_with($language, 'en') && ! str_starts_with($language, 'fr'))
-                        || ! strpos($language, '_')
-                        || in_array($language, [
+                        ! ((str_starts_with($language, 'en_') || str_starts_with($language, 'fr_')))
+                        && ! in_array($language, [
                             'ase',
                             'egy',
                             'grc',

--- a/tests/Unit/LanguageHelpersTest.php
+++ b/tests/Unit/LanguageHelpersTest.php
@@ -21,12 +21,29 @@ test('get available languages', function () {
 test('get all available languages', function () {
     $languages = get_available_languages(true);
 
-    expect(array_shift($languages))->toEqual('English');
-    expect(array_shift($languages))->toEqual('American Sign Language');
-
     expect($languages)->toHaveKey('es');
+    expect($languages)->toHaveKey('asl');
+    expect($languages)->toHaveKey('lsq');
+    expect(isset($languages['ase']))->toBeFalse();
+    expect(isset($languages['egy']))->toBeFalse();
     expect(isset($languages['en_CA']))->toBeFalse();
     expect(isset($languages['fr_CA']))->toBeFalse();
+
+    expect(array_shift($languages))->toEqual('English');
+    expect(array_shift($languages))->toEqual('American Sign Language');
+});
+
+test('get all available unsigned languages', function () {
+    $languages = get_available_languages(true, false);
+
+    expect($languages)->toHaveKey('es');
+    expect(isset($languages['asl']))->toBeFalse();
+    expect(isset($languages['lsq']))->toBeFalse();
+    expect(isset($languages['en_CA']))->toBeFalse();
+    expect(isset($languages['fr_CA']))->toBeFalse();
+
+    expect(array_shift($languages))->toEqual('English');
+    expect(array_shift($languages))->toEqual('French');
 });
 
 test('get a signed language exonym', function () {


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1770 

- Corrects validation rule for engagement language
- Corrects available language helper to not include ASE, as ASL is used instead.
- Adds tests

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
