### PR TITLE
fix: focus on secondary nav overlaps (resolves #1350, #1690)

### DIFF
--- a/resources/css/_tokens.css
+++ b/resources/css/_tokens.css
@@ -1,4 +1,4 @@
-/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 6/21/2023.
+/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2023-07-11.
     Tokens location: ./tailwind.config.js */
 :root {
     --space-0: 0;

--- a/resources/css/components/_navigation.css
+++ b/resources/css/components/_navigation.css
@@ -205,6 +205,10 @@ button.nav-button .indicator {
     z-index: 1;
 }
 
+.secondary .nav-link {
+    display: inline-block;
+}
+
 @media (min-width: 48rem) {
     .primary ul,
     .languages ul ul,

--- a/resources/views/about/partials/what-we-ask-for-navigation.blade.php
+++ b/resources/views/about/partials/what-we-ask-for-navigation.blade.php
@@ -1,5 +1,5 @@
 <nav class="secondary" aria-labelledby="what-we-ask-for">
-    <ul class="stack" role="list">
+    <ul role="list">
         <li>
             <x-nav-link :href="localized_route('about.individual-consultation-participants-what-we-ask-for')" :active="request()->localizedRouteIs('about.individual-consultation-participants-what-we-ask-for')">{{ __('Consultation Participants — Individual') }}
             </x-nav-link>

--- a/resources/views/settings/notifications/individual.blade.php
+++ b/resources/views/settings/notifications/individual.blade.php
@@ -1,7 +1,7 @@
 <div class="with-sidebar">
-    <nav class="stack" aria-labelledby="skip-to">
+    <nav class="secondary stack" aria-labelledby="skip-to">
         <h3 id="skip-to">{{ __('Skip to:') }}</h3>
-        <ul class="stack" role="list">
+        <ul role="list">
             <li>
                 <x-nav-link :href="'#' . Str::slug(__('Participating in engagements'))">{{ __('Participating in engagements') }}</x-nav-link>
             </li>

--- a/resources/views/settings/notifications/organization.blade.php
+++ b/resources/views/settings/notifications/organization.blade.php
@@ -1,7 +1,7 @@
 <div class="with-sidebar">
-    <nav class="stack" aria-labelledby="skip-to">
+    <nav class="secondary stack" aria-labelledby="skip-to">
         <h3 id="skip-to">{{ __('Skip to:') }}</h3>
-        <ul class="stack" role="list">
+        <ul role="list">
             <li>
                 <x-nav-link :href="'#' . Str::slug(__('Projects and engagements by other organizations'))">{{ __('Projects and engagements by other organizations') }}</x-nav-link>
             </li>

--- a/resources/views/settings/notifications/regulated-organization.blade.php
+++ b/resources/views/settings/notifications/regulated-organization.blade.php
@@ -1,7 +1,7 @@
 <div class="with-sidebar">
-    <nav class="stack" aria-labelledby="skip-to">
+    <nav class="secondary stack" aria-labelledby="skip-to">
         <h3 id="skip-to">{{ __('Skip to:') }}</h3>
-        <ul class="stack" role="list">
+        <ul role="list">
             <li>
                 <x-nav-link :href="'#' . Str::slug(__('Your projects and engagements'))">{{ __('Your projects and engagements') }}</x-nav-link>
             </li>


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1350
Resolves #1690 

- Sets secondary nav-links to have display `inline-block`
- Updates other secondary nav's to use the updated styling

### Prerequisites

If this PR changes PHP code or dependencies:

- [ ] I've run `composer format` and fixed any code formatting issues.
- [ ] I've run `composer analyze` and addressed any static analysis issues.
- [ ] I've run `php artisan test` and ensured that all tests pass.
- [ ] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
