### PR TITLE
feat: prevent editing of page titles

### DIFF
--- a/app/Filament/Resources/PageResource/Pages/EditPage.php
+++ b/app/Filament/Resources/PageResource/Pages/EditPage.php
@@ -5,11 +5,43 @@ namespace App\Filament\Resources\PageResource\Pages;
 use App\Filament\Resources\PageResource;
 use App\Models\Page;
 use Filament\Actions;
+use Filament\Forms;
+use Filament\Forms\Form;
 use Filament\Resources\Pages\EditRecord;
 
 class EditPage extends EditRecord
 {
     protected static string $resource = PageResource::class;
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title.en')
+                    ->label(__('Page title').' ('.get_language_exonym('en').')')
+                    ->disabled(),
+                Forms\Components\TextInput::make('title.fr')
+                    ->label(__('Page title').' ('.get_language_exonym('fr').')')
+                    ->disabled(),
+                Forms\Components\MarkdownEditor::make('content.en')
+                    ->disableToolbarButtons(['attachFiles'])
+                    ->label(__('Content').' ('.get_language_exonym('en').')')
+                    ->helperText(__('The following values will be expanded in the output: ":home", ":email", ":tos" and ":privacy_policy". You may wrap these values in "<>" to display the URL itself.'))
+                    ->columnSpan(2),
+                Forms\Components\MarkdownEditor::make('content.fr')
+                    ->disableToolbarButtons(['attachFiles'])
+                    ->label(__('Content').' ('.get_language_exonym('fr').')')
+                    ->helperText(__('The following values will be expanded in the output: ":home", ":email", ":tos" and ":privacy_policy". You may wrap these values in "<>" to display the URL itself.'))
+                    ->columnSpan(2),
+            ]);
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        unset($data['title']);
+
+        return $data;
+    }
 
     protected function getHeaderActions(): array
     {


### PR DESCRIPTION
Once a page is created (see #1957), the title should not be editable. This disables the title fields on the edit view for pages and prevents the existing titles from being erased on form submission using the technique [described here](https://filamentphp.com/docs/3.x/panels/resources/editing-records#customizing-data-before-saving).

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
