### PR TITLE
fix: all engagements showing up for platform admin (resolves #1779)

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -104,10 +104,18 @@ class ProjectController extends Controller
             $language = false;
         }
 
+        if ($user->can('manage', $project)) {
+            $engagements = $project->allEngagements;
+        } elseif ($user->isAdministrator()) {
+            $engagements = $project->allEngagements->filter(fn ($engagement) => $engagement->isPreviewable());
+        } else {
+            $engagements = $project->engagements;
+        }
+
         return view('projects.show', [
             'language' => $language ?? locale(),
             'project' => $project,
-            'engagements' => $user->can('manage', $project) || $user->isAdministrator() ? $project->allEngagements : $project->engagements,
+            'engagements' => $engagements,
         ]);
     }
 


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1779 

- Doesn't show not previewable engagements to platform admin
- Added tests
- Updated project tests to use values from enums

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
