### PR TITLE
fix: update LSQ locale's Translatable inputs default to English (resolves #1715)

### DIFF
--- a/app/View/Components/TranslatableInput.php
+++ b/app/View/Components/TranslatableInput.php
@@ -63,7 +63,7 @@ class TranslatableInput extends Component
     {
         $languages = $model->languages ?? config('locales.supported');
 
-        if (($key = array_search(locale(), $languages)) !== false) {
+        if (($key = array_search(get_written_language_for_signed_language(locale()), $languages)) !== false) {
             unset($languages[$key]);
             array_unshift($languages, locale());
         }

--- a/app/View/Components/TranslatableTextarea.php
+++ b/app/View/Components/TranslatableTextarea.php
@@ -63,7 +63,7 @@ class TranslatableTextarea extends Component
     {
         $languages = $model->languages ?? config('locales.supported');
 
-        if (($key = array_search(locale(), $languages)) !== false) {
+        if (($key = array_search(get_written_language_for_signed_language(locale()), $languages)) !== false) {
             unset($languages[$key]);
             array_unshift($languages, locale());
         }


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #1715; It seems like it was an issue with the languages array's order in TranslatableInput component. Languages array get passed down to translatable-input.blade, and we loop through the languages array to display the content. I noticed that languages array order is different for French and LSQ locales, and that's why we were getting different result from get_language_exonym($language) for the labels. 

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
