### PR TITLE
fix: quiz result email contains markdown (resolve #1790)

### DIFF
--- a/resources/views/emails/quiz/results.blade.php
+++ b/resources/views/emails/quiz/results.blade.php
@@ -1,5 +1,5 @@
 <x-mail::message>
-    # {{ __('Quiz results') }}
+    <h1>{{ __('Quiz results') }}</h1>
 
     {{ __('Congratulations, :name!', ['name' => $name]) }}
     {{ __('You have successfully completed course :course and passed the quiz.', ['course' => $course]) }}


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolve #1790 

Replaces markdown syntax with HTML in email template for quiz results.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
