### PR TITLE
feat: display line breaks in long form user input (resolves #1850)

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -326,6 +326,13 @@ if (! function_exists('safe_inlineMarkdown')) {
     }
 }
 
+if (! function_exists('safe_nl2br')) {
+    function safe_nl2br(string $string, bool $use_xhtml = true): HtmlString
+    {
+        return new HtmlString(nl2br(htmlentities($string), $use_xhtml));
+    }
+}
+
 if (! function_exists('orientation_link')) {
     function orientation_link(string $userType): string
     {

--- a/resources/views/engagements/partials/details-in_person.blade.php
+++ b/resources/views/engagements/partials/details-in_person.blade.php
@@ -11,7 +11,7 @@
 
     @if ($meeting->directions)
         <div><span class="font-semibold">{{ __('Further directions') }}:</span>
-            {{ $meeting->directions }}
+            {{ safe_nl2br($meeting->directions) }}
         </div>
     @endif
 @else

--- a/resources/views/engagements/partials/details-phone.blade.php
+++ b/resources/views/engagements/partials/details-phone.blade.php
@@ -1,6 +1,6 @@
 @can('participate', $engagement)
     <p><strong>{{ __('Phone number:') }}</strong> {{ $meeting->meeting_phone->formatForCountry('CA') }}</p>
     @if ($meeting->additional_phone_information)
-        {{ $meeting->additional_phone_information }}
+        {{ safe_nl2br($meeting->additional_phone_information) }}
     @endif
 @endcan

--- a/resources/views/engagements/partials/details-web_conference.blade.php
+++ b/resources/views/engagements/partials/details-web_conference.blade.php
@@ -9,7 +9,7 @@
      </p>
      @if ($meeting->additional_video_information)
          <div><span class="font-semibold">{{ __('Additional information to join') }}:</span>
-             {{ $meeting->additional_video_information }}
+             {{ safe_nl2br($meeting->additional_video_information) }}
          </div>
      @endif
  @else

--- a/resources/views/engagements/show.blade.php
+++ b/resources/views/engagements/show.blade.php
@@ -110,7 +110,7 @@
     <div class="stack mb-12 w-full md:w-2/3">
         <h2>{{ __('Description') }}</h2>
 
-        {{ $engagement->description }}
+        {{ safe_nl2br($engagement->description) }}
 
         <hr class="divider--thick" />
 

--- a/resources/views/individuals/partials/about.blade.php
+++ b/resources/views/individuals/partials/about.blade.php
@@ -1,4 +1,4 @@
-{{ $individual->getWrittenTranslation('bio', $language) }}
+{{ safe_nl2br($individual->getWrittenTranslation('bio', $language)) }}
 
 <h3>
     {{ __('Languages :name uses', ['name' => $individual->first_name]) }}</h3>
@@ -45,8 +45,9 @@
         @endforeach
     </ul>
 
-    @if ($individual->hasConnections('indigenousConnections') ||
-        $individual->hasConnections('ethnoracialIdentityConnections'))
+    @if (
+        $individual->hasConnections('indigenousConnections') ||
+            $individual->hasConnections('ethnoracialIdentityConnections'))
         <h4>{{ __('Ethno-racial groups') }}</h4>
 
         <ul class="tags" role="list">
@@ -62,8 +63,7 @@
         </ul>
     @endif
 
-    @if ($individual->hasConnections('genderAndSexualityConnections') ||
-        $individual->hasConnections('statusConnections'))
+    @if ($individual->hasConnections('genderAndSexualityConnections') || $individual->hasConnections('statusConnections'))
         <h4>{{ __('Other identity groups') }}</h4>
 
         <ul class="tags" role="list">
@@ -96,8 +96,7 @@
         </ul>
     @endif
 
-    @if ($individual->connection_lived_experience === 'yes-all' ||
-        $individual->connection_lived_experience === 'yes-some')
+    @if ($individual->connection_lived_experience === 'yes-all' || $individual->connection_lived_experience === 'yes-some')
         <h3>{{ __('Does :name have lived experience of the people they can connect to?', ['name' => $individual->firstName]) }}
         </h3>
         {{-- TODO: add attribute getter for this --}}

--- a/resources/views/individuals/partials/experiences.blade.php
+++ b/resources/views/individuals/partials/experiences.blade.php
@@ -1,11 +1,11 @@
 @if ($individual->lived_experience)
     <h3>{{ __('Lived experience') }}</h3>
-    {{ $individual->getWrittenTranslation('lived_experience', $language) }}
+    {{ safe_nl2br($individual->getWrittenTranslation('lived_experience', $language)) }}
 @endif
 
 @if ($individual->skills_and_strengths)
     <h3>{{ __('Skills and strengths') }}</h3>
-    {{ $individual->getWrittenTranslation('skills_and_strengths', $language) }}
+    {{ safe_nl2br($individual->getWrittenTranslation('skills_and_strengths', $language)) }}
 @endif
 
 @if ($individual->relevant_experiences && count($individual->relevant_experiences) > 0)

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -41,7 +41,7 @@
                         </h3>
                         <p>{{ phone(settings('phone'), 'CA')->formatForCountry('CA') }}</p>
                         <h3>{{ __('Mailing Address') }}</h3>
-                        {!! nl2br(htmlentities(settings('address'))) !!}
+                        {{ safe_nl2br(settings('address')) }}
                     </address>
                 </div>
                 <nav class="stack" aria-labelledby="social">

--- a/resources/views/livewire/add-engagement-connector.blade.php
+++ b/resources/views/livewire/add-engagement-connector.blade.php
@@ -24,7 +24,7 @@
                         <x-interpretation name="{{ session('message-interpretation') }}"
                             namespace="add_engagement_connector" />
                     @endif
-                    {{ session('message') }}
+                    {{ safe_nl2br(session('message')) }}
                 </x-hearth-alert>
             @endif
         </div>

--- a/resources/views/livewire/admin-estimates-and-agreements.blade.php
+++ b/resources/views/livewire/admin-estimates-and-agreements.blade.php
@@ -22,7 +22,7 @@
                         <x-interpretation name="{{ session('message-interpretation') }}"
                             namespace="add_estimates_and_agreements" />
                     @endif
-                    {{ session('message') }}
+                    {{ safe_nl2br(session('message')) }}
                 </x-hearth-alert>
             @endif
         </div>

--- a/resources/views/livewire/manage-accounts.blade.php
+++ b/resources/views/livewire/manage-accounts.blade.php
@@ -21,7 +21,7 @@
                     @if (session()->has('message-interpretation'))
                         <x-interpretation name="{{ session('message-interpretation') }}" namespace="manage_accounts" />
                     @endif
-                    {{ session('message') }}
+                    {{ safe_nl2br(session('message')) }}
                 </x-hearth-alert>
             @endif
         </div>

--- a/resources/views/livewire/manage-engagement-connector.blade.php
+++ b/resources/views/livewire/manage-engagement-connector.blade.php
@@ -26,7 +26,7 @@
                         <x-interpretation name="{{ session('message-interpretation') }}"
                             namespace="manage_engagement_connector" />
                     @endif
-                    {{ session('message') }}
+                    {{ safe_nl2br(session('message')) }}
                 </x-hearth-alert>
             @endif
         </div>

--- a/resources/views/organizations/partials/about.blade.php
+++ b/resources/views/organizations/partials/about.blade.php
@@ -1,7 +1,7 @@
 <h3>{{ __('About the organization') }}</h3>
 <x-interpretation name="{{ __('About the organization', [], 'en') }}" />
 
-{{ $organization->getWrittenTranslation('about', $language) }}
+{{ safe_nl2br($organization->getWrittenTranslation('about', $language)) }}
 
 <h3>{{ __('Type of organization') }}</h3>
 <x-interpretation name="{{ __('Type of organization', [], 'en') }}" />

--- a/resources/views/projects/partials/overview.blade.php
+++ b/resources/views/projects/partials/overview.blade.php
@@ -1,7 +1,7 @@
 <h3>{{ __('Project goals') }}</h3>
 <x-interpretation name="{{ __('Project goals', [], 'en') }}" />
 
-{{ $project->getWrittenTranslation('goals', $language) }}
+{{ safe_nl2br($project->getWrittenTranslation('goals', $language)) }}
 
 <h3>{{ __('Engagements') }}</h3>
 <x-interpretation name="{{ __('Engagements', [], 'en') }}" />
@@ -24,7 +24,7 @@
 <x-interpretation
     name="{{ __('How the disability and Deaf communities will be impacted by the outcomes of this project', [], 'en') }}" />
 
-{{ $project->getWrittenTranslation('scope', $language) }}
+{{ safe_nl2br($project->getWrittenTranslation('scope', $language)) }}
 
 <h4>{{ __('Geographical areas this project will impact') }}</h4>
 <x-interpretation name="{{ __('Geographical areas this project will impact', [], 'en') }}" />
@@ -50,7 +50,7 @@
     <h4>{{ __('Not in this project') }}</h4>
     <x-interpretation name="{{ __('Not in this project', [], 'en') }}" />
 
-    {{ $project->getWrittenTranslation('out_of_scope', $language) }}
+    {{ safe_nl2br($project->getWrittenTranslation('out_of_scope', $language)) }}
 @endif
 
 <h3>{{ __('Project timeframe') }}</h3>
@@ -92,7 +92,7 @@
     <h4>{{ __('Tangible outcomes of this project') }}</h4>
     <x-interpretation name="{{ __('Tangible outcomes of this project', [], 'en') }}" />
 
-    {{ $project->getWrittenTranslation('outcomes', $language) }}
+    {{ safe_nl2br($project->getWrittenTranslation('outcomes', $language)) }}
 @endif
 
 <h4>{{ __('Project reports') }}</h4>

--- a/resources/views/projects/partials/team.blade.php
+++ b/resources/views/projects/partials/team.blade.php
@@ -29,7 +29,7 @@
     @endif
 
     @if ($project->consultant_responsibilities)
-        {{ $project->getWrittenTranslation('consultant_responsibilities', $language) }}
+        {{ safe_nl2br($project->getWrittenTranslation('consultant_responsibilities', $language)) }}
     @endif
 @endif
 

--- a/resources/views/regulated-organizations/partials/about.blade.php
+++ b/resources/views/regulated-organizations/partials/about.blade.php
@@ -1,6 +1,6 @@
 <h3>{{ __('About the organization') }}</h3>
 
-{{ $regulatedOrganization->getWrittenTranslation('about', $language) }}
+{{ safe_nl2br($regulatedOrganization->getWrittenTranslation('about', $language)) }}
 
 <h3>{{ __('Service areas') }}</h3>
 

--- a/tests/Unit/SafeNL2BRHelperTest.php
+++ b/tests/Unit/SafeNL2BRHelperTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\HtmlString;
+
+test('encoding of N2BL content', function (bool $use_xhmtl, string $input, string $output) {
+    $rendered = safe_nl2br($input, $use_xhmtl);
+    $expected = str_replace('%break%', $use_xhmtl ? '<br />' : '<br>', $output);
+
+    expect($rendered)->toBeInstanceOf(HtmlString::class);
+    expect(trim($rendered))->toEqual($expected);
+})->with([
+    'xhtml compatible breaks' => true,
+    'xhmtl incompatible breaks' => false,
+])->with([
+    'plain string' => [
+        'input' => 'Text',
+        'output' => 'Text',
+    ],
+    'new line' => [
+        'input' => 'Before
+                    After',
+        'output' => 'Before%break%
+                    After',
+    ],
+    'with HTML' => [
+        'input' => '<strong>Before</strong>
+                    After',
+        'output' => '&lt;strong&gt;Before&lt;/strong&gt;%break%
+                    After',
+    ],
+]);

--- a/tests/Unit/SafeNL2BRHelperTest.php
+++ b/tests/Unit/SafeNL2BRHelperTest.php
@@ -2,9 +2,9 @@
 
 use Illuminate\Support\HtmlString;
 
-test('encoding of N2BL content', function (bool $use_xhmtl, string $input, string $output) {
-    $rendered = safe_nl2br($input, $use_xhmtl);
-    $expected = str_replace('%break%', $use_xhmtl ? '<br />' : '<br>', $output);
+test('encoding of N2BL content', function (bool $use_xhtml, string $input, string $output) {
+    $rendered = safe_nl2br($input, $use_xhtml);
+    $expected = str_replace('%break%', $use_xhtml ? '<br />' : '<br>', $output);
 
     expect($rendered)->toBeInstanceOf(HtmlString::class);
     expect(trim($rendered))->toEqual($expected);


### PR DESCRIPTION
Resolves #1850 

- Preserves the line breaks when output long form user input. These had been removed in #1727

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
