### PR TITLE
ci: use PCOV for code coverage, disable Xdebug

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   php-analyze:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [8.1]
 
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +25,8 @@ jobs:
       - uses: shivammathur/setup-php@v2
         if: steps.git-diff.outputs.diff
         with:
-          php-version: "8.1"
+          php-version: ${{ matrix.php }}
+          coverage: none
       - name: Cache Composer packages
         if: steps.git-diff.outputs.diff
         uses: actions/cache@v3

--- a/.github/workflows/asset-lint.yml
+++ b/.github/workflows/asset-lint.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   asset-lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [8.1]
 
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +26,8 @@ jobs:
       - uses: shivammathur/setup-php@v2
         if: steps.git-diff.outputs.diff
         with:
-          php-version: "8.1"
+          php-version: ${{ matrix.php }}
+          coverage: none
       - name: Cache Composer packages
         if: steps.git-diff.outputs.diff
         uses: actions/cache@v3

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   frontend-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [8.1]
 
     steps:
       - uses: actions/checkout@v3
@@ -26,7 +29,8 @@ jobs:
       - uses: shivammathur/setup-php@v2
         if: steps.git-diff.outputs.diff
         with:
-          php-version: "8.1"
+          php-version: ${{ matrix.php }}
+          coverage: none
       - name: Cache Composer packages
         if: steps.git-diff.outputs.diff
         uses: actions/cache@v3

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -30,6 +30,7 @@ jobs:
         if: steps.git-diff.outputs.diff
         with:
           php-version: ${{ matrix.php }}
+          coverage: pcov
       - name: Cache Composer packages
         if: steps.git-diff.outputs.diff
         uses: actions/cache@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   lighthouse-ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [8.1]
 
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +32,8 @@ jobs:
         if: steps.git-diff.outputs.diff
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: ${{ matrix.php }}
+          coverage: none
       - name: Cache Composer packages
         if: steps.git-diff.outputs.diff
         uses: actions/cache@v3

--- a/ray.php
+++ b/ray.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @see https://spatie.be/docs/ray/v1/configuration/laravel
+ */
+
 return [
     /*
      *  The host used to communicate with the Ray app.


### PR DESCRIPTION
This PR disables Xdebug for all GitHub Actions and enables PCOV for the action where code coverage is generated. This should speed things up a bit.