### PR TITLE
fix: fro card throws an error without locality (resolves #1862)

### DIFF
--- a/resources/views/components/card/regulated-organization.blade.php
+++ b/resources/views/components/card/regulated-organization.blade.php
@@ -8,9 +8,13 @@
     </x-slot>
     <p><strong>{{ __('Federally regulated organization') }}</strong></p>
     <p>
-        <span class="font-semibold">{{ __('Sector:') }}</span>
-        {{ implode(', ',$model->sectors()->pluck('name')->toArray()) }}<br />
-        <span class="font-semibold">{{ __('Location') }}:</span> {{ $model->locality }},
-        {{ $model->display_region }}
+        @if ($model->sectors()->count())
+            <span class="font-semibold">{{ __('Sector:') }}</span>
+            {{ implode(', ',$model->sectors()->pluck('name')->toArray()) }}<br />
+        @endif
+        @isset($model->locality)
+            <span class="font-semibold">{{ __('Location') }}:</span> {{ $model->locality }},
+            {{ $model->display_region }}
+        @endisset
     </p>
 </x-card>


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resovles #1862 

- for FRO card, only show sectors if there are sectors attached
- for FRO card, only show location if locality set

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
