### PR TITLE
ci(deploy): add command & queue to put site into maintenance and brin…

### DIFF
--- a/.kube/app/entrypoint.sh
+++ b/.kube/app/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+php artisan maintenance:queue
+
 # TODO permanent remove cache lines once testing on per/pod caching is tested
 
 mkdir -p $FILES_PATH
@@ -26,7 +28,7 @@ ln -s $FILES_PATH /app/storage
 
 php artisan deploy:local
 
-flock -n -E 0 /opt/data -c "php artisan deploy:global" # run exclusively on a single instance at once
+flock -n -E 0 /opt/data/deploy-global.lock -c "php artisan deploy:global" # run exclusively on a single instance at once
 
 ## fix permissions after syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1236
 chown -R www-data:root /app/bootstrap/cache $FILES_PATH # $CACHE_PATH removed per and added path to cache in the pod https://github.com/accessibility-exchange/platform/issues/1596

--- a/.kube/app/supervisord.conf
+++ b/.kube/app/supervisord.conf
@@ -24,3 +24,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:laravel-worker]
+command=php /app/artisan queue:work --force --sleep=30 --tries=3 --max-time=900
+autostart=true
+autorestart=false
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/.kube/app/values.development.yaml
+++ b/.kube/app/values.development.yaml
@@ -13,7 +13,7 @@ env:
   LOG_LEVEL: "debug"
   BROADCAST_DRIVER: "log"
   CACHE_DRIVER: "file"
-  QUEUE_CONNECTION: "sync"
+  QUEUE_CONNECTION: "redis"
   SESSION_DRIVER: "database"
   SESSION_LIFETIME: "120"
   SAIL_XDEBUG_MODE: "develop,debug,coverage"

--- a/.kube/app/values.production.yaml
+++ b/.kube/app/values.production.yaml
@@ -13,7 +13,7 @@ env:
   LOG_LEVEL: "debug"
   BROADCAST_DRIVER: "log"
   CACHE_DRIVER: "file"
-  QUEUE_CONNECTION: "sync"
+  QUEUE_CONNECTION: "redis"
   SESSION_DRIVER: "database"
   SESSION_LIFETIME: "120"
   SAIL_XDEBUG_MODE: "develop,debug,coverage"

--- a/.kube/app/values.staging.yaml
+++ b/.kube/app/values.staging.yaml
@@ -13,7 +13,7 @@ env:
   LOG_LEVEL: "debug"
   BROADCAST_DRIVER: "log"
   CACHE_DRIVER: "file"
-  QUEUE_CONNECTION: "sync"
+  QUEUE_CONNECTION: "redis"
   SESSION_DRIVER: "database"
   SESSION_LIFETIME: "120"
   SAIL_XDEBUG_MODE: "develop,debug,coverage"

--- a/.kube/app/values.yaml
+++ b/.kube/app/values.yaml
@@ -1,5 +1,5 @@
 name: "IRIS Accessibility Exchange"
-health: /
+health: /status/db
 cronjobs:
   - name: schedule
     schedule: "* * * * *"

--- a/app/Console/Commands/MaintenanceModeQueueCommand.php
+++ b/app/Console/Commands/MaintenanceModeQueueCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\BringSiteBackUp;
+use Illuminate\Console\Command;
+
+class MaintenanceModeQueueCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'maintenance:queue';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Put the site into maintenance mode and bring it back up after 5 minutes';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // Put the site into maintenance mode
+        $this->call('down');
+
+        // Schedule bringing the site back up after 5 minutes
+        BringSiteBackUp::dispatch()->delay(now()->addMinutes(5));
+
+        $this->info('The site is in maintenance mode. It will be brought back up in 5 minutes.');
+    }
+}

--- a/app/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/app/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -12,6 +12,7 @@ class PreventRequestsDuringMaintenance extends Middleware
      * @var array<int, string>
      */
     protected $except = [
-        //
+        'status',
+        'status/db',
     ];
 }

--- a/app/Jobs/BringSiteBackUp.php
+++ b/app/Jobs/BringSiteBackUp.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Artisan;
+
+class BringSiteBackUp implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        Artisan::call('up');
+    }
+}


### PR DESCRIPTION
Creates a method to put the site into maintenance mode during delpoyments and creates a delayed queue that will bring the site back up within a certain amount of time (5 minutes).

- Creates new command `maintenance:queue` that initiates putting the site into maintenance mode and initiating the delayed queue.
- Creates new queue **BringSiteBackUp** that brings the site out of maintenance mode.
- Added calling the command `maintenance:queue` at the start of the entrypoint.
- Added running the laravel queue worker for 15 minutes after the pod starts.
- Changed the `QUEUE_CONNECTION` from **sync** to **redis** this allows for delayed queues to occur.
