### PR TITLE
fix: dashboard breaks with Invitation notification and site is using a signed language locale (resolves #2054)

### DIFF
--- a/database/seeders/data/Interpretations.json
+++ b/database/seeders/data/Interpretations.json
@@ -919,27 +919,27 @@
                 "namespace": "getting_started-regulated_org"
             },
             {
-                "name": "A new verification link has been sent to the email address you provided.",
+                "name": "hearth::auth.verification_sent",
                 "namespace": "flash_messages"
             },
             {
-                "name": "Your password has been changed.",
+                "name": "hearth::auth.password_change_succeeded",
                 "namespace": "flash_messages"
             },
             {
-                "name": "You have enabled two-factor authentication.",
+                "name": "hearth::user.two_factor_auth_enabled",
                 "namespace": "flash_messages"
             },
             {
-                "name": "New recovery codes have been generated.",
+                "name": "hearth::user.two_factor_auth_recovery_codes_regenerated",
                 "namespace": "flash_messages"
             },
             {
-                "name": "You have disabled two-factor authentication.",
+                "name": "hearth::user.two_factor_auth_disabled",
                 "namespace": "flash_messages"
             },
             {
-                "name": "Please verify your email address by clicking on the link we emailed to you. If you didn’t receive the email, we will gladly send you another.",
+                "name": "hearth::auth.verification_intro",
                 "namespace": "flash_messages",
                 "video": {
                     "asl": "https://vimeo.com/871064392/3644d6f659",
@@ -1322,7 +1322,7 @@
                 "namespace": "flash_messages"
             },
             {
-                "name": "Invite new member",
+                "name": "invitation.invitation_title",
                 "namespace": "invitation",
                 "video": {
                     "asl": "https://vimeo.com/861741196/2c099b1cbd",
@@ -2359,7 +2359,7 @@
                 "namespace": "preview_page"
             },
             {
-                "name": "Sorry, some errors were found in your submission. Please correct these errors and try again.",
+                "name": "hearth::forms.errors_found_message",
                 "namespace": "errors_found_message",
                 "video": {
                     "asl": "https://vimeo.com/871058145/3fbadf91a2",
@@ -3953,7 +3953,7 @@
                 "name": "Full name"
             },
             {
-                "name": "Email address",
+                "name": "hearth::forms.label_email",
                 "namespace": "label_email"
             },
             {
@@ -3964,11 +3964,11 @@
                 }
             },
             {
-                "name": "Password",
+                "name": "hearth::auth.label_password",
                 "namespace": "label_password"
             },
             {
-                "name": "Confirm password",
+                "name": "hearth::auth.label_password_confirmation",
                 "namespace": "label_password_confirmation"
             },
             {
@@ -3976,7 +3976,7 @@
                 "namespace": "back_create_account"
             },
             {
-                "name": "Sorry, something went wrong.",
+                "name": "hearth::auth.error_intro",
                 "namespace": "auth_validation_errors"
             }
         ]
@@ -4317,7 +4317,7 @@
                 "name": "Change password"
             },
             {
-                "name": "Two-factor authentication"
+                "name": "hearth::user.two_factor_auth"
             }
         ]
     },

--- a/resources/views/auth/register/steps/3.blade.php
+++ b/resources/views/auth/register/steps/3.blade.php
@@ -19,7 +19,7 @@
     <!-- Email Address -->
     <div class="field @error('email') field--error @enderror stack">
         <x-hearth-label for="email" :value="__('hearth::forms.label_email')" />
-        <x-interpretation name="{{ __('hearth::forms.label_email', [], 'en') }}" namespace="label_email" />
+        <x-interpretation name="hearth::forms.label_email" namespace="label_email" />
         <x-hearth-hint for="email">
             {{ __('This is the email address you will use to sign in to The Accessibility Exchange.') }}
         </x-hearth-hint>

--- a/resources/views/auth/register/steps/4.blade.php
+++ b/resources/views/auth/register/steps/4.blade.php
@@ -6,7 +6,7 @@
     <!-- Password -->
     <div class="field @error('password') field--error @enderror stack">
         <x-hearth-label for="password" :value="__('hearth::auth.label_password')" />
-        <x-interpretation name="{{ __('hearth::auth.label_password', [], 'en') }}" namespace="label_password" />
+        <x-interpretation name="hearth::auth.label_password" namespace="label_password" />
         <div class="field__hint" id="password-hint">
             <p>{{ __('For your security, please make sure your password has:') }}</p>
             <ul>
@@ -23,8 +23,7 @@
     <!-- Confirm Password -->
     <div class="field @error('password') field--error @enderror stack">
         <x-hearth-label for="password_confirmation" :value="__('hearth::auth.label_password_confirmation')" />
-        <x-interpretation name="{{ __('hearth::auth.label_password_confirmation', [], 'en') }}"
-            namespace="label_password_confirmation" />
+        <x-interpretation name="hearth::auth.label_password_confirmation" namespace="label_password_confirmation" />
         <x-password-input name="password_confirmation" />
         <x-hearth-error for="password" />
     </div>

--- a/resources/views/components/auth-card.blade.php
+++ b/resources/views/components/auth-card.blade.php
@@ -7,7 +7,7 @@
         @if (session('status') == 'verification-link-sent')
             <x-live-region>
                 <x-hearth-alert type="success">
-                    <x-interpretation name="{{ __('hearth::auth.verification_sent', [], 'en') }}" namespace="auth_card" />
+                    <x-interpretation name="hearth::auth.verification_sent" namespace="flash_messages" />
                     {{ __('hearth::auth.verification_sent') }}
                 </x-hearth-alert>
             </x-live-region>

