### PR TITLE
fix: duplicated error messages (resolves #1827)

### DIFF
--- a/resources/views/projects/edit/1.blade.php
+++ b/resources/views/projects/edit/1.blade.php
@@ -67,11 +67,9 @@
             <x-interpretation name="{{ __('Project start date', [], 'en') }}"
                 namespace="project_start_date-required" />
             <x-date-picker name="start_date" :label="__('Project start date') . ' ' . __('(required)')" :value="old('start_date', $project->start_date?->format('Y-m-d') ?? '')" />
-            <x-hearth-error for="start_date" />
 
             <x-interpretation name="{{ __('Project end date', [], 'en') }}" namespace="project_end_date-required" />
             <x-date-picker name="end_date" :label="__('Project end date') . ' ' . __('(required)')" :value="old('end_date', $project->end_date?->format('Y-m-d') ?? '')" />
-            <x-hearth-error for="end_date" />
 
             <h3>{{ __('Project outcome') }}</h3>
             <x-interpretation name="{{ __('Project outcome', [], 'en') }}" />


### PR DESCRIPTION
Resolves #1827 

- Removes extra calls to `<x-hearth-error>` as they are already included in the `<x-date-picker>`.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
