### PR TITLE
fix: remove unneeded CSRF token on resource collection search form

### DIFF
--- a/resources/views/resource-collections/index.blade.php
+++ b/resources/views/resource-collections/index.blade.php
@@ -12,7 +12,6 @@
     <x-section class="px-0" aria-labelledby="search">
         <h2 class="h4" id="search">{{ __('Search for resources') }}</h2>
         <form class="search" action="{{ localized_route('resources.index') }}" method="get">
-            @csrf
             <label class="visually-hidden" for="search">{{ __('Search') }}</label>
             <input id="search" name="search" type="search" />
             <button type="submit">{{ __('Search') }}</button>


### PR DESCRIPTION
@sbates-idrc identified the presence of an unneeded CSRF token in a search form. This PR removes it. 

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
