### PR TITLE
fix: deploy stops on livewire:discover not defined (resolves #1943)

### DIFF
--- a/app/Console/Commands/DeployLocal.php
+++ b/app/Console/Commands/DeployLocal.php
@@ -31,7 +31,6 @@ class DeployLocal extends Command
         $this->call('icons:cache');
         $this->call('event:cache');
         $this->call('optimize');
-        $this->call('livewire:discover');
 
         return 0;
     }


### PR DESCRIPTION
Resolves #1943 

- Removes the call to `livewire:discover` as it is no longer valid.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
