### PR TITLE
fix: can change email to an existing email (resolves #1826)

### DIFF
--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -2,10 +2,11 @@
 
 namespace App\Actions\Fortify;
 
+use App\Rules\UniqueUserEmail;
 use App\Traits\UserEmailVerification;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\Rule;
+use Illuminate\Support\Str;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
 class UpdateUserProfileInformation implements UpdatesUserProfileInformation
@@ -25,12 +26,12 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
                 'string',
                 'email',
                 'max:255',
-                Rule::unique('users')->ignore($user->id),
+                new UniqueUserEmail($user->id),
             ],
         ])->validateWithBag('updateProfileInformation');
 
         if (
-            $input['email'] !== $user->email &&
+            Str::lower($input['email']) !== $user->email &&
             $user instanceof MustVerifyEmail
         ) {
             $this->updateVerifiedUser($user, $input['email']);

--- a/app/Http/Controllers/IndividualController.php
+++ b/app/Http/Controllers/IndividualController.php
@@ -31,6 +31,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 use Spatie\LaravelOptions\Options;
 
 class IndividualController extends Controller
@@ -307,7 +308,7 @@ class IndividualController extends Controller
 
         if (
             $data['email'] !== ''
-                && $data['email'] !== $user->email
+                && Str::lower($data['email']) !== $user->email
                 && $user instanceof MustVerifyEmail
         ) {
             $this->updateVerifiedUser($user, $data['email']);

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -30,6 +30,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 use Spatie\LaravelOptions\Options;
 
 class SettingsController extends Controller
@@ -196,7 +197,7 @@ class SettingsController extends Controller
         $individual = $user->individual;
 
         if (
-            isset($data['email']) && $data['email'] !== $user->email && $user instanceof MustVerifyEmail
+            isset($data['email']) && Str::lower($data['email']) !== $user->email && $user instanceof MustVerifyEmail
         ) {
             $this->updateVerifiedUser($user, $data['email']);
         }

--- a/app/Http/Requests/UpdateCommunicationAndConsultationPreferencesRequest.php
+++ b/app/Http/Requests/UpdateCommunicationAndConsultationPreferencesRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use App\Enums\ContactPerson;
 use App\Enums\EngagementFormat;
 use App\Enums\MeetingType;
+use App\Rules\UniqueUserEmail;
 use App\Traits\ConditionallyRequireContactMethods;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -32,7 +33,7 @@ class UpdateCommunicationAndConsultationPreferencesRequest extends FormRequest
                 'string',
                 'email',
                 'max:255',
-                Rule::unique('users')->ignore($this->user()->id),
+                new UniqueUserEmail($this->user()->id),
             ],
             'phone' => 'required_if:vrs,true|nullable|phone:CA',
             'vrs' => 'nullable|boolean',

--- a/app/Http/Requests/UpdateIndividualCommunicationAndConsultationPreferencesRequest.php
+++ b/app/Http/Requests/UpdateIndividualCommunicationAndConsultationPreferencesRequest.php
@@ -4,9 +4,9 @@ namespace App\Http\Requests;
 
 use App\Enums\ContactPerson;
 use App\Enums\MeetingType;
+use App\Rules\UniqueUserEmail;
 use App\Traits\ConditionallyRequireContactMethods;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Validator;
 
@@ -31,7 +31,7 @@ class UpdateIndividualCommunicationAndConsultationPreferencesRequest extends For
                 'string',
                 'email',
                 'max:255',
-                Rule::unique('users')->ignore($this->user()->id),
+                new UniqueUserEmail($this->user()->id),
             ],
             'phone' => 'required_if:vrs,true|nullable|phone:CA',
             'vrs' => 'nullable|boolean',

--- a/app/Rules/UniqueUserEmail.php
+++ b/app/Rules/UniqueUserEmail.php
@@ -8,9 +8,28 @@ use Illuminate\Support\Str;
 
 class UniqueUserEmail implements InvokableRule
 {
+    public $id;
+
+    public $idColumn;
+
+    // Can use the $id and $idColumn to define a model to ignore. Similar to how Laravel's unique validation rule works
+    // see: https://laravel.com/docs/9.x/validation#rule-unique
+    public function __construct(mixed $id = null, ?string $idColumn = null)
+    {
+        $this->id = $id;
+        $this->idColumn = $idColumn ?? 'id';
+    }
+
     public function __invoke($attribute, mixed $value, $fail): void
     {
-        if (User::whereBlind($attribute, $attribute.'_index', Str::lower($value))->exists()) {
+        $exists = User::whereBlind($attribute, $attribute.'_index', Str::lower($value))
+            ->when($this->id, function ($query, $role) {
+                $query->whereNot(function ($query) {
+                    $query->where($this->idColumn, $this->id);
+                });
+            })
+            ->exists();
+        if ($exists) {
             $fail(__('A user with this email already exists.'));
         }
     }


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1826 

- Updates the UniqueUserEmail custom rule to allow for specifying an id to ignore. Similar to how the unique laravel rule works.
- Uses the updated UniqueUserEmail rule in all places where emails are updated. Laravel's unique validation rule can't be used here because the e-mails are encrypted in the database.
- Note that tests weren't provided but I've filed a #1833 writing them. 

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
