### PR TITLE
fix: remove unused spatie/valuestore package

### DIFF
--- a/app/Settings.php
+++ b/app/Settings.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace App;
-
-use Spatie\Valuestore\Valuestore;
-
-class Settings extends Valuestore
-{
-}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 
 if (! function_exists('settings')) {
     /**
-     * Retrieve a setting from the settings Valuestore.
+     * Retrieve a setting from the general settings table.
      *
      * @param  string|null  $key The setting key.
      * @param  mixed|null  $default A default value for the setting.

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "spatie/laravel-options": "^1.0",
         "spatie/laravel-schemaless-attributes": "^2.3",
         "spatie/laravel-translatable": "^6.0",
-        "spatie/valuestore": "^1.3",
         "staudenmeir/eloquent-has-many-deep": "^1.15",
         "staudenmeir/laravel-merged-relations": "^1.5",
         "symfony/http-foundation": "~6.2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e06d5b2e582a3d255583483c3f28f37",
+    "content-hash": "39982df0271629f34e5e8a0dd30bd5a6",
     "packages": [
         {
             "name": "akaunting/laravel-money",
@@ -8347,73 +8347,6 @@
             "time": "2022-08-23T07:15:15+00:00"
         },
         {
-            "name": "spatie/valuestore",
-            "version": "1.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/valuestore.git",
-                "reference": "29562273e843ff0967725f1e2cb946e5c029d606"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/valuestore/zipball/29562273e843ff0967725f1e2cb946e5c029d606",
-                "reference": "29562273e843ff0967725f1e2cb946e5c029d606",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.0|^8.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Spatie\\Valuestore\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Freek Van der Herten",
-                    "email": "freek@spatie.be",
-                    "homepage": "https://spatie.be",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Jolita Grazyte",
-                    "email": "jolita@spatie.be",
-                    "homepage": "https://spatie.be",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Easily store some values",
-            "homepage": "https://github.com/spatie/valuestore",
-            "keywords": [
-                "json",
-                "spatie",
-                "valuestore"
-            ],
-            "support": {
-                "issues": "https://github.com/spatie/valuestore/issues",
-                "source": "https://github.com/spatie/valuestore/tree/1.3.2"
-            },
-            "funding": [
-                {
-                    "url": "https://spatie.be/open-source/support-us",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/spatie",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-12-13T09:04:49+00:00"
-        },
-        {
             "name": "staudenmeir/eloquent-has-many-deep",
             "version": "v1.17",
             "source": {
@@ -15787,5 +15720,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Site settings were moved to the database in https://github.com/accessibility-exchange/platform/pull/1718. This PR finishes that task by removing the no longer used spatie/valuestore package.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