--- a/resources/views/components/auth-validation-errors.blade.php
+++ b/resources/views/components/auth-validation-errors.blade.php
@@ -3,8 +3,7 @@
 @if ($errors->any())
     <x-live-region>
         <x-hearth-alert type="error">
-            <x-interpretation name="{{ __('hearth::auth.error_intro', [], 'en') }}"
-                namespace="auth_validation_errors" />
+            <x-interpretation name="hearth::auth.error_intro" namespace="auth_validation_errors" />
             {{ __('hearth::auth.error_intro') }}
             {{-- TODO: Break down errors, link to fields
                 <ul>

--- a/resources/views/components/invitation.blade.php
+++ b/resources/views/components/invitation.blade.php
@@ -1,6 +1,6 @@
 <div class="notification stack">
     <span class="notification-dot absolute left-10 top-14"></span>
     <p class="h4">{{ __('invitation.invitation_title') }}</p>
-    <x-interpretation name="{{ __('invitation.invitation_title', [], 'en') }}" namespace="invitation" />
+    <x-interpretation name="invitation.invitation_title" namespace="invitation" />
     {{ $slot }}
 </div>

--- a/resources/views/partials/flash-messages.blade.php
+++ b/resources/views/partials/flash-messages.blade.php
@@ -11,30 +11,28 @@
 
         @if (session('status') === 'verification-link-sent')
             <x-hearth-alert type="success">
-                <x-interpretation name="{{ __('hearth::auth.verification_sent', [], 'en') }}" namespace="flash_messages" />
+                <x-interpretation name="hearth::auth.verification_sent" namespace="flash_messages" />
                 <p>{{ __('hearth::auth.verification_sent') }}</p>
             </x-hearth-alert>
         @endif
 
         @if (session('status') === 'password-updated')
             <x-hearth-alert type="success">
-                <x-interpretation name="{{ __('hearth::auth.password_change_succeeded', [], 'en') }}"
-                    namespace="flash_messages" />
+                <x-interpretation name="hearth::auth.password_change_succeeded" namespace="flash_messages" />
                 <p>{{ __('hearth::auth.password_change_succeeded') }}</p>
             </x-hearth-alert>
         @endif
 
         @if (session('status') === 'two-factor-authentication-enabled')
             <x-hearth-alert type="success">
-                <x-interpretation name="{{ __('hearth::user.two_factor_auth_enabled', [], 'en') }}"
-                    namespace="flash_messages" />
+                <x-interpretation name="hearth::user.two_factor_auth_enabled" namespace="flash_messages" />
                 <p>{{ __('hearth::user.two_factor_auth_enabled') }}</p>
             </x-hearth-alert>
         @endif
 
         @if (session('status') === 'recovery-codes-generated')
             <x-hearth-alert type="success">
-                <x-interpretation name="{{ __('hearth::user.two_factor_auth_recovery_codes_regenerated', [], 'en') }}"
+                <x-interpretation name="hearth::user.two_factor_auth_recovery_codes_regenerated"
                     namespace="flash_messages" />
                 <p>{{ __('hearth::user.two_factor_auth_recovery_codes_regenerated') }}</p>
             </x-hearth-alert>
@@ -42,8 +40,7 @@
 
         @if (session('status') === 'two-factor-authentication-disabled')
             <x-hearth-alert type="success">
-                <x-interpretation name="{{ __('hearth::user.two_factor_auth_disabled', [], 'en') }}"
-                    namespace="flash_messages" />
+                <x-interpretation name="hearth::user.two_factor_auth_disabled" namespace="flash_messages" />
                 <p>{{ __('hearth::user.two_factor_auth_disabled') }}</p>
             </x-hearth-alert>
         @endif
@@ -51,7 +48,7 @@
         @auth
             @unless (Auth::user()->hasVerifiedEmail())
                 <x-hearth-alert type="notice" x-show="true" :dismissable="false">
-                    <x-interpretation name="{{ __('hearth::auth.verification_intro', [], 'en') }}" namespace="flash_messages" />
+                    <x-interpretation name="hearth::auth.verification_intro" namespace="flash_messages" />
                     <p>{{ __('hearth::auth.verification_intro') }}</p>
                     <form method="POST" action="{{ route('verification.send') }}">
                         @csrf

--- a/resources/views/partials/validation-errors.blade.php
+++ b/resources/views/partials/validation-errors.blade.php
@@ -3,8 +3,7 @@
         @foreach ($errors->getBags() as $bag)
             <x-hearth-alert type="error" :title="__('hearth::forms.errors_found')">
                 <p>{{ __('hearth::forms.errors_found_message') }}</p>
-                <x-interpretation name="{{ __('hearth::forms.errors_found_message', [], 'en') }}"
-                    namespace="errors_found_message" />
+                <x-interpretation name="hearth::forms.errors_found_message" namespace="errors_found_message" />
                 <ul>
                     @foreach ($bag->unique() as $error)
                         <li>{{ $error }}</li>

--- a/resources/views/settings/account-details.blade.php
+++ b/resources/views/settings/account-details.blade.php
@@ -76,7 +76,7 @@
     @if (Laravel\Fortify\Features::canManageTwoFactorAuthentication())
         <x-hearth-password-confirmation>
             <h2>{{ __('hearth::user.two_factor_auth') }}</h2>
-            <x-interpretation name="{{ __('hearth::user.two_factor_auth', [], 'en') }}" />
+            <x-interpretation name="hearth::user.two_factor_auth" />
 
             <p><em>{{ __('hearth::user.two_factor_auth_intro') }}</em></p>
 


### PR DESCRIPTION
Resolves #2054 

Handles interpretation names when the text is localized by short key.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
