### PR TITLE
fix: sitemap command fails if pages table missing (resolves #1993)

### DIFF
--- a/.kube/app/entrypoint.sh
+++ b/.kube/app/entrypoint.sh
@@ -31,4 +31,7 @@ flock -n -E 0 /opt/data -c "php artisan deploy:global" # run exclusively on a si
 ## fix permissions after syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1236
 chown -R www-data:root /app/bootstrap/cache $FILES_PATH # $CACHE_PATH removed per and added path to cache in the pod https://github.com/accessibility-exchange/platform/issues/1596
 
+# Generate the robots.txt and sitemap.xml files
+php artisan seo:generate
+
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/app/Console/Commands/DeployLocal.php
+++ b/app/Console/Commands/DeployLocal.php
@@ -31,6 +31,5 @@ class DeployLocal extends Command
         $this->call('icons:cache');
         $this->call('event:cache');
         $this->call('optimize');
-        $this->call('seo:generate');
     }
 }

--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -6,6 +6,7 @@ use App\Models\Page;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 
 class GenerateSitemap extends Command
@@ -34,6 +35,7 @@ class GenerateSitemap extends Command
         $routes = ['/' => ['en' => 'en', 'asl' => 'asl', 'fr' => 'fr', 'lsq' => 'lsq']];
         // once deployed to the server, files have the same modified date, use README as a default last modified date
         $lastmod = ['default' => Carbon::createFromTimestamp(filemtime('./README.md'))->toISOString()];
+        $hasPages = Schema::hasTable('pages'); // Check if the Pages table exists.
         foreach (Route::getRoutes()->get('GET') as $route) {
             if ($route->named(config('seo.sitemap.patterns'))) {
                 $routeURI = $route->uri();
@@ -42,7 +44,7 @@ class GenerateSitemap extends Command
                     $routes[$url][$locale] = $routeURI;
                 } else {
                     $routes[$url] = [$locale => $routeURI];
-                    if ($route->named(config('seo.sitemap.pages'))) {
+                    if ($route->named(config('seo.sitemap.pages')) && $hasPages) {
                         $routeName = explode('.', $route->getName());
                         /*
                          * TODO: come up with better query for the page, as slug may not follow the pattern in route name


### PR DESCRIPTION
Resolves #1993 

- On deploy moves set generation to after the migrations have occurred
- In the sitemap generation checks if the pages table exists before trying to access it.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
