### PR TITLE
fix: pagination throws error (resolves #2045)

### DIFF
--- a/resources/views/vendor/livewire/tailwind-custom.blade.php
+++ b/resources/views/vendor/livewire/tailwind-custom.blade.php
@@ -1,7 +1,5 @@
 <div>
     @if ($paginator->hasPages())
-        @php(isset($this->numberOfPaginatorsRendered[$paginator->getPageName()]) ? $this->numberOfPaginatorsRendered[$paginator->getPageName()]++ : ($this->numberOfPaginatorsRendered[$paginator->getPageName()] = 1))
-
         <nav class="flex flex-col items-center justify-between" role="navigation" aria-label="Pagination Navigation">
             <div class="w-full text-center" role="alert" aria-live="polite">
                 <p>
@@ -67,8 +65,7 @@
                         {{-- Array Of Links --}}
                         @if (is_array($element))
                             @foreach ($element as $page => $url)
-                                <li
-                                    wire:key="paginator-{{ $paginator->getPageName() }}-{{ $this->numberOfPaginatorsRendered[$paginator->getPageName()] }}-page{{ $page }}">
+                                <li wire:key="paginator-{{ $paginator->getPageName() }}-page{{ $page }}">
                                     <a href="{{ route(RalphJSmit\Livewire\Urls\Facades\Url::currentRoute(), ['page' => $page]) }}"
                                         wire:click.prevent="gotoPage({{ $page }}, '{{ $paginator->getPageName() }}')"
                                         @if ($page == $paginator->currentPage()) aria-current="page" @endif>


### PR DESCRIPTION
Resolves #2045 

Removes use of `numberOfPaginatorsRendered` as this was removed from Livewire 3.

See: https://github.com/livewire/livewire/commit/a81b6fd59e5ec961c5b154539e8ca91effde6a94

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.

BEGIN_COMMIT_OVERRIDE
fix: pagination throws error (resolves #2045) #2046
END_COMMIT_OVERRIDE
