### PR TITLE
fix: robots and sitemap served at /storage path (resolves #1998)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /node_modules
 /public/hot
 /public/storage
+/public/robots.txt
+/public/sitemap.xml
 /storage/*.key
 /vendor
 .DS_Store

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -82,6 +82,8 @@ return [
 
     'links' => [
         public_path('storage') => storage_path('app/public'),
+        public_path('sitemap.xml') => storage_path('app/public/sitemap.xml'),
+        public_path('robots.txt') => storage_path('app/public/robots.txt'),
     ],
 
 ];

--- a/tests/Feature/Console/DeployLocalTest.php
+++ b/tests/Feature/Console/DeployLocalTest.php
@@ -2,37 +2,10 @@
 
 use function Pest\Laravel\artisan;
 
-beforeEach(function () {
-    $this->disk = Storage::disk('public');
-    $this->robots = 'robots.txt';
-    $this->robotsOriginal = 'robots.original.txt';
-    $this->sitemap = 'sitemap.xml';
-    $this->sitemapOriginal = 'sitemap.original.xml';
-
-    if ($this->disk->fileExists($this->robots)) {
-        Storage::disk('public')->move($this->robots, $this->robotsOriginal);
-    }
-
-    if ($this->disk->fileExists($this->sitemap)) {
-        Storage::disk('public')->move($this->sitemap, $this->sitemapOriginal);
-    }
-});
-
 afterEach(function () {
     artisan('optimize:clear');
     artisan('icons:clear');
     artisan('event:clear');
-
-    Storage::disk('public')->delete($this->robots);
-    Storage::disk('public')->delete($this->sitemap);
-
-    if ($this->disk->fileExists($this->robotsOriginal)) {
-        Storage::disk('public')->move($this->robotsOriginal, $this->robots);
-    }
-
-    if ($this->disk->fileExists($this->sitemapOriginal)) {
-        Storage::disk('public')->move($this->sitemapOriginal, $this->sitemap);
-    }
 });
 
 test('Completes successfully', function () {

--- a/tests/Feature/Console/GenerateSitemapTest.php
+++ b/tests/Feature/Console/GenerateSitemapTest.php
@@ -35,7 +35,7 @@ test('Generate sitemaps completes even if file already exists', function () {
 
     $this->disk->assertExists($this->sitemap);
 
-    artisan('seo:generate')->assertSuccessful();
+    artisan('seo:generate-sitemap')->assertSuccessful();
 
     $this->disk->assertExists($this->sitemap);
 });


### PR DESCRIPTION
Resolves #1998 

- Adds symlinks for the sitemap and robots files into the public directory
- Updates/cleans up tests

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
