### PR TITLE
fix: participant should be first individual role (resolves #2064)

### DIFF
--- a/app/Enums/IndividualRole.php
+++ b/app/Enums/IndividualRole.php
@@ -4,16 +4,16 @@ namespace App\Enums;
 
 enum IndividualRole: string
 {
+    case ConsultationParticipant = 'participant';
     case AccessibilityConsultant = 'consultant';
     case CommunityConnector = 'connector';
-    case ConsultationParticipant = 'participant';
 
     public static function labels(): array
     {
         return [
+            'participant' => __('Consultation Participant'),
             'consultant' => __('Accessibility Consultant'),
             'connector' => __('Community Connector'),
-            'participant' => __('Consultation Participant'),
         ];
     }
 


### PR DESCRIPTION
Resolves #2064 

- Makes Consultation participant the first Individual role option.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
