### PR TITLE
fix: no validation error when accepted formats not entered (resolves #1830)

### DIFF
--- a/app/Http/Controllers/EngagementController.php
+++ b/app/Http/Controllers/EngagementController.php
@@ -397,6 +397,10 @@ class EngagementController extends Controller
     {
         $data = $request->validated();
 
+        if (empty($data['other_accepted_formats'])) {
+            $data['other_accepted_format'] = [];
+        }
+
         if (isset($data['window_start_time'])) {
             $window_start_time = Carbon::createFromTimeString($data['window_start_time'])->toTimeString();
             $data['window_start_time'] = $window_start_time;

--- a/app/Http/Requests/StoreEngagementRequest.php
+++ b/app/Http/Requests/StoreEngagementRequest.php
@@ -18,9 +18,9 @@ class StoreEngagementRequest extends FormRequest
     {
         return [
             'project_id' => 'required|exists:App\Models\Project,id',
-            'name.*' => 'nullable|string|max:255|unique_translation:engagements',
             'name.en' => 'required_without:name.fr|nullable|string|max:255',
             'name.fr' => 'required_without:name.en|nullable|string|max:255',
+            'name.*' => 'nullable|string|max:255|unique_translation:engagements',
             'who' => 'required|in:individuals,organization',
         ];
     }

--- a/app/Http/Requests/UpdateEngagementRequest.php
+++ b/app/Http/Requests/UpdateEngagementRequest.php
@@ -190,7 +190,6 @@ class UpdateEngagementRequest extends FormRequest
             'accepted_formats' => [
                 'nullable',
                 Rule::excludeIf($this->engagement->format !== 'interviews'),
-                Rule::requiredIf($this->engagement->format === 'interviews' && ! request('other_accepted_format')),
                 'array',
             ],
             'accepted_formats.*' => [
@@ -242,6 +241,10 @@ class UpdateEngagementRequest extends FormRequest
             return ! $input->other_accepted_formats === false;
         });
 
+        $validator->sometimes('other_accepted_formats', 'required_without:accepted_formats', function ($input) {
+            return $this->engagement->format === 'interviews';
+        });
+
         $validator->sometimes('signup_by_date', 'before:window_start_date', function ($input) {
             return ! blank($input->window_start_date);
         });
@@ -255,7 +258,6 @@ class UpdateEngagementRequest extends FormRequest
     {
         $fallbacks = [
             'accepted_formats' => [],
-            'other_accepted_formats' => false,
             'other_accepted_format' => [],
             'paid' => true,
         ];
@@ -265,8 +267,13 @@ class UpdateEngagementRequest extends FormRequest
             'meeting_url' => normalize_url($this->meeting_url),
         ]);
 
-        // Prepare old input in case of validation failure
-        request()->mergeIfMissing($fallbacks);
+        // Prevents the model values from coming back if the other accepted format options have been removed when a
+        // validation error occurs.
+        request()->mergeIfMissing([
+            'accepted_formats' => [],
+            'other_accepted_formats' => false,
+            'other_accepted_format' => [],
+        ]);
     }
 
     public function attributes(): array
@@ -351,6 +358,7 @@ class UpdateEngagementRequest extends FormRequest
             'accepted_formats.required' => __('You must indicate the :attribute.'),
             'accepted_formats.*.Illuminate\Validation\Rules\Enum' => __('You must select a valid format.'),
             'other_accepted_formats.required' => __('You must indicate the :attribute.'),
+            'other_accepted_formats.required_without' => __('You must indicate the :values.'),
             'other_accepted_format.*.string' => __('The other accepted format must be a string.'),
             'other_accepted_format.*.required_without' => __('The other accepted format must be provided in at least English or French.'),
             'meeting_types.*.Illuminate\Validation\Rules\Enum' => __('You must select a valid meeting type.'),

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2011,6 +2011,7 @@
     "You must indicate at least one way for participants to attend the meeting.": "You must indicate at least one way for participants to attend the meeting.",
     "You must indicate if the reports will be publicly available.": "You must indicate if the reports will be publicly available.",
     "You must indicate the :attribute.": "You must indicate the :attribute.",
+    "You must indicate the :values.": "You must indicate the :values.",
     "You must indicate who you want to engage.": "You must indicate who you want to engage.",
     "You must pick at least one of these roles.": "You must pick at least one of these roles.",
     "You must select a language.": "You must select a language.",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -2011,6 +2011,7 @@
     "You must indicate at least one way for participants to attend the meeting.": "Vous devez indiquer au moins un moyen pour les personnes participantes de se joindre à la réunion.",
     "You must indicate if the reports will be publicly available.": "Veuillez indiquer si les rapports seront accessibles au public.",
     "You must indicate the :attribute.": "Vous devez indiquer l’attribut :attribute.",
+    "You must indicate the :values.": "",
     "You must indicate who you want to engage.": "Vous devez indiquer qui vous voulez impliquer.",
     "You must pick at least one of these roles.": "Vous devez choisir au moins un de ces rôles.",
     "You must select a language.": "Vous devez sélectionner une langue.",

--- a/tests/Datasets/AddOrganizationValidationErrors.php
+++ b/tests/Datasets/AddOrganizationValidationErrors.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\Organization;
+
+dataset('addOrganizationValidationErrors', function () {
+    return [
+        'Organization id is missing' => [
+            'state' => ['organization_id' => null],
+            'errors' => fn () => ['organization_id' => __('validation.required', ['attribute' => __('organization.singular_name')])],
+        ],
+        'Organization id is invalid' => [
+            'state' => ['organization_id' => 1000000],
+            'errors' => fn () => ['organization_id' => __('validation.exists', ['attribute' => __('organization.singular_name')])],
+        ],
+        'Organization is not a participant' => [
+            'state' => fn () => ['organization_id' => Organization::factory()->create([
+                'name' => 'not a participant org',
+                'roles' => ['connector'],
+            ])->id],
+            'errors' => fn () => ['organization_id' => __('The organization you have added does not participate in engagements.')],
+        ],
+    ];
+});

--- a/tests/Datasets/InviteParticipantValidationErrors.php
+++ b/tests/Datasets/InviteParticipantValidationErrors.php
@@ -1,0 +1,26 @@
+<?php
+
+dataset('inviteParticipantValidationErrors', function () {
+    return [
+        'Email is missing' => [
+            'state' => ['email' => null],
+            'errors' => fn () => ['email' => __('You must enter an email address.')],
+        ],
+        'User already invited' => [
+            'state' => ['email' => 'invited@example.com'],
+            'errors' => fn () => ['email' => __('This individual has already been invited to your engagement.')],
+        ],
+        'User already added to engagement' => [
+            'state' => ['email' => 'existing@example.com'],
+            'errors' => fn () => ['email' => __('The individual with the email address you provided is already participating in this engagement.')],
+        ],
+        'User not a consultation participant' => [
+            'state' => ['email' => 'not-participant@example.com'],
+            'errors' => fn () => ['email' => __('The person with the email address you provided is not a consultation participant.')],
+        ],
+        'Email address not for an individual user' => [
+            'state' => ['email' => 'not-individual@example.com'],
+            'errors' => fn () => ['email' => __('The person with the email address you provided is not a consultation participant.')],
+        ],
+    ];
+});

--- a/tests/Datasets/StoreAccessNeedsPermissionsValidationErrors.php
+++ b/tests/Datasets/StoreAccessNeedsPermissionsValidationErrors.php
@@ -1,0 +1,14 @@
+<?php
+
+dataset('storeAccessNeedsPermissionsValidationErrors', function () {
+    return [
+        'Share access needs is missing' => [
+            'state' => [],
+            'errors' => fn () => ['share_access_needs' => __('validation.required', ['attribute' => __('share access needs')])],
+        ],
+        'Share access needs is not a boolean' => [
+            'state' => ['share_access_needs' => 123],
+            'errors' => fn () => ['share_access_needs' => __('validation.boolean', ['attribute' => __('share access needs')])],
+        ],
+    ];
+});

--- a/tests/Datasets/StoreEngagementFormatRequestValidationErrors.php
+++ b/tests/Datasets/StoreEngagementFormatRequestValidationErrors.php
@@ -1,0 +1,14 @@
+<?php
+
+dataset('storeEngagementFormatRequestValidationErrors', function () {
+    return [
+        'Format is missing' => [
+            'state' => ['format' => null],
+            'errors' => fn () => ['format' => __('validation.required', ['attribute' => __('engagement format')])],
+        ],
+        'Format is invalid' => [
+            'state' => ['format' => ['xyz']],
+            'errors' => fn () => ['format' => __('validation.exists', ['attribute' => __('engagement format')])],
+        ],
+    ];
+});

--- a/tests/Datasets/StoreEngagementLanguagesRequestValidationErrors.php
+++ b/tests/Datasets/StoreEngagementLanguagesRequestValidationErrors.php
@@ -1,0 +1,22 @@
+<?php
+
+dataset('storeEngagementLanguagesRequestValidationErrors', function () {
+    return [
+        'Languages is missing' => [
+            'state' => ['languages' => null],
+            'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('languages')])],
+        ],
+        'Languages is not an array' => [
+            'state' => ['languages' => false],
+            'errors' => fn () => ['languages' => __('validation.array', ['attribute' => __('languages')])],
+        ],
+        'Languages is empty' => [
+            'state' => ['languages' => []],
+            'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('languages')])],
+        ],
+        'Language is invalid' => [
+            'state' => ['languages' => ['xyz']],
+            'errors' => fn () => ['languages.0' => __('validation.exists', ['attribute' => __('languages')])],
+        ],
+    ];
+});

--- a/tests/Datasets/StoreEngagementRecruitmentRequestValidationErrors.php
+++ b/tests/Datasets/StoreEngagementRecruitmentRequestValidationErrors.php
@@ -1,0 +1,14 @@
+<?php
+
+dataset('storeEngagementRecruitmentRequestValidationErrors', function () {
+    return [
+        'Recruitment is missing' => [
+            'state' => ['recruitment' => null],
+            'errors' => fn () => ['recruitment' => __('validation.required', ['attribute' => __('recruitment method')])],
+        ],
+        'Recruitment is invalid' => [
+            'state' => ['recruitment' => ['xyz']],
+            'errors' => fn () => ['recruitment' => __('validation.exists', ['attribute' => __('recruitment method')])],
+        ],
+    ];
+});

--- a/tests/Datasets/StoreEngagementRequestValidationErrors.php
+++ b/tests/Datasets/StoreEngagementRequestValidationErrors.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\Engagement;
+
+dataset('storeEngagementRequestValidationErrors', function () {
+    return [
+        'Project id is missing' => [
+            'state' => ['project_id' => null],
+            'errors' => fn () => ['project_id' => __('validation.required', ['attribute' => __('project id')])],
+        ],
+        'Project id is invalid' => [
+            'state' => ['project_id' => 100000],
+            'errors' => fn () => ['project_id' => __('validation.exists', ['attribute' => __('project id')])],
+        ],
+        'Name is not a string' => [
+            'state' => ['name' => ['en' => 123]],
+            'errors' => fn () => ['name.en' => __('validation.string', ['attribute' => __('engagement name (English)')])],
+        ],
+        'Name is not unique' => [
+            'state' => fn () => ['name' => ['en' => Engagement::factory()->create()->name]],
+            'errors' => fn () => ['name.en' => __('An engagement with this name already exists.')],
+        ],
+        'Name is missing required translation' => [
+            'state' => ['name' => ['es' => 'Nombre del compromiso']],
+            'errors' => fn () => [
+                'name.en' => __('An engagement name must be provided in at least one language.'),
+                'name.fr' => __('An engagement name must be provided in at least one language.'),
+            ],
+        ],
+        'Who is missing' => [
+            'state' => ['who' => null],
+            'errors' => fn () => ['who' => __('You must indicate who you want to engage.')],
+        ],
+        'Who is invalid' => [
+            'state' => ['who' => 'other'],
+            'errors' => fn () => ['who' => __('validation.exists', ['attribute' => __('who')])],
+        ],
+    ];
+});

--- a/tests/Datasets/UpdateEngagementLanguagesRequestValidationErrors.php
+++ b/tests/Datasets/UpdateEngagementLanguagesRequestValidationErrors.php
@@ -1,0 +1,22 @@
+<?php
+
+dataset('updateEngagementLanguagesRequestValidationErrors', function () {
+    return [
+        'Languages is missing' => [
+            'state' => ['languages' => null],
+            'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('languages')])],
+        ],
+        'Languages is not an array' => [
+            'state' => ['languages' => false],
+            'errors' => fn () => ['languages' => __('validation.array', ['attribute' => __('languages')])],
+        ],
+        'Languages is empty' => [
+            'state' => ['languages' => []],
+            'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('languages')])],
+        ],
+        'Language is invalid' => [
+            'state' => ['languages' => ['xyz']],
+            'errors' => fn () => ['languages.0' => __('validation.exists', ['attribute' => __('languages')])],
+        ],
+    ];
+});

--- a/tests/Datasets/UpdateEngagementRequestValidationErrors.php
+++ b/tests/Datasets/UpdateEngagementRequestValidationErrors.php
@@ -547,7 +547,7 @@ dataset('updateEngagementRequestValidationErrors', function () {
         ],
         'Accepted formats missing' => [
             ['accepted_formats' => null],
-            fn () => ['accepted_formats' => __('You must indicate the :attribute.', ['attribute' => __('accepted formats')])],
+            fn () => ['other_accepted_formats' => __('You must indicate the :attribute.', ['attribute' => __('accepted formats')])],
             [
                 'format' => EngagementFormat::Interviews->value,
                 'meetingType' => MeetingType::InPerson->value,

--- a/tests/Feature/AccessNeedsFacilitationNotificationTest.php
+++ b/tests/Feature/AccessNeedsFacilitationNotificationTest.php
@@ -4,9 +4,11 @@ use App\Enums\ContactPerson;
 use App\Models\Engagement;
 use App\Models\User;
 use App\Notifications\AccessNeedsFacilitationRequested;
-use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
 
-uses(WithFaker::class);
+use function Pest\Faker\fake;
+use function Pest\Laravel\actingAs;
 
 beforeEach(function () {
     $this->admin = User::factory()->create([
@@ -20,9 +22,9 @@ beforeEach(function () {
     ]);
 
     $this->participantUser = User::factory()->create([
-        'support_person_name' => $this->faker->name(),
+        'support_person_name' => fake()->name(),
         'support_person_email' => function (array $attributes) {
-            return Str::slug($attributes['support_person_name']).'@'.$this->faker->safeEmailDomain();
+            return Str::slug($attributes['support_person_name']).'@'.fake()->safeEmailDomain();
         },
         'support_person_phone' => '9054444444',
         'phone' => '9055555555',
@@ -145,7 +147,7 @@ test('Notification view', function ($userData) {
     // End of notification
     $toSee[] = __('Mark as read');
 
-    $response = $this->actingAs($this->admin)->get(localized_route('dashboard.notifications'));
+    $response = actingAs($this->admin)->get(localized_route('dashboard.notifications'));
     $response->assertSeeTextInOrder($toSee);
 
     foreach ($dontSee as $dontSeeText) {

--- a/tests/Feature/AccessSupportTest.php
+++ b/tests/Feature/AccessSupportTest.php
@@ -4,7 +4,9 @@ use App\Models\AccessSupport;
 use Database\Seeders\AccessSupportSeeder;
 use Spatie\LaravelOptions\Options;
 
+use function Pest\Laravel\seed;
+
 test('access supports can be turned into select options', function () {
-    $this->seed(AccessSupportSeeder::class);
+    seed(AccessSupportSeeder::class);
     expect(Options::forModels(AccessSupport::class)->toArray())->toBeArray()->toHaveCount(AccessSupport::all()->count());
 });

--- a/tests/Feature/AdministratorTest.php
+++ b/tests/Feature/AdministratorTest.php
@@ -2,19 +2,22 @@
 
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
+
 test('only administrators can access estimates and agreements admin page', function () {
     $user = User::factory()->create();
     $administrator = User::factory()->create(['context' => 'administrator']);
 
-    $response = $this->actingAs($user)->get(localized_route('admin.estimates-and-agreements'));
-    $response->assertRedirect(localized_route('dashboard'));
+    actingAs($user)->get(localized_route('admin.estimates-and-agreements'))
+        ->assertRedirect(localized_route('dashboard'));
 
-    $response = $this->actingAs($administrator)->get(localized_route('admin.estimates-and-agreements'));
-    $response->assertOk();
+    actingAs($administrator)->get(localized_route('admin.estimates-and-agreements'))
+        ->assertOk();
 });
 
 test('log out from Filament redirects to standard login', function () {
     $administrator = User::factory()->create(['context' => 'administrator']);
-    $response = $this->actingAs($administrator)->from(route('filament.admin.resources.interpretations.index'))->post(route('filament.admin.auth.logout'));
-    $response->assertRedirect(localized_route('login'));
+
+    actingAs($administrator)->from(route('filament.admin.resources.interpretations.index'))->post(route('filament.admin.auth.logout'))
+        ->assertRedirect(localized_route('login'));
 });

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertAuthenticatedAs;

--- a/tests/Feature/BlocklistTest.php
+++ b/tests/Feature/BlocklistTest.php
@@ -15,48 +15,45 @@ beforeEach(function () {
 test('only individual users can have a block list', function () {
     $user = User::factory()->create();
 
-    $response = actingAs($user)->get(localized_route('block-list.show'));
-
-    $response->assertOk();
+    actingAs($user)->get(localized_route('block-list.show'))
+        ->assertOk();
 
     $regulatedOrganizationUser = User::factory()->create(['context' => 'regulated-organization']);
 
-    $response = actingAs($regulatedOrganizationUser)->get(localized_route('block-list.show'));
-
-    $response->assertForbidden();
+    actingAs($regulatedOrganizationUser)->get(localized_route('block-list.show'))
+        ->assertForbidden();
 });
 
 test('individual users can block and unblock regulated organizations', function () {
     $user = User::factory()->create();
     $regulatedOrganization = RegulatedOrganization::factory()->create(['name' => ['en' => 'Umbrella Corporation'], 'published_at' => now()]);
 
-    $response = actingAs($user)->get(localized_route('regulated-organizations.show', $regulatedOrganization));
-    $response->assertSee('Block');
+    actingAs($user)->get(localized_route('regulated-organizations.show', $regulatedOrganization))
+        ->assertSee('Block');
 
-    $response = actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
+    actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
         ->post(localized_route('block-list.block'), [
             'blockable_type' => get_class($regulatedOrganization),
             'blockable_id' => $regulatedOrganization->id,
-        ]);
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('dashboard'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('dashboard'));
 
     expect($regulatedOrganization->blockedBy($user))->toBeTrue();
 
-    $response = actingAs($user)->get(localized_route('regulated-organizations.show', $regulatedOrganization));
-    $response->assertForbidden();
+    actingAs($user)->get(localized_route('regulated-organizations.show', $regulatedOrganization))
+        ->assertForbidden();
 
-    $response = actingAs($user)->get(localized_route('block-list.show'));
-    $response->assertSee('Umbrella Corporation');
+    actingAs($user)->get(localized_route('block-list.show'))
+        ->assertSee('Umbrella Corporation');
 
-    $response = actingAs($user)->from(localized_route('block-list.show'))
+    actingAs($user)->from(localized_route('block-list.show'))
         ->post(localized_route('block-list.unblock'), [
             'blockable_type' => get_class($regulatedOrganization),
             'blockable_id' => $regulatedOrganization->id,
-        ]);
-
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('block-list.show'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('block-list.show'));
 
     $user = $user->fresh();
 
@@ -70,33 +67,32 @@ test('individual users can block and unblock organizations', function () {
     $user = User::factory()->create();
     $organization = Organization::factory()->create(['name' => ['en' => 'Umbrella Corporation'], 'published_at' => now()]);
 
-    $response = actingAs($user)->get(localized_route('organizations.show', $organization));
-    $response->assertSee('Block');
+    actingAs($user)->get(localized_route('organizations.show', $organization))
+        ->assertSee('Block');
 
-    $response = actingAs($user)->from(localized_route('organizations.show', $organization))
+    actingAs($user)->from(localized_route('organizations.show', $organization))
         ->post(localized_route('block-list.block'), [
             'blockable_type' => get_class($organization),
             'blockable_id' => $organization->id,
-        ]);
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('dashboard'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('dashboard'));
 
     expect($organization->blockedBy($user))->toBeTrue();
 
-    $response = actingAs($user)->get(localized_route('organizations.show', $organization));
-    $response->assertForbidden();
+    actingAs($user)->get(localized_route('organizations.show', $organization))
+        ->assertForbidden();
 
-    $response = actingAs($user)->get(localized_route('block-list.show'));
-    $response->assertSee('Umbrella Corporation');
+    actingAs($user)->get(localized_route('block-list.show'))
+        ->assertSee('Umbrella Corporation');
 
-    $response = actingAs($user)->from(localized_route('block-list.show'))
+    actingAs($user)->from(localized_route('block-list.show'))
         ->post(localized_route('block-list.unblock'), [
             'blockable_type' => get_class($organization),
             'blockable_id' => $organization->id,
-        ]);
-
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('block-list.show'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('block-list.show'));
 
     $user = $user->fresh();
 
@@ -110,33 +106,32 @@ test('individual users can block and unblock individuals', function () {
     $user = User::factory()->create();
     $individual = Individual::factory()->create(['roles' => ['consultant'], 'consulting_services' => ['analysis']]);
 
-    $response = actingAs($user)->get(localized_route('individuals.show', $individual));
-    $response->assertSee('Block');
+    actingAs($user)->get(localized_route('individuals.show', $individual))
+        ->assertSee('Block');
 
-    $response = actingAs($user)->from(localized_route('individuals.show', $individual))
+    actingAs($user)->from(localized_route('individuals.show', $individual))
         ->post(localized_route('block-list.block'), [
             'blockable_type' => get_class($individual),
             'blockable_id' => $individual->id,
-        ]);
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('dashboard'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('dashboard'));
 
     expect($individual->blockedBy($user))->toBeTrue();
 
-    $response = actingAs($user)->get(localized_route('individuals.show', $individual));
-    $response->assertForbidden();
+    actingAs($user)->get(localized_route('individuals.show', $individual))
+        ->assertForbidden();
 
-    $response = actingAs($user)->get(localized_route('block-list.show'));
-    $response->assertSee($individual->name);
+    actingAs($user)->get(localized_route('block-list.show'))
+        ->assertSee($individual->name);
 
-    $response = actingAs($user)->from(localized_route('block-list.show'))
+    actingAs($user)->from(localized_route('block-list.show'))
         ->post(localized_route('block-list.unblock'), [
             'blockable_type' => get_class($individual),
             'blockable_id' => $individual->id,
-        ]);
-
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('block-list.show'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('block-list.show'));
 
     $user = $user->fresh();
 
@@ -152,12 +147,12 @@ test('regulated organization member cannot block their regulated organization', 
         ->hasAttached($user, ['role' => 'admin'])
         ->create();
 
-    $response = actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
+    actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
         ->post(localized_route('block-list.block'), [
             'blockable_type' => get_class($regulatedOrganization),
             'blockable_id' => $regulatedOrganization->id,
-        ]);
-    $response->assertForbidden();
+        ])
+        ->assertForbidden();
 });
 
 test('organization member cannot block their organization', function () {
@@ -166,50 +161,49 @@ test('organization member cannot block their organization', function () {
         ->hasAttached($user, ['role' => 'admin'])
         ->create();
 
-    $response = actingAs($user)->from(localized_route('organizations.show', $organization))
+    actingAs($user)->from(localized_route('organizations.show', $organization))
         ->post(localized_route('block-list.block'), [
             'blockable_type' => get_class($organization),
             'blockable_id' => $organization->id,
-        ]);
-    $response->assertForbidden();
+        ])
+        ->assertForbidden();
 });
 
 test('individual cannot block their individual profile', function () {
     $user = User::factory()->create();
     $individual = $user->individual;
-    $response = actingAs($user)->from(localized_route('individuals.show', $individual))
+    actingAs($user)->from(localized_route('individuals.show', $individual))
         ->post(localized_route('block-list.block'), [
             'blockable_type' => get_class($individual),
             'blockable_id' => $individual->id,
-        ]);
-
-    $response->assertForbidden();
+        ])
+        ->assertForbidden();
 });
 
 test('individual warning when attempt to block again', function () {
     $user = User::factory()->create();
     $regulatedOrganization = RegulatedOrganization::factory()->create(['name' => ['en' => 'Umbrella Corporation'], 'published_at' => now()]);
 
-    $response = actingAs($user)->get(localized_route('regulated-organizations.show', $regulatedOrganization));
-    $response->assertSee('Block');
+    actingAs($user)->get(localized_route('regulated-organizations.show', $regulatedOrganization))
+        ->assertSee('Block');
 
-    $response = actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
+    actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
         ->post(localized_route('block-list.block'), [
             'blockable_type' => get_class($regulatedOrganization),
             'blockable_id' => $regulatedOrganization->id,
-        ]);
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('dashboard'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('dashboard'));
 
     expect($regulatedOrganization->blockedBy($user))->toBeTrue();
 
-    $response = $this->actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
+    actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
         ->post(localized_route('block-list.block'), [
             'blockable_type' => get_class($regulatedOrganization),
             'blockable_id' => $regulatedOrganization->id,
-        ]);
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('dashboard'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('dashboard'));
 
     expect($regulatedOrganization->blockedBy($user))->toBeTrue();
 
@@ -221,14 +215,13 @@ test('individual warning when unblocking user not on block list', function () {
     $user = User::factory()->create();
     $regulatedOrganization = RegulatedOrganization::factory()->create(['name' => ['en' => 'Umbrella Corporation'], 'published_at' => now()]);
 
-    $response = actingAs($user)->from(localized_route('block-list.show'))
+    actingAs($user)->from(localized_route('block-list.show'))
         ->post(localized_route('block-list.unblock'), [
             'blockable_type' => get_class($regulatedOrganization),
             'blockable_id' => $regulatedOrganization->id,
-        ]);
-
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('dashboard'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('dashboard'));
 
     expect(flash()->class)->toBe('warning|Could not be blocked because it was not on your block list.');
     expect(flash()->message)->toBe(__(':blockable could not be unblocked because it was not on your block list.', ['blockable' => $regulatedOrganization->name]));

--- a/tests/Feature/CollaborationPreferencesTest.php
+++ b/tests/Feature/CollaborationPreferencesTest.php
@@ -5,6 +5,8 @@ use App\Models\Organization;
 use App\Models\RegulatedOrganization;
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
+
 test('individual user can access collaboration preferences', function () {
     $user = User::factory()->create([
         'context' => UserContext::Individual->value,
@@ -14,8 +16,9 @@ test('individual user can access collaboration preferences', function () {
     $individual->roles = ['participant'];
     $individual->save();
 
-    $response = $this->actingAs($user)->get(localized_route('dashboard.collaboration-preferences'));
+    $response = actingAs($user)->get(localized_route('dashboard.collaboration-preferences'));
     $response->assertOk();
+
     expect($response['individual'])->toBe($user->individual);
 });
 
@@ -28,8 +31,8 @@ test('regulated organization user cannot access collaboration preferences', func
         ->hasAttached($regulatedOrganizationUser, ['role' => 'admin'])
         ->create();
 
-    $response = $this->actingAs($regulatedOrganizationUser)->get(localized_route('dashboard.collaboration-preferences'));
-    $response->assertForbidden();
+    actingAs($regulatedOrganizationUser)->get(localized_route('dashboard.collaboration-preferences'))
+        ->assertForbidden();
 });
 
 test('organization user cannot access collaboration preferences', function () {
@@ -41,15 +44,15 @@ test('organization user cannot access collaboration preferences', function () {
         ->hasAttached($organizationUser, ['role' => 'admin'])
         ->create();
 
-    $response = $this->actingAs($organizationUser)->get(localized_route('dashboard.collaboration-preferences'));
-    $response->assertRedirect(localized_route('organizations.show-role-selection', $organization));
+    actingAs($organizationUser)->get(localized_route('dashboard.collaboration-preferences'))
+        ->assertRedirect(localized_route('organizations.show-role-selection', $organization));
 
     $organization->roles = ['consultant'];
     $organization->save();
     $organizationUser->refresh();
 
-    $response = $this->actingAs($organizationUser)->get(localized_route('dashboard.collaboration-preferences'));
-    $response->assertForbidden();
+    actingAs($organizationUser)->get(localized_route('dashboard.collaboration-preferences'))
+        ->assertForbidden();
 });
 
 test('admin user cannot access collaboration preferences', function () {
@@ -57,8 +60,8 @@ test('admin user cannot access collaboration preferences', function () {
         'context' => UserContext::Administrator->value,
     ]);
 
-    $response = $this->actingAs($adminUser)->get(localized_route('dashboard.collaboration-preferences'));
-    $response->assertForbidden();
+    actingAs($adminUser)->get(localized_route('dashboard.collaboration-preferences'))
+        ->assertForbidden();
 });
 
 test('training user cannot access collaboration preferences', function () {
@@ -66,6 +69,6 @@ test('training user cannot access collaboration preferences', function () {
         'context' => UserContext::TrainingParticipant->value,
     ]);
 
-    $response = $this->actingAs($trainingUser)->get(localized_route('dashboard.collaboration-preferences'));
-    $response->assertForbidden();
+    actingAs($trainingUser)->get(localized_route('dashboard.collaboration-preferences'))
+        ->assertForbidden();
 });

--- a/tests/Feature/ConfirmLanguageTest.php
+++ b/tests/Feature/ConfirmLanguageTest.php
@@ -1,39 +1,39 @@
 <?php
 
-test('confirm language state on initial visit', function () {
-    $response = $this->get(localized_route('welcome'));
+use function Pest\Laravel\followingRedirects;
+use function Pest\Laravel\get;
+use function Pest\Laravel\withCookie;
+use function Pest\Laravel\withSession;
 
-    $response->assertOk();
-    $response->assertCookie('language-confirmed', 'true');
-    $response->assertSessionMissing('language-confirmed');
+test('confirm language state on initial visit', function () {
+    get(localized_route('welcome'))
+        ->assertOk()
+        ->assertCookie('language-confirmed', 'true')
+        ->assertSessionMissing('language-confirmed');
 });
 
 test('confirm language state on subsequent visit', function () {
-    $response = $this->withCookie('language-confirmed', true)->get(localized_route('welcome'));
-
-    $response->assertOk();
-    $response->assertCookie('language-confirmed', 'true');
-    $response->assertSessionHas('language-confirmed', true);
+    withCookie('language-confirmed', true)->get(localized_route('welcome'))
+        ->assertOk()
+        ->assertCookie('language-confirmed', 'true')
+        ->assertSessionHas('language-confirmed', true);
 });
 
 test('confirm language state no cookie but in session', function () {
-    $response = $this->withSession(['language-confirmed' => true])->get(localized_route('welcome'));
-
-    $response->assertOk();
-    $response->assertCookie('language-confirmed', 'true');
-    $response->assertSessionHas('language-confirmed', true);
+    withSession(['language-confirmed' => true])->get(localized_route('welcome'))
+        ->assertOk()
+        ->assertCookie('language-confirmed', 'true')
+        ->assertSessionHas('language-confirmed', true);
 });
 
 test('confirm language with initial redirect', function () {
-    $response = $this->get('/');
+    get('/')
+        ->assertStatus(302)
+        ->assertCookieMissing('language-confirmed')
+        ->assertSessionMissing('language-confirmed');
 
-    $response->assertStatus(302);
-    $response->assertCookieMissing('language-confirmed');
-    $response->assertSessionMissing('language-confirmed');
-
-    $response = $this->followingRedirects()->get('/');
-
-    $response->assertOk();
-    $response->assertCookie('language-confirmed', 'true');
-    $response->assertSessionMissing('language-confirmed');
+    followingRedirects()->get('/')
+        ->assertOk()
+        ->assertCookie('language-confirmed', 'true')
+        ->assertSessionMissing('language-confirmed');
 });

--- a/tests/Feature/CourseTest.php
+++ b/tests/Feature/CourseTest.php
@@ -7,6 +7,8 @@ use App\Models\Question;
 use App\Models\Quiz;
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
+
 test('a course can have an author', function () {
     $course = Course::factory()->create();
 
@@ -65,10 +67,10 @@ test('users can take the quiz for courses once they finish all the modules in th
     $question = Question::factory()->create();
     $quiz->questions()->attach($question);
 
-    $response = $this->actingAs($user)->get(localized_route('courses.show', $course));
-    $response->assertOk();
-    $response->assertSee(__('not available yet'));
-    $response->assertDontSee(__('completed'));
+    actingAs($user)->get(localized_route('courses.show', $course))
+        ->assertOk()
+        ->assertSee(__('not available yet'))
+        ->assertDontSee(__('completed'));
 
     $user->modules()->attach(
         $module->id, [
@@ -78,10 +80,10 @@ test('users can take the quiz for courses once they finish all the modules in th
 
     $user->refresh();
 
-    $response = $this->actingAs($user)->get(localized_route('courses.show', $course));
-    $response->assertOk();
-    $response->assertSee(__('not available yet'));
-    $response->assertSee(__('In progress'));
+    actingAs($user)->get(localized_route('courses.show', $course))
+        ->assertOk()
+        ->assertSee(__('not available yet'))
+        ->assertSee(__('In progress'));
 
     $user->modules()->updateExistingPivot(
         $module->id, [
@@ -91,20 +93,20 @@ test('users can take the quiz for courses once they finish all the modules in th
 
     $user->refresh();
 
-    $response = $this->actingAs($user)->get(localized_route('courses.show', $course));
-    $response->assertOk();
-    $response->assertSessionHasNoErrors();
-    $response->assertDontSee(__('not available yet'));
-    $response->assertSee(__('completed'));
+    actingAs($user)->get(localized_route('courses.show', $course))
+        ->assertOk()
+        ->assertSessionHasNoErrors()
+        ->assertDontSee(__('not available yet'))
+        ->assertSee(__('completed'));
 });
 
 test('users can not take quiz if the course does not have quiz or quiz for the course does not have questions', function () {
     $course = Course::factory()->create();
     $user = User::factory()->create();
 
-    $response = $this->actingAs($user)->get(localized_route('courses.show', $course));
-    $response->assertOk();
-    $response->assertDontSee(__('Take Quiz'));
+    actingAs($user)->get(localized_route('courses.show', $course))
+        ->assertOk()
+        ->assertDontSee(__('Take Quiz'));
 
     $module = Module::factory()->for($course)->create();
     $quiz = Quiz::factory()->for($course)->create();
@@ -118,14 +120,14 @@ test('users can not take quiz if the course does not have quiz or quiz for the c
 
     $user->refresh();
 
-    $response = $this->actingAs($user)->get(localized_route('courses.show', $course));
-    $response->assertOk();
-    $response->assertDontSee(__('Take Quiz'));
+    actingAs($user)->get(localized_route('courses.show', $course))
+        ->assertOk()
+        ->assertDontSee(__('Take Quiz'));
 
     $question = Question::factory()->create();
     $quiz->questions()->attach($question);
 
-    $response = $this->actingAs($user)->get(localized_route('courses.show', $course));
-    $response->assertOk();
-    $response->assertSee(__('Take Quiz'));
+    actingAs($user)->get(localized_route('courses.show', $course))
+        ->assertOk()
+        ->assertSee(__('Take Quiz'));
 });

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -4,6 +4,8 @@ use App\Models\Organization;
 use App\Models\RegulatedOrganization;
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
+
 test('individual user can access dashboard', function () {
     $user = User::factory()->create([
         'context' => 'individual',
@@ -13,8 +15,8 @@ test('individual user can access dashboard', function () {
     $individual->roles = ['participant'];
     $individual->save();
 
-    $response = $this->actingAs($user)->get(localized_route('dashboard'));
-    $response->assertOk();
+    actingAs($user)->get(localized_route('dashboard'))
+        ->assertOk();
 });
 
 test('regulated organization user can access dashboard', function () {
@@ -26,8 +28,8 @@ test('regulated organization user can access dashboard', function () {
         ->hasAttached($regulatedOrganizationUser, ['role' => 'admin'])
         ->create();
 
-    $response = $this->actingAs($regulatedOrganizationUser)->get(localized_route('dashboard'));
-    $response->assertOk();
+    actingAs($regulatedOrganizationUser)->get(localized_route('dashboard'))
+        ->assertOk();
 });
 
 test('organization user can access dashboard', function () {
@@ -39,13 +41,12 @@ test('organization user can access dashboard', function () {
         ->hasAttached($organizationUser, ['role' => 'admin'])
         ->create();
 
-    $response = $this->actingAs($organizationUser)->get(localized_route('dashboard'));
-
-    $response->assertRedirect(localized_route('organizations.show-role-selection', $organization));
+    actingAs($organizationUser)->get(localized_route('dashboard'))
+        ->assertRedirect(localized_route('organizations.show-role-selection', $organization));
 
     $organization->roles = ['consultant'];
     $organization->save();
 
-    $response = $this->actingAs($organizationUser->fresh())->get(localized_route('dashboard'));
-    $response->assertOk();
+    actingAs($organizationUser->fresh())->get(localized_route('dashboard'))
+        ->assertOk();
 });

--- a/tests/Feature/DefinedTermTest.php
+++ b/tests/Feature/DefinedTermTest.php
@@ -3,10 +3,12 @@
 use App\Models\DefinedTerm;
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
+
 test('defined terms appear in glossary', function () {
     $user = User::factory()->create();
     $term = DefinedTerm::factory()->create();
 
-    $response = $this->actingAs($user)->get(localized_route('about.defined-terms.index'));
-    $response->assertSee($term->term);
+    actingAs($user)->get(localized_route('about.defined-terms.index'))
+        ->assertSee($term->term);
 });

--- a/tests/Feature/EmailVerificationTest.php
+++ b/tests/Feature/EmailVerificationTest.php
@@ -5,14 +5,15 @@ use Illuminate\Auth\Events\Verified;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
 
+use function Pest\Laravel\actingAs;
+
 test('email verification screen can be rendered', function () {
     $user = User::factory()->create([
         'email_verified_at' => null,
     ]);
 
-    $response = $this->actingAs($user)->get(localized_route('verification.notice'));
-
-    $response->assertOk();
+    actingAs($user)->get(localized_route('verification.notice'))
+        ->assertOk();
 });
 
 test('email can be verified', function () {
@@ -29,11 +30,11 @@ test('email can be verified', function () {
         ['id' => $user->id, 'hash' => sha1($user->email)]
     );
 
-    $response = $this->actingAs($user)->get($verificationUrl);
+    actingAs($user)->get($verificationUrl)
+        ->assertRedirect(localized_route('dashboard', ['verified' => 1]));
 
     Event::assertDispatched(Verified::class);
     expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
-    $response->assertRedirect(localized_route('dashboard', ['verified' => 1]));
 });
 
 test('email is not verified with invalid hash', function () {
@@ -48,7 +49,7 @@ test('email is not verified with invalid hash', function () {
         ['id' => $user->id, 'hash' => sha1('wrong-email')]
     );
 
-    $this->actingAs($user)->get($verificationUrl);
+    actingAs($user)->get($verificationUrl);
 
     expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
 });

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -436,6 +436,22 @@ test('update engagement request validation errors', function (array $state, arra
         ->assertSessionHasErrors($errors);
 })->with('updateEngagementRequestValidationErrors');
 
+test('update engagement languages request validation errors', function (array $state, array $errors) {
+    $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
+    $regulatedOrganization = RegulatedOrganization::factory()
+        ->hasAttached($user, ['role' => 'admin'])
+        ->create();
+    $project = Project::factory()->create([
+        'projectable_id' => $regulatedOrganization->id,
+    ]);
+    $engagement = Engagement::factory()->create([
+        'project_id' => $project->id,
+    ]);
+
+    actingAs($user)->put(localized_route('engagements.update-languages', $engagement), $state)
+        ->assertSessionHasErrors($errors);
+})->with('updateEngagementLanguagesRequestValidationErrors');
+
 test('update engagement selection criteria request validation errors', function (array $state, array $errors, array $without = []) {
     $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
     $regulatedOrganization = RegulatedOrganization::factory()

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -195,6 +195,22 @@ test('store engagement format request validation errors', function (array $state
         ->assertSessionHasErrors($errors);
 })->with('storeEngagementFormatRequestValidationErrors');
 
+test('store engagement recruitment request validation errors', function (array $state, array $errors) {
+    $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
+    $regulatedOrganization = RegulatedOrganization::factory()
+        ->hasAttached($user, ['role' => 'admin'])
+        ->create();
+    $project = Project::factory()->create([
+        'projectable_id' => $regulatedOrganization->id,
+    ]);
+    $engagement = Engagement::factory()
+        ->for($project)
+        ->create([]);
+
+    actingAs($user)->put(localized_route('engagements.store-recruitment', $engagement), $state)
+        ->assertSessionHasErrors($errors);
+})->with('storeEngagementRecruitmentRequestValidationErrors');
+
 test('users can view engagements', function () {
     seed(IdentitySeeder::class);
 

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -788,6 +788,25 @@ test('store access needs permissions validation errors', function (array $state,
         ->assertSessionHasErrors($errors);
 })->with('storeAccessNeedsPermissionsValidationErrors');
 
+test('add organization validation errors', function (array $state, array $errors) {
+    $engagement = Engagement::factory()->create([
+        'who' => 'organization',
+        'recruitment' => 'open-call',
+    ]);
+    $project = $engagement->project;
+    $project->update(['estimate_requested_at' => now(), 'agreement_received_at' => now()]);
+    $regulatedOrganization = $project->projectable;
+    $regulatedOrganizationUser = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
+    $regulatedOrganization->users()->attach(
+        $regulatedOrganizationUser,
+        ['role' => 'admin']
+    );
+
+    actingAs($regulatedOrganizationUser)
+        ->post(localized_route('engagements.add-organization', $engagement), $state)
+        ->assertSessionHasErrors($errors);
+})->with('addOrganizationValidationErrors');
+
 test('invite participant validation errors', function (array $state, array $errors) {
     $engagement = Engagement::factory()->create(['recruitment' => 'open-call']);
     $project = $engagement->project;

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -149,6 +149,23 @@ test('users without regulated organization admin role cannot create engagements'
         ->assertForbidden();
 });
 
+test('store engagement request validation errors', function (array $state, array $errors) {
+    $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
+    $regulatedOrganization = RegulatedOrganization::factory()
+        ->hasAttached($user, ['role' => 'admin'])
+        ->create();
+    $project = Project::factory()->create([
+        'projectable_id' => $regulatedOrganization->id,
+    ]);
+
+    StoreEngagementRequest::factory()->state([
+        'project_id' => $project->id,
+    ])->fake();
+
+    actingAs($user)->post(localized_route('engagements.store', $project), $state)
+        ->assertSessionHasErrors($errors);
+})->with('storeEngagementRequestValidationErrors');
+
 test('users can view engagements', function () {
     seed(IdentitySeeder::class);
 

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -149,6 +149,19 @@ test('users without regulated organization admin role cannot create engagements'
         ->assertForbidden();
 });
 
+test('store engagement languages request validation errors', function (array $state, array $errors) {
+    $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
+    $regulatedOrganization = RegulatedOrganization::factory()
+        ->hasAttached($user, ['role' => 'admin'])
+        ->create();
+    $project = Project::factory()->create([
+        'projectable_id' => $regulatedOrganization->id,
+    ]);
+
+    actingAs($user)->post(localized_route('engagements.store-languages', $project), $state)
+        ->assertSessionHasErrors($errors);
+})->with('storeEngagementLanguagesRequestValidationErrors');
+
 test('store engagement request validation errors', function (array $state, array $errors) {
     $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
     $regulatedOrganization = RegulatedOrganization::factory()

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -179,6 +179,22 @@ test('store engagement request validation errors', function (array $state, array
         ->assertSessionHasErrors($errors);
 })->with('storeEngagementRequestValidationErrors');
 
+test('store engagement format request validation errors', function (array $state, array $errors) {
+    $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
+    $regulatedOrganization = RegulatedOrganization::factory()
+        ->hasAttached($user, ['role' => 'admin'])
+        ->create();
+    $project = Project::factory()->create([
+        'projectable_id' => $regulatedOrganization->id,
+    ]);
+    $engagement = Engagement::factory()
+        ->for($project)
+        ->create([]);
+
+    actingAs($user)->put(localized_route('engagements.store-format', $engagement), $state)
+        ->assertSessionHasErrors($errors);
+})->with('storeEngagementFormatRequestValidationErrors');
+
 test('users can view engagements', function () {
     seed(IdentitySeeder::class);
 
@@ -474,9 +490,9 @@ test('update engagement languages request validation errors', function (array $s
     $project = Project::factory()->create([
         'projectable_id' => $regulatedOrganization->id,
     ]);
-    $engagement = Engagement::factory()->create([
-        'project_id' => $project->id,
-    ]);
+    $engagement = Engagement::factory()
+        ->for($project)
+        ->create([]);
 
     actingAs($user)->put(localized_route('engagements.update-languages', $engagement), $state)
         ->assertSessionHasErrors($errors);

--- a/tests/Feature/IdentityTest.php
+++ b/tests/Feature/IdentityTest.php
@@ -8,10 +8,12 @@ use App\Models\User;
 use Database\Seeders\IdentitySeeder;
 use Spatie\LaravelOptions\Options;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\seed;
 use function Pest\Livewire\livewire;
 
 beforeEach(function () {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 });
 
 test('identities can be grouped by cluster', function () {
@@ -32,14 +34,14 @@ test('only administrative users can access identity admin pages', function () {
     $user = User::factory()->create();
     $administrator = User::factory()->create(['context' => 'administrator']);
 
-    $this->actingAs($user)->get(IdentityResource::getUrl('index'))->assertForbidden();
-    $this->actingAs($administrator)->get(IdentityResource::getUrl('index'))->assertSuccessful();
+    actingAs($user)->get(IdentityResource::getUrl('index'))->assertForbidden();
+    actingAs($administrator)->get(IdentityResource::getUrl('index'))->assertSuccessful();
 });
 
 test('identities can be listed', function () {
     $administrator = User::factory()->create(['context' => 'administrator']);
 
-    $this->actingAs($administrator);
+    actingAs($administrator);
 
     $identity = Identity::first();
 

--- a/tests/Feature/IndividualTest.php
+++ b/tests/Feature/IndividualTest.php
@@ -21,9 +21,13 @@ use Database\Seeders\ImpactSeeder;
 use Database\Seeders\SectorSeeder;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertAuthenticated;
+use function Pest\Laravel\get;
+use function Pest\Laravel\seed;
+use function Pest\Laravel\withSession;
 
 beforeEach(function () {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 
     $this->livedExperience = Identity::withoutGlobalScope(ReachableIdentityScope::class)->whereJsonContains('clusters', IdentityCluster::LivedExperience)->first();
     $this->areaType = Identity::whereJsonContains('clusters', IdentityCluster::Area)->first();
@@ -135,10 +139,10 @@ test('save roles request validation errors', function (array $data, array $error
 })->with('saveIndividualRolesRequestValidationErrors');
 
 test('users can create individual pages', function () {
-    $this->seed(ImpactSeeder::class);
-    $this->seed(SectorSeeder::class);
+    seed(ImpactSeeder::class);
+    seed(SectorSeeder::class);
 
-    $response = $this->withSession([
+    withSession([
         'locale' => 'en',
         'name' => 'Test User',
         'email' => 'test@example.com',
@@ -150,7 +154,7 @@ test('users can create individual pages', function () {
         'accepted_privacy_policy' => true,
     ]);
 
-    $this->assertAuthenticated();
+    assertAuthenticated();
 
     $user = Auth::user();
     $user->update(['oriented_at' => now()]);
@@ -859,11 +863,11 @@ test('users without a verified email can not view individual pages', function ()
 test('guests can not view individual pages', function () {
     $individual = Individual::factory()->create(['roles' => ['consultant']]);
 
-    $response = $this->get(localized_route('individuals.index'));
-    $response->assertRedirect(localized_route('login'));
+    get(localized_route('individuals.index'))
+        ->assertRedirect(localized_route('login'));
 
-    $response = $this->get(localized_route('individuals.show', $individual));
-    $response->assertRedirect(localized_route('login'));
+    get(localized_route('individuals.show', $individual))
+        ->assertRedirect(localized_route('login'));
 });
 
 test('individual pages can be published', function () {
@@ -911,7 +915,7 @@ test('individual pages cannot be published by other users', function () {
 });
 
 test('individual isPublishable()', function ($expected, $data, $userData, $connections = []) {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 
     $individualUser = User::factory()->create();
     $individualUser->update($userData);
@@ -1113,7 +1117,7 @@ test('Individual isReady()', function ($userData, $indData, $withPaymentTypes, $
         ->create($indData);
 
     if ($withPaymentTypes) {
-        $this->seed(PaymentTypeSeeder::class);
+        seed(PaymentTypeSeeder::class);
         $individual->paymentTypes()->attach(PaymentType::first());
     }
 

--- a/tests/Feature/InterpretationTest.php
+++ b/tests/Feature/InterpretationTest.php
@@ -4,6 +4,7 @@ use App\Filament\Resources\InterpretationResource;
 use App\Models\Interpretation;
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 test('namespace generated from route', function () {
@@ -74,17 +75,17 @@ test('only administrative users can access interpretation admin pages', function
     $user = User::factory()->create();
     $administrator = User::factory()->create(['context' => 'administrator']);
 
-    $this->actingAs($user)->get(InterpretationResource::getUrl('index'))->assertForbidden();
-    $this->actingAs($administrator)->get(InterpretationResource::getUrl('index'))->assertSuccessful();
+    actingAs($user)->get(InterpretationResource::getUrl('index'))->assertForbidden();
+    actingAs($administrator)->get(InterpretationResource::getUrl('index'))->assertSuccessful();
 
-    $this->actingAs($user)->get(InterpretationResource::getUrl('create'))->assertForbidden();
-    $this->actingAs($administrator)->get(InterpretationResource::getUrl('create'))->assertForbidden();
+    actingAs($user)->get(InterpretationResource::getUrl('create'))->assertForbidden();
+    actingAs($administrator)->get(InterpretationResource::getUrl('create'))->assertForbidden();
 
-    $this->actingAs($user)->get(InterpretationResource::getUrl('edit', [
+    actingAs($user)->get(InterpretationResource::getUrl('edit', [
         'record' => Interpretation::factory()->create(),
     ]))->assertForbidden();
 
-    $this->actingAs($administrator)->get(InterpretationResource::getUrl('edit', [
+    actingAs($administrator)->get(InterpretationResource::getUrl('edit', [
         'record' => Interpretation::factory()->create(),
     ]))->assertSuccessful();
 });

--- a/tests/Feature/LanguageChangerTest.php
+++ b/tests/Feature/LanguageChangerTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Individual;
 use App\View\Components\LanguageChanger;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 
 use function Pest\Laravel\get;

--- a/tests/Feature/Livewire/AddEngagementConnectorTest.php
+++ b/tests/Feature/Livewire/AddEngagementConnectorTest.php
@@ -9,9 +9,12 @@ use App\Models\Organization;
 use App\Models\User;
 use App\Notifications\IndividualContractorInvited;
 use App\Notifications\OrganizationalContractorInvited;
+use Illuminate\Support\Facades\URL;
 use Spatie\LaravelOptions\Options;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertModelMissing;
+use function Pest\Laravel\seed;
 use function Pest\Livewire\livewire;
 
 test('unregistered individual can be invited to be an engagement’s community connector', function () {
@@ -26,10 +29,10 @@ test('unregistered individual can be invited to be an engagement’s community c
         ['role' => 'admin']
     );
 
-    $response = $this->actingAs($user)->get(localized_route('engagements.add-connector', $engagement));
-    $response->assertOk();
+    actingAs($user)->get(localized_route('engagements.add-connector', $engagement))
+        ->assertOk();
 
-    $this->actingAs($user);
+    actingAs($user);
 
     livewire(AddEngagementConnector::class, [
         'engagement' => $engagement,
@@ -45,9 +48,9 @@ test('unregistered individual can be invited to be an engagement’s community c
     expect($engagement->invitations->first()->role)->toEqual('connector');
     expect($engagement->invitations->first()->type)->toEqual('individual');
 
-    $response = $this->actingAs($user)->get(localized_route('engagements.manage-connector', $engagement));
-    $response->assertOk();
-    $response->assertSee('connector@example.com');
+    actingAs($user)->get(localized_route('engagements.manage-connector', $engagement))
+        ->assertOk()
+        ->assertSee('connector@example.com');
 });
 
 test('registered individual can be invited to be an engagement’s community connector', function () {
@@ -69,10 +72,10 @@ test('registered individual can be invited to be an engagement’s community con
 
     $individual = $individual->fresh();
 
-    $response = $this->actingAs($user)->get(localized_route('engagements.add-connector', $engagement));
-    $response->assertOk();
+    actingAs($user)->get(localized_route('engagements.add-connector', $engagement))
+        ->assertOk();
 
-    $this->actingAs($user);
+    actingAs($user);
 
     livewire(AddEngagementConnector::class, [
         'engagement' => $engagement,
@@ -101,9 +104,9 @@ test('registered individual can be invited to be an engagement’s community con
     expect($engagement->invitations->first()->role)->toEqual('connector');
     expect($engagement->invitations->first()->type)->toEqual('individual');
 
-    $response = $this->actingAs($user)->get(localized_route('engagements.manage-connector', $engagement));
-    $response->assertOk();
-    $response->assertSee($individual->name);
+    actingAs($user)->get(localized_route('engagements.manage-connector', $engagement))
+        ->assertOk()
+        ->assertSee($individual->name);
 
     $notification = new IndividualContractorInvited($engagement->invitations->first());
     $this->assertStringContainsString('You have been invited', $notification->toMail($individualUser)->render());
@@ -112,16 +115,16 @@ test('registered individual can be invited to be an engagement’s community con
     expect($individualUser->notifications)->toHaveCount(1);
     $databaseNotification = $individualUser->notifications->first();
 
-    $response = $this->actingAs($individualUser)->get(localized_route('dashboard'));
-    $response->assertOk();
-    $response->assertSee('Accept');
-    $response->assertSee(URL::signedRoute('contractor-invitations.accept', $engagement->invitations->first()));
+    actingAs($individualUser)->get(localized_route('dashboard'))
+        ->assertOk()
+        ->assertSee('Accept')
+        ->assertSee(URL::signedRoute('contractor-invitations.accept', $engagement->invitations->first()));
 
-    $response = $this->actingAs($individualUser)->get(URL::signedRoute('contractor-invitations.accept', $engagement->invitations->first()));
-    $response->assertRedirect(localized_route('dashboard'));
+    actingAs($individualUser)->get(URL::signedRoute('contractor-invitations.accept', $engagement->invitations->first()))
+        ->assertRedirect(localized_route('dashboard'));
 
     expect($engagement->fresh()->connector->id)->toEqual($individual->id);
-    $this->assertModelMissing($databaseNotification);
+    assertModelMissing($databaseNotification);
 });
 
 test('registered organization can be invited to be an engagement’s community connector', function () {
@@ -145,10 +148,10 @@ test('registered organization can be invited to be an engagement’s community c
         ['role' => 'admin']
     );
 
-    $response = $this->actingAs($user)->get(localized_route('engagements.add-connector', $engagement));
-    $response->assertOk();
+    actingAs($user)->get(localized_route('engagements.add-connector', $engagement))
+        ->assertOk();
 
-    $this->actingAs($user);
+    actingAs($user);
 
     livewire(AddEngagementConnector::class, [
         'engagement' => $engagement,
@@ -200,9 +203,9 @@ test('registered organization can be invited to be an engagement’s community c
     expect($engagement->invitations->first()->role)->toEqual('connector');
     expect($engagement->invitations->first()->type)->toEqual('organization');
 
-    $response = $this->actingAs($user)->get(localized_route('engagements.manage-connector', $engagement));
-    $response->assertOk();
-    $response->assertSee($organization->name);
+    actingAs($user)->get(localized_route('engagements.manage-connector', $engagement))
+        ->assertOk()
+        ->assertSee($organization->name);
 
     $notification = new OrganizationalContractorInvited($engagement->invitations->first());
     $this->assertStringContainsString('Your organization has been invited', $notification->toMail($organization)->render());
@@ -211,20 +214,20 @@ test('registered organization can be invited to be an engagement’s community c
     expect($organization->notifications)->toHaveCount(1);
     $databaseNotification = $organization->notifications->first();
 
-    $response = $this->actingAs($organizationUser)->get(localized_route('dashboard'));
-    $response->assertOk();
-    $response->assertSee('Accept');
-    $response->assertSee(URL::signedRoute('contractor-invitations.accept', $engagement->invitations->first()));
+    actingAs($organizationUser)->get(localized_route('dashboard'))
+        ->assertOk()
+        ->assertSee('Accept')
+        ->assertSee(URL::signedRoute('contractor-invitations.accept', $engagement->invitations->first()));
 
-    $response = $this->actingAs($organizationUser)->get(URL::signedRoute('contractor-invitations.accept', $engagement->invitations->first()));
-    $response->assertRedirect(localized_route('dashboard'));
+    actingAs($organizationUser)->get(URL::signedRoute('contractor-invitations.accept', $engagement->invitations->first()))
+        ->assertRedirect(localized_route('dashboard'));
 
     expect($engagement->fresh()->organizationalConnector->id)->toEqual($organization->id);
-    $this->assertModelMissing($databaseNotification);
+    assertModelMissing($databaseNotification);
 });
 
 test('only publishable orgs are available to choose as a community connector', function () {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 
     $engagement = Engagement::factory()->create(['recruitment' => 'connector']);
     $areaIdentity = Identity::whereJsonContains('clusters', IdentityCluster::Area)->first();

--- a/tests/Feature/Livewire/AllProjectsTest.php
+++ b/tests/Feature/Livewire/AllProjectsTest.php
@@ -15,6 +15,7 @@ use Database\Seeders\IdentitySeeder;
 use Database\Seeders\ImpactSeeder;
 use Database\Seeders\SectorSeeder;
 
+use function Pest\Laravel\seed;
 use function Pest\Livewire\livewire;
 
 test('test searchQuery property change', function () {
@@ -170,7 +171,7 @@ test('test initiators property change', function () {
 });
 
 test('test seekingGroups property change', function () {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 
     $disabilityTypeDeaf = Identity::where('name->en', 'Deaf')->first();
     $projectSeekingDeafExperienceName = 'Project Seeking Deaf Experience';
@@ -309,7 +310,7 @@ test('test compensations property change', function () {
 });
 
 test('test sectors property change', function () {
-    $this->seed(SectorSeeder::class);
+    seed(SectorSeeder::class);
     $regulatedPrivateSector = Sector::where('name->en', 'Federally Regulated private sector')->first();
     $privateRegulatedOrganization = RegulatedOrganization::factory()->create();
     $privateRegulatedOrganization->sectors()->save($regulatedPrivateSector);
@@ -346,7 +347,7 @@ test('test sectors property change', function () {
 });
 
 test('test impacts property change', function () {
-    $this->seed(ImpactSeeder::class);
+    seed(ImpactSeeder::class);
     $employmentImpact = Impact::where('name->en', 'Employment')->first();
     $employmentImpactProjectName = 'Employment Impact Project';
     $employmentImpactProject = Project::factory()->create([

--- a/tests/Feature/Livewire/EstimateApproverTest.php
+++ b/tests/Feature/Livewire/EstimateApproverTest.php
@@ -5,13 +5,14 @@ use App\Models\Project;
 use App\Models\User;
 use App\Notifications\EstimateApproved;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 test('unauthorized user cannot approve an estimate', function () {
     $project = Project::factory()->create();
     $user = User::factory()->create();
 
-    $this->actingAs($user);
+    actingAs($user);
 
     livewire(EstimateApprover::class, ['model' => $project])
         ->call('updateStatus')
@@ -31,7 +32,7 @@ test('authorized user can approve an estimate', function () {
         ['role' => 'admin']
     );
 
-    $this->actingAs($user);
+    actingAs($user);
 
     livewire(EstimateApprover::class, ['model' => $project])
         ->call('updateStatus');
@@ -47,9 +48,9 @@ test('authorized user can approve an estimate', function () {
     expect($administrator->unreadNotifications)->toHaveCount(1);
     $notification = $administrator->unreadNotifications->first();
 
-    $response = $this->actingAs($administrator)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('New estimate approval');
+    actingAs($administrator)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('New estimate approval');
 
     expect($notification->type)->toEqual('App\Notifications\EstimateApproved');
     expect($notification->data['project_id'])->toEqual($project->id);

--- a/tests/Feature/Livewire/EstimateRequesterTest.php
+++ b/tests/Feature/Livewire/EstimateRequesterTest.php
@@ -5,13 +5,14 @@ use App\Models\Project;
 use App\Models\User;
 use App\Notifications\EstimateRequested;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 test('unauthorized user cannot request an estimate', function () {
     $project = Project::factory()->create();
     $user = User::factory()->create();
 
-    $this->actingAs($user);
+    actingAs($user);
 
     livewire(EstimateRequester::class, ['model' => $project])
         ->call('updateStatus')
@@ -31,7 +32,7 @@ test('authorized user can request an estimate', function () {
         ['role' => 'admin']
     );
 
-    $this->actingAs($user);
+    actingAs($user);
 
     livewire(EstimateRequester::class, ['model' => $project])
         ->call('updateStatus');
@@ -47,9 +48,9 @@ test('authorized user can request an estimate', function () {
     expect($administrator->unreadNotifications)->toHaveCount(1);
     $notification = $administrator->unreadNotifications->first();
 
-    $response = $this->actingAs($administrator)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('New estimate request');
+    actingAs($administrator)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('New estimate request');
 
     expect($notification->type)->toEqual('App\Notifications\EstimateRequested');
     expect($notification->data['project_id'])->toEqual($project->id);

--- a/tests/Feature/Livewire/EstimatesAndAgreementsTest.php
+++ b/tests/Feature/Livewire/EstimatesAndAgreementsTest.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use App\Notifications\AgreementReceived;
 use App\Notifications\EstimateReturned;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 test('estimates and agreements appear in expected order', function () {
@@ -54,7 +55,7 @@ test('estimate can be marked as returned', function () {
     $projectManager = User::factory()->create(['context' => 'regulated-organization']);
     $project->projectable->users()->attach($projectManager, ['role' => 'admin']);
 
-    $this->actingAs($administrator);
+    actingAs($administrator);
 
     livewire(AdminEstimatesAndAgreements::class)
         ->assertSee($project->name)
@@ -73,11 +74,12 @@ test('estimate can be marked as returned', function () {
     expect($project->unreadNotifications)->toHaveCount(1);
     expect($project->unreadNotifications->first()->type)->toEqual('App\Notifications\EstimateReturned');
 
-    $response = $this->actingAs($projectManager)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your estimate has been returned');
     $projectName = htmlentities($project->name);
-    $response->assertSee("Your estimate for <strong>{$projectName}</strong>, along with a project agreement for to sign", false);
+
+    actingAs($projectManager)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your estimate has been returned')
+        ->assertSee("Your estimate for <strong>{$projectName}</strong>, along with a project agreement for to sign", false);
 });
 
 test('agreement can be marked as received', function () {
@@ -94,7 +96,7 @@ test('agreement can be marked as received', function () {
     $projectManager = User::factory()->create(['context' => 'regulated-organization']);
     $project->projectable->users()->attach($projectManager, ['role' => 'admin']);
 
-    $this->actingAs($administrator);
+    actingAs($administrator);
 
     livewire(AdminEstimatesAndAgreements::class)
         ->assertSee($project->name)
@@ -112,11 +114,12 @@ test('agreement can be marked as received', function () {
     expect($project->unreadNotifications)->toHaveCount(1);
     expect($project->unreadNotifications->first()->type)->toEqual('App\Notifications\AgreementReceived');
 
-    $response = $this->actingAs($projectManager)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your agreement has been received');
     $projectName = htmlentities($project->name);
-    $response->assertSee("Your agreement has been received for <strong>{$projectName}</strong>", false);
+
+    actingAs($projectManager)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your agreement has been received')
+        ->assertSee("Your agreement has been received for <strong>{$projectName}</strong>", false);
 });
 
 test('projects can be searched by organization name', function () {

--- a/tests/Feature/Livewire/ManageAccountsTest.php
+++ b/tests/Feature/Livewire/ManageAccountsTest.php
@@ -160,17 +160,17 @@ test('users can access approval notifications', function () {
     $this->organization->notify(new AccountApproved($this->organization));
     $this->regulatedOrganization->notify(new AccountApproved($this->regulatedOrganization));
 
-    $response = actingAs($this->individualUser)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your account has been approved');
+    actingAs($this->individualUser)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your account has been approved');
 
-    $response = actingAs($this->organizationUser)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your account has been approved');
+    actingAs($this->organizationUser)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your account has been approved');
 
-    $response = actingAs($this->regulatedOrganizationUser)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your account has been approved');
+    actingAs($this->regulatedOrganizationUser)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your account has been approved');
 });
 
 test('accounts can be suspended', function () {
@@ -262,17 +262,17 @@ test('users can access suspension notifications', function () {
     $this->organization->notify(new AccountSuspended($this->organization));
     $this->regulatedOrganization->notify(new AccountSuspended($this->regulatedOrganization));
 
-    $response = actingAs($this->individualUser)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your account has been suspended');
+    actingAs($this->individualUser)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your account has been suspended');
 
-    $response = actingAs($this->organizationUser)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your account has been suspended');
+    actingAs($this->organizationUser)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your account has been suspended');
 
-    $response = actingAs($this->regulatedOrganizationUser)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your account has been suspended');
+    actingAs($this->regulatedOrganizationUser)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your account has been suspended');
 });
 
 test('accounts appear with suspended status when suspended', function () {
@@ -418,17 +418,17 @@ test('users can access unsuspension notifications', function () {
     $this->organization->notify(new AccountUnsuspended($this->organization));
     $this->regulatedOrganization->notify(new AccountUnsuspended($this->regulatedOrganization));
 
-    $response = actingAs($this->individualUser)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your account is no longer suspended');
+    actingAs($this->individualUser)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your account is no longer suspended');
 
-    $response = actingAs($this->organizationUser)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your account is no longer suspended');
+    actingAs($this->organizationUser)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your account is no longer suspended');
 
-    $response = actingAs($this->regulatedOrganizationUser)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your account is no longer suspended');
+    actingAs($this->regulatedOrganizationUser)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your account is no longer suspended');
 });
 
 test('accounts can be searched', function () {

--- a/tests/Feature/Livewire/ManageEngagementConnectorTest.php
+++ b/tests/Feature/Livewire/ManageEngagementConnectorTest.php
@@ -7,6 +7,7 @@ use App\Models\Organization;
 use App\Models\User;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertModelMissing;
 use function Pest\Livewire\livewire;
 
 test('engagement consultant management page can be rendered and connector can be sought', function () {
@@ -21,8 +22,8 @@ test('engagement consultant management page can be rendered and connector can be
         ['role' => 'admin']
     );
 
-    $response = $this->actingAs($user)->get(localized_route('engagements.manage-connector', $engagement));
-    $response->assertOk();
+    actingAs($user)->get(localized_route('engagements.manage-connector', $engagement))
+        ->assertOk();
 
     livewire(ManageEngagementConnector::class, ['engagement' => $engagement])
         ->assertSet('project', $engagement->project)
@@ -59,7 +60,7 @@ test('connector invitations can be cancelled', function () {
         'email' => $individual->user->email,
     ]);
 
-    $this->actingAs($regulatedOrganizationUser);
+    actingAs($regulatedOrganizationUser);
 
     livewire(ManageEngagementConnector::class, [
         'engagement' => $engagement,
@@ -68,7 +69,7 @@ test('connector invitations can be cancelled', function () {
         ->assertSee('Cancel')
         ->call('cancelInvitation');
 
-    $this->assertModelMissing($invitation);
+    assertModelMissing($invitation);
 });
 
 test('individual connector can be removed', function () {

--- a/tests/Feature/Livewire/ResourcesTest.php
+++ b/tests/Feature/Livewire/ResourcesTest.php
@@ -13,13 +13,14 @@ use Database\Seeders\ImpactSeeder;
 use Database\Seeders\SectorSeeder;
 use Database\Seeders\TopicSeeder;
 
+use function Pest\Laravel\seed;
 use function Pest\Livewire\livewire;
 
 beforeEach(function () {
-    $this->seed(ContentTypeSeeder::class);
-    $this->seed(ImpactSeeder::class);
-    $this->seed(SectorSeeder::class);
-    $this->seed(TopicSeeder::class);
+    seed(ContentTypeSeeder::class);
+    seed(ImpactSeeder::class);
+    seed(SectorSeeder::class);
+    seed(TopicSeeder::class);
 
     $this->contentType = ContentType::first();
     $this->impact = Impact::first();

--- a/tests/Feature/Livewire/ThemeSwitcherTest.php
+++ b/tests/Feature/Livewire/ThemeSwitcherTest.php
@@ -3,11 +3,12 @@
 use App\Livewire\ThemeSwitcher;
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 test('setting theme updates current user preference', function () {
     $user = User::factory()->create();
-    $this->actingAs($user);
+    actingAs($user);
 
     livewire(ThemeSwitcher::class)
         ->call('setTheme', 'dark')

--- a/tests/Feature/LocalizationTest.php
+++ b/tests/Feature/LocalizationTest.php
@@ -2,21 +2,24 @@
 
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertAuthenticated;
+use function Pest\Laravel\post;
+
 test('user is redirected to preferred locale on login', function () {
     $user = User::factory()->create(['locale' => 'fr']);
 
-    $response = $this->post(localized_route('login-store'), [
+    post(localized_route('login-store'), [
         'email' => $user->email,
         'password' => 'password',
-    ]);
+    ])->assertRedirect(localized_route('dashboard', [], 'fr'));
 
-    $this->assertAuthenticated();
-    $response->assertRedirect(localized_route('dashboard', [], 'fr'));
+    assertAuthenticated();
 });
 
 test('user is redirected to preferred locale when editing language preferences', function () {
     $user = User::factory()->create(['locale' => 'fr']);
 
-    $response = $this->actingAs($user)->withCookie('locale', 'fr')->get(localized_route('settings.edit-language-preferences'));
-    $response->assertRedirect(localized_route('settings.edit-language-preferences', [], 'fr'));
+    actingAs($user)->withCookie('locale', 'fr')->get(localized_route('settings.edit-language-preferences'))
+        ->assertRedirect(localized_route('settings.edit-language-preferences', [], 'fr'));
 });

--- a/tests/Feature/MatchingStrategyTest.php
+++ b/tests/Feature/MatchingStrategyTest.php
@@ -8,8 +8,10 @@ use App\Models\User;
 use Database\Seeders\IdentitySeeder;
 use Database\Seeders\LanguageSeeder;
 
+use function Pest\Laravel\seed;
+
 beforeEach(function () {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
     $this->strategy = MatchingStrategy::factory()->create();
 });
 
@@ -141,7 +143,7 @@ test('matching strategy disability and deaf group summary accessor', function ($
 })->with('matchingStrategyDisabilityAndDeafGroupSummary');
 
 test('matching strategy other identities summary accessor', function ($data, array $identities, ?array $expected = null) {
-    $this->seed(LanguageSeeder::class);
+    seed(LanguageSeeder::class);
     $matchingStrategy = MatchingStrategy::factory()->create($data);
     $expectedIdentities = [];
 

--- a/tests/Feature/MeetingTest.php
+++ b/tests/Feature/MeetingTest.php
@@ -10,6 +10,9 @@ use App\Models\RegulatedOrganization;
 use App\Models\User;
 use Database\Seeders\IdentitySeeder;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\seed;
+
 beforeEach(function () {
     $user = User::factory()->create(['context' => 'regulated-organization']);
     $otherUser = User::factory()->create();
@@ -25,7 +28,7 @@ beforeEach(function () {
 });
 
 test('meetings can be created', function () {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 
     $user = User::where('context', 'regulated-organization')->first();
     $otherUser = User::where('context', 'individual')->first();
@@ -36,13 +39,13 @@ test('meetings can be created', function () {
     expect($engagement->meeting_dates)->toBeNull();
     expect($engagement->display_meeting_types)->toBeEmpty();
 
-    $response = $this->actingAs($otherUser)->get(localized_route('meetings.create', $engagement));
-    $response->assertForbidden();
+    actingAs($otherUser)->get(localized_route('meetings.create', $engagement))
+        ->assertForbidden();
 
-    $response = $this->actingAs($user)->get(localized_route('meetings.create', $engagement));
-    $response->assertOk();
+    actingAs($user)->get(localized_route('meetings.create', $engagement))
+        ->assertOk();
 
-    $response = $this->actingAs($user)->post(localized_route('meetings.store', $engagement), [
+    actingAs($user)->post(localized_route('meetings.store', $engagement), [
         'title' => ['en' => 'Meeting 1'],
         'date' => '2022-11-15',
         'start_time' => '9:00',
@@ -56,13 +59,13 @@ test('meetings can be created', function () {
         'meeting_software' => 'WebMeetingApp',
         'meeting_url' => 'https://example.com/meet',
         'meeting_phone' => '6476231847',
-    ]);
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('engagements.manage', $engagement));
+    ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('engagements.manage', $engagement));
 
-    $response = $this->actingAs($user)->get(localized_route('engagements.manage', $engagement));
-    $response->assertSee('Meeting 1');
-    $response->assertSee('Tuesday, November 15, 2022 9:00 AM');
+    actingAs($user)->get(localized_route('engagements.manage', $engagement))
+        ->assertSee('Meeting 1')
+        ->assertSee('Tuesday, November 15, 2022 9:00 AM');
 
     expect($engagement->fresh()->meeting_dates)->toEqual('November 15, 2022');
 });
@@ -100,16 +103,16 @@ test('meetings can be edited', function () {
         'postal_code' => 'M4W 1E6',
     ]);
 
-    $response = $this->actingAs($otherUser)->get(localized_route('meetings.edit', ['meeting' => $meeting, 'engagement' => $engagement]));
-    $response->assertForbidden();
+    actingAs($otherUser)->get(localized_route('meetings.edit', ['meeting' => $meeting, 'engagement' => $engagement]))
+        ->assertForbidden();
 
-    $response = $this->actingAs($user)->get(localized_route('meetings.edit', ['meeting' => $meeting, 'engagement' => $engagement]));
-    $response->assertOk();
+    actingAs($user)->get(localized_route('meetings.edit', ['meeting' => $meeting, 'engagement' => $engagement]))
+        ->assertOk();
 
     $meeting = $meeting->fresh();
     expect($engagement->meeting_dates)->toEqual('November 15–December 15, 2022');
 
-    $response = $this->actingAs($user)->put(localized_route('meetings.update', ['meeting' => $meeting, 'engagement' => $engagement]), [
+    actingAs($user)->put(localized_route('meetings.update', ['meeting' => $meeting, 'engagement' => $engagement]), [
         'title' => ['en' => 'Meeting 1'],
         'date' => '2022-12-06',
         'start_time' => '9:00',
@@ -123,9 +126,9 @@ test('meetings can be edited', function () {
         'meeting_software' => 'WebMeetingApp',
         'meeting_url' => 'https://example.com/meet',
         'meeting_phone' => '6476231847',
-    ]);
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('engagements.manage', $engagement));
+    ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('engagements.manage', $engagement));
 
     $meeting = $meeting->fresh();
     $engagement = $engagement->fresh();
@@ -162,16 +165,16 @@ test('Meeting request validation errors', function ($state, array $errors, $modi
     $data = $requestFactory->without($modifiers['without'] ?? [])->create($state);
 
     // create meeting
-    $response = $this->actingAs($user)->post(localized_route('meetings.store', $engagement), $data);
-    $response->assertSessionHasErrors($errors);
+    actingAs($user)->post(localized_route('meetings.store', $engagement), $data)
+        ->assertSessionHasErrors($errors);
 
     // update existing meeting
-    $response = $this->actingAs($user)->post(localized_route('meetings.update', ['meeting' => $meeting, 'engagement' => $engagement]), $data);
-    $response->assertSessionHasErrors($errors);
+    actingAs($user)->post(localized_route('meetings.update', ['meeting' => $meeting, 'engagement' => $engagement]), $data)
+        ->assertSessionHasErrors($errors);
 })->with('meetingRequestValidationErrors');
 
 test('meetings can be deleted', function () {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 
     $user = User::where('context', 'regulated-organization')->first();
     $otherUser = User::where('context', 'individual')->first();
@@ -192,13 +195,13 @@ test('meetings can be deleted', function () {
         'postal_code' => 'M4W 1E6',
     ]);
 
-    $response = $this->actingAs($otherUser)->delete(localized_route('meetings.destroy', ['meeting' => $meeting, 'engagement' => $engagement]));
-    $response->assertForbidden();
+    actingAs($otherUser)->delete(localized_route('meetings.destroy', ['meeting' => $meeting, 'engagement' => $engagement]))
+        ->assertForbidden();
 
-    $response = $this->actingAs($user)->delete(localized_route('meetings.destroy', ['meeting' => $meeting, 'engagement' => $engagement]));
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('engagements.manage', $engagement));
+    actingAs($user)->delete(localized_route('meetings.destroy', ['meeting' => $meeting, 'engagement' => $engagement]))
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('engagements.manage', $engagement));
 
-    $response = $this->actingAs($user)->get(localized_route('engagements.manage', $engagement));
-    $response->assertSee('No meetings found.');
+    actingAs($user)->get(localized_route('engagements.manage', $engagement))
+        ->assertSee('No meetings found.');
 });

--- a/tests/Feature/NotificationListTest.php
+++ b/tests/Feature/NotificationListTest.php
@@ -4,18 +4,18 @@ use App\Models\Organization;
 use App\Models\RegulatedOrganization;
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
+
 test('only individual users can have a notification list', function () {
     $user = User::factory()->create();
 
-    $response = $this->actingAs($user)->get(localized_route('notification-list.show'));
-
-    $response->assertOk();
+    actingAs($user)->get(localized_route('notification-list.show'))
+        ->assertOk();
 
     $regulatedOrganizationUser = User::factory()->create(['context' => 'regulated-organization']);
 
-    $response = $this->actingAs($regulatedOrganizationUser)->get(localized_route('notification-list.show'));
-
-    $response->assertForbidden();
+    actingAs($regulatedOrganizationUser)->get(localized_route('notification-list.show'))
+        ->assertForbidden();
 });
 
 test('individual users can add and remove regulated organizations from their notification list', function () {
@@ -23,34 +23,33 @@ test('individual users can add and remove regulated organizations from their not
     $regulatedOrganization = RegulatedOrganization::factory()->create(['name' => ['en' => 'Umbrella Corporation']]);
     $regulatedOrganization->publish();
 
-    $response = $this->actingAs($user)->get(localized_route('regulated-organizations.show', $regulatedOrganization));
-    $response->assertSee('Add to my notification list');
+    actingAs($user)->get(localized_route('regulated-organizations.show', $regulatedOrganization))
+        ->assertSee('Add to my notification list');
 
-    $response = $this->actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
+    actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
         ->post(localized_route('notification-list.add'), [
             'notificationable_type' => get_class($regulatedOrganization),
             'notificationable_id' => $regulatedOrganization->id,
-        ]);
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('regulated-organizations.show', $regulatedOrganization));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('regulated-organizations.show', $regulatedOrganization));
 
-    $response = $this->actingAs($user)->get(localized_route('regulated-organizations.show', $regulatedOrganization));
-    $response->assertSee('Remove from my notification list');
+    actingAs($user)->get(localized_route('regulated-organizations.show', $regulatedOrganization))
+        ->assertSee('Remove from my notification list');
 
-    $response = $this->actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
+    actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
         ->post(localized_route('notification-list.remove'), [
             'notificationable_type' => get_class($regulatedOrganization),
             'notificationable_id' => $regulatedOrganization->id,
-        ]);
-
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('regulated-organizations.show', $regulatedOrganization));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('regulated-organizations.show', $regulatedOrganization));
 
     $user = $user->fresh();
 
     expect($user->regulatedOrganizationsForNotification)->toHaveCount(0);
 
-    $this->actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
+    actingAs($user)->from(localized_route('regulated-organizations.show', $regulatedOrganization))
         ->post(localized_route('notification-list.add'), [
             'notificationable_type' => get_class($regulatedOrganization),
             'notificationable_id' => $regulatedOrganization->id,
@@ -58,17 +57,16 @@ test('individual users can add and remove regulated organizations from their not
 
     expect($regulatedOrganization->isNotifying($user))->toBeTrue();
 
-    $response = $this->actingAs($user)->get(localized_route('notification-list.show'));
-    $response->assertSee('Umbrella Corporation');
+    actingAs($user)->get(localized_route('notification-list.show'))
+        ->assertSee('Umbrella Corporation');
 
-    $response = $this->actingAs($user)->from(localized_route('notification-list.show'))
+    actingAs($user)->from(localized_route('notification-list.show'))
         ->post(localized_route('notification-list.remove'), [
             'notificationable_type' => get_class($regulatedOrganization),
             'notificationable_id' => $regulatedOrganization->id,
-        ]);
-
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('notification-list.show'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('notification-list.show'));
 
     $user = $user->fresh();
 
@@ -82,49 +80,47 @@ test('individual users can add and remove organizations from their notification 
     $user = User::factory()->create();
     $organization = Organization::factory()->create(['name' => ['en' => 'Umbrella Corporation'], 'published_at' => now()]);
 
-    $response = $this->actingAs($user)->from(localized_route('organizations.show', $organization))
+    actingAs($user)->from(localized_route('organizations.show', $organization))
         ->post(localized_route('notification-list.add'), [
             'notificationable_type' => get_class($organization),
             'notificationable_id' => $organization->id,
-        ]);
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('organizations.show', $organization));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('organizations.show', $organization));
 
     expect($organization->isNotifying($user))->toBeTrue();
 
-    $response = $this->actingAs($user)->get(localized_route('organizations.show', $organization));
-    $response->assertSee('Remove from my notification list');
+    actingAs($user)->get(localized_route('organizations.show', $organization))
+        ->assertSee('Remove from my notification list');
 
-    $response = $this->actingAs($user)->from(localized_route('organizations.show', $organization))
+    actingAs($user)->from(localized_route('organizations.show', $organization))
         ->post(localized_route('notification-list.remove'), [
             'notificationable_type' => get_class($organization),
             'notificationable_id' => $organization->id,
-        ]);
-
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('organizations.show', $organization));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('organizations.show', $organization));
 
     $user = $user->fresh();
 
     expect($user->organizationsForNotification)->toHaveCount(0);
 
-    $this->actingAs($user)->from(localized_route('organizations.show', $organization))
+    actingAs($user)->from(localized_route('organizations.show', $organization))
         ->post(localized_route('notification-list.add'), [
             'notificationable_type' => get_class($organization),
             'notificationable_id' => $organization->id,
         ]);
 
-    $response = $this->actingAs($user)->get(localized_route('notification-list.show'));
-    $response->assertSee('Umbrella Corporation');
+    actingAs($user)->get(localized_route('notification-list.show'))
+        ->assertSee('Umbrella Corporation');
 
-    $response = $this->actingAs($user)->from(localized_route('notification-list.show'))
+    actingAs($user)->from(localized_route('notification-list.show'))
         ->post(localized_route('notification-list.remove'), [
             'notificationable_type' => get_class($organization),
             'notificationable_id' => $organization->id,
-        ]);
-
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect(localized_route('notification-list.show'));
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('notification-list.show'));
 
     $user = $user->fresh();
 
@@ -148,7 +144,7 @@ test('add notificationable validation errors', function ($data, ?array $errors =
         'notificationable_id' => $user->id,
     ];
 
-    $response = $this->actingAs($user)->post(localized_route('notification-list.add'), array_merge($baseData, empty($data) ? $alternateData : $data));
+    $response = actingAs($user)->post(localized_route('notification-list.add'), array_merge($baseData, empty($data) ? $alternateData : $data));
 
     if (isset($errors)) {
         $response->assertSessionHasErrors($errors);
@@ -166,7 +162,6 @@ test('remove notificationable validation errors', function ($data, array $errors
         'notificationable_id' => $organization->id,
     ];
 
-    $response = $this->actingAs($user)->post(localized_route('notification-list.remove'), array_merge($baseData, $data));
-
-    $response->assertSessionHasErrors($errors);
+    actingAs($user)->post(localized_route('notification-list.remove'), array_merge($baseData, $data))
+        ->assertSessionHasErrors($errors);
 })->with('removeNotificaitonableRequestValidationErrors');

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use App\Notifications\AgreementReceived;
 use App\Notifications\OrganizationalContractorInvited;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 test('organization users see merged notifications for their organizations and projects', function () {
@@ -35,12 +36,12 @@ test('organization users see merged notifications for their organizations and pr
     expect($organizationAdministrator->allUnreadNotifications())->toHaveCount(2);
     expect($organizationAdministrator->allNotifications())->toHaveCount(2);
 
-    $response = $this->actingAs($organizationAdministrator)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your agreement has been received');
-    $response->assertSee('Your organization has been invited as a Community Connector');
+    actingAs($organizationAdministrator)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your agreement has been received')
+        ->assertSee('Your organization has been invited as a Community Connector');
 
-    $this->actingAs($organizationAdministrator);
+    actingAs($organizationAdministrator);
 
     livewire(MarkNotificationAsRead::class, ['notification' => $organizationAdministrator->allUnreadNotifications()->first()])
         ->call('markAsRead');
@@ -50,17 +51,15 @@ test('organization users see merged notifications for their organizations and pr
     expect($organizationAdministrator->allUnreadNotifications())->toHaveCount(1);
     expect($organizationAdministrator->allNotifications())->toHaveCount(2);
 
-    $response = $this->actingAs($organizationAdministrator)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
+    actingAs($organizationAdministrator)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your agreement has been received')
+        ->assertDontSee('Your organization has been invited as a Community Connector');
 
-    $response->assertSee('Your agreement has been received');
-    $response->assertDontSee('Your organization has been invited as a Community Connector');
-
-    $response = $this->actingAs($organizationAdministrator)->get(localized_route('dashboard.notifications-all'));
-    $response->assertOk();
-
-    $response->assertSee('Your agreement has been received');
-    $response->assertSee('Your organization has been invited as a Community Connector');
+    actingAs($organizationAdministrator)->get(localized_route('dashboard.notifications-all'))
+        ->assertOk()
+        ->assertSee('Your agreement has been received')
+        ->assertSee('Your organization has been invited as a Community Connector');
 });
 
 test('regulated organization users see merged notifications for their regulated organizations and projects', function () {
@@ -79,11 +78,11 @@ test('regulated organization users see merged notifications for their regulated 
     expect($regulatedOrganizationAdministrator->allUnreadNotifications())->toHaveCount(1);
     expect($regulatedOrganizationAdministrator->allNotifications())->toHaveCount(1);
 
-    $response = $this->actingAs($regulatedOrganizationAdministrator)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
-    $response->assertSee('Your agreement has been received');
+    actingAs($regulatedOrganizationAdministrator)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertSee('Your agreement has been received');
 
-    $this->actingAs($regulatedOrganizationAdministrator);
+    actingAs($regulatedOrganizationAdministrator);
 
     livewire(MarkNotificationAsRead::class, ['notification' => $regulatedOrganizationAdministrator->allUnreadNotifications()->first()])
         ->call('markAsRead');
@@ -93,13 +92,11 @@ test('regulated organization users see merged notifications for their regulated 
     expect($regulatedOrganizationAdministrator->allUnreadNotifications())->toHaveCount(0);
     expect($regulatedOrganizationAdministrator->allNotifications())->toHaveCount(1);
 
-    $response = $this->actingAs($regulatedOrganizationAdministrator)->get(localized_route('dashboard.notifications'));
-    $response->assertOk();
+    actingAs($regulatedOrganizationAdministrator)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertDontSee('Your agreement has been received');
 
-    $response->assertDontSee('Your agreement has been received');
-
-    $response = $this->actingAs($regulatedOrganizationAdministrator)->get(localized_route('dashboard.notifications-all'));
-    $response->assertOk();
-
-    $response->assertSee('Your agreement has been received');
+    actingAs($regulatedOrganizationAdministrator)->get(localized_route('dashboard.notifications-all'))
+        ->assertOk()
+        ->assertSee('Your agreement has been received');
 });

--- a/tests/Feature/OrganizationTest.php
+++ b/tests/Feature/OrganizationTest.php
@@ -26,6 +26,10 @@ use Tests\RequestFactories\UpdateOrganizationRequestFactory;
 
 use function Pest\Faker\fake;
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\from;
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\seed;
 
 test('users can create organizations', function () {
     $user = User::factory()->create(['context' => 'organization', 'locale' => 'asl']);
@@ -99,7 +103,7 @@ test('users can create organizations', function () {
 });
 
 test('users with admin role can edit and publish organizations', function () {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 
     $user = User::factory()->create(['context' => 'organization']);
     $organization = Organization::factory()
@@ -173,7 +177,7 @@ test('users with admin role can edit and publish organizations', function () {
 });
 
 test('users with admin role can edit organization constituencies', function () {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 
     $user = User::factory()->create(['context' => 'organization']);
     $organization = Organization::factory()
@@ -324,8 +328,8 @@ test('users with admin role can edit organization constituencies', function () {
 });
 
 test('users with admin role can edit organization interests', function () {
-    $this->seed(ImpactSeeder::class);
-    $this->seed(SectorSeeder::class);
+    seed(ImpactSeeder::class);
+    seed(SectorSeeder::class);
 
     $user = User::factory()->create(['context' => 'organization']);
     $organization = Organization::factory()
@@ -589,7 +593,7 @@ test('organization pages cannot be published by other users', function () {
 });
 
 test('organization isPublishable()', function ($expected, $data, $connections = []) {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 
     // fill data so that we don't hit a Database Integrity constraint violation during creation
     $organization = Organization::factory()->create();
@@ -935,16 +939,14 @@ test('users with admin role can delete organizations', function () {
         ->hasAttached($user, ['role' => 'admin'])
         ->create();
 
-    $response = $this->post(localized_route('login'), [
+    post(localized_route('login'), [
         'email' => $user->email,
         'password' => 'password',
     ]);
 
-    $response = $this->from(localized_route('organizations.edit', $organization))->delete(localized_route('organizations.destroy', $organization), [
+    from(localized_route('organizations.edit', $organization))->delete(localized_route('organizations.destroy', $organization), [
         'current_password' => 'password',
-    ]);
-
-    $response->assertRedirect(localized_route('dashboard'));
+    ])->assertRedirect(localized_route('dashboard'));
 });
 
 test('users with admin role cannot delete organizations with wrong password', function () {
@@ -953,17 +955,16 @@ test('users with admin role cannot delete organizations with wrong password', fu
         ->hasAttached($user, ['role' => 'admin'])
         ->create();
 
-    $response = $this->post(localized_route('login'), [
+    post(localized_route('login'), [
         'email' => $user->email,
         'password' => 'password',
     ]);
 
-    $response = $this->from(localized_route('organizations.edit', $organization))->delete(localized_route('organizations.destroy', $organization), [
+    from(localized_route('organizations.edit', $organization))->delete(localized_route('organizations.destroy', $organization), [
         'current_password' => 'wrong_password',
-    ]);
-
-    $response->assertSessionHasErrors();
-    $response->assertRedirect(localized_route('organizations.edit', $organization));
+    ])
+        ->assertSessionHasErrors()
+        ->assertRedirect(localized_route('organizations.edit', $organization));
 });
 
 test('users without admin role cannot delete organizations', function () {
@@ -972,16 +973,14 @@ test('users without admin role cannot delete organizations', function () {
         ->hasAttached($user, ['role' => 'member'])
         ->create();
 
-    $response = $this->post(localized_route('login'), [
+    post(localized_route('login'), [
         'email' => $user->email,
         'password' => 'password',
     ]);
 
-    $response = $this->from(localized_route('organizations.edit', $organization))->delete(localized_route('organizations.destroy', $organization), [
+    from(localized_route('organizations.edit', $organization))->delete(localized_route('organizations.destroy', $organization), [
         'current_password' => 'password',
-    ]);
-
-    $response->assertForbidden();
+    ])->assertForbidden();
 });
 
 test('non members cannot delete organizations', function () {
@@ -996,16 +995,14 @@ test('non members cannot delete organizations', function () {
         ->hasAttached($other_user, ['role' => 'admin'])
         ->create();
 
-    $response = $this->post(localized_route('login'), [
+    post(localized_route('login'), [
         'email' => $user->email,
         'password' => 'password',
     ]);
 
-    $response = $this->from(localized_route('organizations.edit', $other_organization))->delete(localized_route('organizations.destroy', $other_organization), [
+    from(localized_route('organizations.edit', $other_organization))->delete(localized_route('organizations.destroy', $other_organization), [
         'current_password' => 'password',
-    ]);
-
-    $response->assertForbidden();
+    ])->assertForbidden();
 });
 
 test('users can not view organizations if they are not oriented', function () {
@@ -1056,11 +1053,11 @@ test('users can view organizations', function () {
 test('guests cannot view organizations', function () {
     $organization = Organization::factory()->create();
 
-    $response = $this->get(localized_route('organizations.index'));
-    $response->assertRedirect(localized_route('login'));
+    get(localized_route('organizations.index'))
+        ->assertRedirect(localized_route('login'));
 
-    $response = $this->get(localized_route('organizations.show', $organization));
-    $response->assertRedirect(localized_route('login'));
+    get(localized_route('organizations.show', $organization))
+        ->assertRedirect(localized_route('login'));
 });
 
 test('organizational relationships to projects can be derived from both projects and engagements', function () {
@@ -1161,7 +1158,7 @@ test('organization can have many courses', function () {
 });
 
 test('Organization isInProgress()', function ($data, $withConstituentIdentity, $expected) {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
     $organization = Organization::factory()
         ->create($data);
 

--- a/tests/Feature/PasswordConfirmationTest.php
+++ b/tests/Feature/PasswordConfirmationTest.php
@@ -2,31 +2,29 @@
 
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
+
 test('confirm password screen can be rendered', function () {
     $user = User::factory()->create();
 
-    $response = $this->actingAs($user)->get(localized_route('password.confirm'));
-
-    $response->assertOk();
+    actingAs($user)->get(localized_route('password.confirm'))
+        ->assertOk();
 });
 
 test('password can be confirmed', function () {
     $user = User::factory()->create();
 
-    $response = $this->actingAs($user)->post(localized_route('password.confirm'), [
+    actingAs($user)->post(localized_route('password.confirm'), [
         'password' => 'password',
-    ]);
-
-    $response->assertRedirect();
-    $response->assertSessionHasNoErrors();
+    ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
 });
 
 test('password is not confirmed with invalid password', function () {
     $user = User::factory()->create();
 
-    $response = $this->actingAs($user)->post(localized_route('password.confirm'), [
+    actingAs($user)->post(localized_route('password.confirm'), [
         'password' => 'wrong-password',
-    ]);
-
-    $response->assertSessionHasErrors();
+    ])->assertSessionHasErrors();
 });

--- a/tests/Feature/PasswordResetTest.php
+++ b/tests/Feature/PasswordResetTest.php
@@ -4,10 +4,11 @@ use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
 
-test('reset password link screen can be rendered', function () {
-    $response = $this->get(localized_route('password.request'));
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
 
-    $response->assertOk();
+test('reset password link screen can be rendered', function () {
+    get(localized_route('password.request'))->assertOk();
 });
 
 test('reset password link can be requested', function () {
@@ -15,7 +16,7 @@ test('reset password link can be requested', function () {
 
     $user = User::factory()->create();
 
-    $this->post(route('password.email'), ['email' => $user->email]);
+    post(route('password.email'), ['email' => $user->email]);
 
     Notification::assertSentTo($user, ResetPassword::class);
 });
@@ -25,12 +26,10 @@ test('reset password screen can be rendered', function () {
 
     $user = User::factory()->create();
 
-    $this->post(route('password.email'), ['email' => $user->email]);
+    post(route('password.email'), ['email' => $user->email]);
 
     Notification::assertSentTo($user, ResetPassword::class, function ($notification) {
-        $response = $this->get(route('password.reset', $notification->token));
-
-        $response->assertOk();
+        get(route('password.reset', $notification->token))->assertOk();
 
         return true;
     });
@@ -41,20 +40,17 @@ test('password can be reset with valid token', function () {
 
     $user = User::factory()->create();
 
-    $this->post(route('password.email'), ['email' => $user->email]);
+    post(route('password.email'), ['email' => $user->email]);
 
     Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
-        $response = $this->post(localized_route('password.update', ['token' => $notification->token]), [
+        post(localized_route('password.update', ['token' => $notification->token]), [
             'email' => $user->email,
             'password' => 'correctHorse-batteryStaple7',
             'password_confirmation' => 'correctHorse-batteryStaple7',
-        ]);
-
-        $response->assertRedirect();
-
-        $response->assertSessionHasNoErrors();
-
-        $response->assertSessionHas('status', 'You have successfully reset your password for The Accessibility Exchange.');
+        ])
+            ->assertRedirect()
+            ->assertSessionHasNoErrors()
+            ->assertSessionHas('status', 'You have successfully reset your password for The Accessibility Exchange.');
 
         return true;
     });

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -23,6 +23,8 @@ use Database\Seeders\SectorSeeder;
 
 use function Pest\Faker\fake;
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Laravel\seed;
 
 test('users with organization or regulated organization admin role can create projects', function () {
     $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
@@ -177,7 +179,7 @@ test('store project request validation errors', function (array $state, array $e
 })->with('storeProjectRequestValidationErrors');
 
 test('projects can be published and unpublished', function () {
-    $this->seed(ImpactSeeder::class);
+    seed(ImpactSeeder::class);
     $adminUser = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
     $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
     $regulatedOrganization = RegulatedOrganization::factory()
@@ -234,7 +236,7 @@ test('projects can be published and unpublished', function () {
 });
 
 test('project isPublishable()', function ($expected, $data, $connections = [], $context = 'organization', $projectableData = []) {
-    $this->seed(ImpactSeeder::class);
+    seed(ImpactSeeder::class);
 
     $adminUser = User::factory()->create(['context' => $context]);
     $user = User::factory()->create(['context' => $context]);
@@ -482,15 +484,15 @@ test('guests cannot view projects', function () {
         'projectable_id' => $regulatedOrganization->id,
     ]);
 
-    $response = $this->get(localized_route('projects.all-projects'));
-    $response->assertRedirect(localized_route('login'));
+    get(localized_route('projects.all-projects'))
+        ->assertRedirect(localized_route('login'));
 
-    $response = $this->get(localized_route('projects.show', $project));
-    $response->assertRedirect(localized_route('login'));
+    get(localized_route('projects.show', $project))
+        ->assertRedirect(localized_route('login'));
 });
 
 test('users with regulated organization admin role can edit projects', function () {
-    $this->seed(ImpactSeeder::class);
+    seed(ImpactSeeder::class);
 
     $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
     $regulatedOrganization = RegulatedOrganization::factory()
@@ -603,7 +605,7 @@ test('users without regulated organization admin role cannot edit projects', fun
 });
 
 test('projects can edit outcome_analysis_other', function () {
-    $this->seed(ImpactSeeder::class);
+    seed(ImpactSeeder::class);
 
     $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
     $regulatedOrganization = RegulatedOrganization::factory()
@@ -643,7 +645,7 @@ test('projects can edit outcome_analysis_other', function () {
 });
 
 test('update project request validation errors', function (array $state, array $errors, array $without = []) {
-    $this->seed(ImpactSeeder::class);
+    seed(ImpactSeeder::class);
 
     $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
     $regulatedOrganization = RegulatedOrganization::factory()
@@ -666,7 +668,7 @@ test('update project request validation errors', function (array $state, array $
 })->with('updateProjectRequestValidationErrors');
 
 test('update project team request validation errors', function (array $state, array $errors, array $without = []) {
-    $this->seed(ImpactSeeder::class);
+    seed(ImpactSeeder::class);
 
     $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
     $regulatedOrganization = RegulatedOrganization::factory()
@@ -1003,8 +1005,8 @@ test('registered users can access my projects page', function () {
 });
 
 test('guests can not access my projects page', function () {
-    $response = $this->get(localized_route('projects.my-projects'));
-    $response->assertRedirect(localized_route('login'));
+    get(localized_route('projects.my-projects'))
+        ->assertRedirect(localized_route('login'));
 });
 
 test('test project statuses scope', function () {
@@ -1108,7 +1110,7 @@ test('test project initiators scope', function () {
 });
 
 test('test project seekingDisabilityAndDeafGroups scope', function () {
-    $this->seed(IdentitySeeder::class);
+    seed(IdentitySeeder::class);
 
     $disabilityTypeDeaf = Identity::where('name->en', 'Deaf')->first();
     $projectSeekingDeafExperienceName = 'Project Seeking Deaf Experience';
@@ -1207,7 +1209,7 @@ test('test project compensations scope', function () {
 });
 
 test('test project sectors scope', function () {
-    $this->seed(SectorSeeder::class);
+    seed(SectorSeeder::class);
     $regulatedPrivateSector = Sector::where('name->en', 'Federally Regulated private sector')->first();
     $privateRegulatedOrganization = RegulatedOrganization::factory()->create();
     $privateRegulatedOrganization->sectors()->save($regulatedPrivateSector);
@@ -1235,7 +1237,7 @@ test('test project sectors scope', function () {
 });
 
 test('test project areas of impact scope', function () {
-    $this->seed(ImpactSeeder::class);
+    seed(ImpactSeeder::class);
     $employmentImpact = Impact::where('name->en', 'Employment')->first();
     $employmentImpactProject = Project::factory()->create();
     $employmentImpactProject->impacts()->attach($employmentImpact->id);

--- a/tests/Feature/ResourceCollectionTest.php
+++ b/tests/Feature/ResourceCollectionTest.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\App;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
 use function Pest\Livewire\livewire;
 
 test('resource collections can be translated', function () {
@@ -50,7 +52,7 @@ test('many resources can belong in single resource collection', function () {
 
     foreach ($resources as $resource) {
         $resourceCollection->resources()->sync($resource->id);
-        $this->assertDatabaseHas('resource_resource_collection', [
+        assertDatabaseHas('resource_resource_collection', [
             'resource_collection_id' => $resourceCollection->id,
             'resource_id' => $resource->id,
         ]);
@@ -62,18 +64,18 @@ test('deleting resources belonging to resource collection removes them from the 
     $resource = Resource::factory()->create();
     $resourceCollection->resources()->sync($resource->id);
 
-    $this->assertDatabaseHas('resources', [
+    assertDatabaseHas('resources', [
         'id' => $resource->id,
     ]);
 
-    $this->assertDatabaseHas('resource_resource_collection', [
+    assertDatabaseHas('resource_resource_collection', [
         'resource_collection_id' => $resourceCollection->id,
         'resource_id' => $resource->id,
     ]);
 
     $resource->delete();
 
-    $this->assertDatabaseMissing('resource_resource_collection', [
+    assertDatabaseMissing('resource_resource_collection', [
         'resource_collection_id' => $resourceCollection->id,
         'resource_id' => $resource->id,
     ]);
@@ -84,18 +86,18 @@ test('users can view resource collections', function () {
     $administrator = User::factory()->create(['context' => 'administrator']);
     $resourceCollection = ResourceCollection::factory()->create();
 
-    $response = $this->actingAs($user)->get(localized_route('resource-collections.index'));
-    $response->assertOk();
-    $response->assertSee($resourceCollection->title);
+    actingAs($user)->get(localized_route('resource-collections.index'))
+        ->assertOk()
+        ->assertSee($resourceCollection->title);
 
-    $response = $this->actingAs($user)->get(localized_route('resource-collections.show', $resourceCollection));
-    $response->assertOk();
-    $response->assertSee($resourceCollection->title);
-    $response->assertDontSee('Edit resource collection');
+    actingAs($user)->get(localized_route('resource-collections.show', $resourceCollection))
+        ->assertOk()
+        ->assertSee($resourceCollection->title)
+        ->assertDontSee('Edit resource collection');
 
-    $response = $this->actingAs($administrator)->get(localized_route('resource-collections.show', $resourceCollection));
-    $response->assertOk();
-    $response->assertSee('Edit resource collection');
+    actingAs($administrator)->get(localized_route('resource-collections.show', $resourceCollection))
+        ->assertOk()
+        ->assertSee('Edit resource collection');
 });
 
 test('only administrative users can access resource collection admin pages', function () {

--- a/tests/Feature/ResourceTest.php
+++ b/tests/Feature/ResourceTest.php
@@ -18,6 +18,10 @@ use Database\Seeders\TopicSeeder;
 use Illuminate\Support\Facades\App;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+use function Pest\Laravel\seed;
 use function Pest\Livewire\livewire;
 
 test('resources can be translated', function () {
@@ -42,24 +46,24 @@ test('resources can be translated', function () {
 });
 
 test('users can view resources', function () {
-    $this->seed(ContentTypeSeeder::class);
+    seed(ContentTypeSeeder::class);
 
     $user = User::factory()->create();
     $administrator = User::factory()->create(['context' => 'administrator']);
     $resource = Resource::factory()->create();
 
-    $response = $this->actingAs($user)->get(localized_route('resources.index'));
-    $response->assertOk();
-    $response->assertSee($resource->title);
+    actingAs($user)->get(localized_route('resources.index'))
+        ->assertOk()
+        ->assertSee($resource->title);
 
-    $response = $this->actingAs($user)->get(localized_route('resources.show', $resource));
-    $response->assertOk();
-    $response->assertSee($resource->title);
-    $response->assertDontSee('Edit resource');
+    actingAs($user)->get(localized_route('resources.show', $resource))
+        ->assertOk()
+        ->assertSee($resource->title)
+        ->assertDontSee('Edit resource');
 
-    $response = $this->actingAs($administrator)->get(localized_route('resources.show', $resource));
-    $response->assertOk();
-    $response->assertSee('Edit resource');
+    actingAs($administrator)->get(localized_route('resources.show', $resource))
+        ->assertOk()
+        ->assertSee('Edit resource');
 });
 
 test('single resource can be in many resource collections', function () {
@@ -69,7 +73,7 @@ test('single resource can be in many resource collections', function () {
 
     foreach ($resourceCollections as $resourceCollection) {
         $resource->resourceCollections()->sync($resourceCollection->id);
-        $this->assertDatabaseHas('resource_resource_collection', [
+        assertDatabaseHas('resource_resource_collection', [
             'resource_collection_id' => $resourceCollection->id,
             'resource_id' => $resource->id,
         ]);
@@ -81,18 +85,18 @@ test('deleting resource collection with resource', function () {
     $resourceCollection = ResourceCollection::factory()->create();
     $resource->resourceCollections()->sync($resourceCollection->id);
 
-    $this->assertDatabaseHas('resource_collections', [
+    assertDatabaseHas('resource_collections', [
         'id' => $resourceCollection->id,
     ]);
 
-    $this->assertDatabaseHas('resource_resource_collection', [
+    assertDatabaseHas('resource_resource_collection', [
         'resource_collection_id' => $resourceCollection->id,
         'resource_id' => $resource->id,
     ]);
 
     $resourceCollection->delete();
 
-    $this->assertDatabaseMissing('resource_resource_collection', [
+    assertDatabaseMissing('resource_resource_collection', [
         'resource_collection_id' => $resourceCollection->id,
         'resource_id' => $resource->id,
     ]);
@@ -125,17 +129,17 @@ test('only administrative users can access resource admin pages', function () {
     $user = User::factory()->create();
     $administrator = User::factory()->create(['context' => 'administrator']);
 
-    $this->actingAs($user)->get(ResourceResource::getUrl('index'))->assertForbidden();
-    $this->actingAs($administrator)->get(ResourceResource::getUrl('index'))->assertSuccessful();
+    actingAs($user)->get(ResourceResource::getUrl('index'))->assertForbidden();
+    actingAs($administrator)->get(ResourceResource::getUrl('index'))->assertSuccessful();
 
-    $this->actingAs($user)->get(ResourceResource::getUrl('create'))->assertForbidden();
-    $this->actingAs($administrator)->get(ResourceResource::getUrl('create'))->assertSuccessful();
+    actingAs($user)->get(ResourceResource::getUrl('create'))->assertForbidden();
+    actingAs($administrator)->get(ResourceResource::getUrl('create'))->assertSuccessful();
 
-    $this->actingAs($user)->get(ResourceResource::getUrl('edit', [
+    actingAs($user)->get(ResourceResource::getUrl('edit', [
         'record' => Resource::factory()->create(),
     ]))->assertForbidden();
 
-    $this->actingAs($administrator)->get(ResourceResource::getUrl('edit', [
+    actingAs($administrator)->get(ResourceResource::getUrl('edit', [
         'record' => Resource::factory()->create(),
     ]))->assertSuccessful();
 });
@@ -162,7 +166,7 @@ test('resources can be scoped by language', function () {
 });
 
 test('resources can be scoped by topic', function () {
-    $this->seed(TopicSeeder::class);
+    seed(TopicSeeder::class);
 
     $topic = Topic::first();
 
@@ -193,7 +197,7 @@ test('resources can be scoped by phase', function () {
 });
 
 test('resources can be scoped by content type', function () {
-    $this->seed(ContentTypeSeeder::class);
+    seed(ContentTypeSeeder::class);
 
     $contentType = ContentType::first();
 
@@ -213,7 +217,7 @@ test('resources can be scoped by content type', function () {
 });
 
 test('resources can be scoped by sector', function () {
-    $this->seed(SectorSeeder::class);
+    seed(SectorSeeder::class);
 
     $sector = Sector::first();
 
@@ -229,7 +233,7 @@ test('resources can be scoped by sector', function () {
 });
 
 test('resources can be scoped by area of impact', function () {
-    $this->seed(ImpactSeeder::class);
+    seed(ImpactSeeder::class);
 
     $impact = Impact::first();
 

--- a/tests/Feature/SectionHeadingTest.php
+++ b/tests/Feature/SectionHeadingTest.php
@@ -4,6 +4,8 @@ use App\Enums\IndividualRole;
 use App\Models\Individual;
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
+
 beforeEach(function () {
     $this->individual = Individual::factory()->create([
         'roles' => [IndividualRole::CommunityConnector->value],
@@ -11,16 +13,14 @@ beforeEach(function () {
 });
 
 test('Section heading for authorized user', function () {
-    $view = $this->actingAs($this->individual->user)->blade(
+    actingAs($this->individual->user)->blade(
         '<x-section-heading :name="$name" :model="$model" :href="$href" />',
         [
             'name' => 'Testing',
             'href' => 'http://example.com',
             'model' => $this->individual,
         ]
-    );
-
-    $view->assertSeeInOrder([
+    )->assertSeeInOrder([
         'h2',
         'Testing',
         'href="http://example.com"',
@@ -31,26 +31,24 @@ test('Section heading for authorized user', function () {
 test('Section heading for unauthorized user', function () {
     $user = User::factory()->create();
 
-    $view = $this->actingAs($user)->blade(
+    actingAs($user)->blade(
         '<x-section-heading :name="$name" :model="$model" :href="$href" />',
         [
             'name' => 'Testing',
             'href' => 'http://example.com',
             'model' => $this->individual,
         ]
-    );
-
-    $view->assertSeeInOrder([
-        'h2',
-        'Testing',
-    ], false);
-
-    $view->assertDontSee('href="http://example.com"', false);
-    $view->assertDontSee('Edit <span class="visually-hidden">Testing</span>', false);
+    )
+        ->assertSeeInOrder([
+            'h2',
+            'Testing',
+        ], false)
+        ->assertDontSee('href="http://example.com"', false)
+        ->assertDontSee('Edit <span class="visually-hidden">Testing</span>', false);
 });
 
 test('Custom section heading level', function () {
-    $view = $this->actingAs($this->individual->user)->blade(
+    actingAs($this->individual->user)->blade(
         '<x-section-heading :level="$level" :name="$name" :model="$model" :href="$href" />',
         [
             'level' => 3,
@@ -58,20 +56,18 @@ test('Custom section heading level', function () {
             'href' => 'http://example.com',
             'model' => $this->individual,
         ]
-    );
-
-    $view->assertSeeInOrder([
-        'h3',
-        'Testing',
-        'href="http://example.com"',
-        'Edit <span class="visually-hidden">Testing</span>',
-    ], false);
-
-    $view->assertDontSee('h2', false);
+    )
+        ->assertSeeInOrder([
+            'h3',
+            'Testing',
+            'href="http://example.com"',
+            'Edit <span class="visually-hidden">Testing</span>',
+        ], false)
+        ->assertDontSee('h2', false);
 });
 
 test('Different link text', function () {
-    $view = $this->actingAs($this->individual->user)->blade(
+    actingAs($this->individual->user)->blade(
         '<x-section-heading :name="$name" :model="$model" :href="$href" :linkText="$linkText"  />',
         [
             'name' => 'Testing',
@@ -79,20 +75,18 @@ test('Different link text', function () {
             'model' => $this->individual,
             'linkText' => 'Custom link',
         ]
-    );
-
-    $view->assertSeeInOrder([
-        'h2',
-        'Testing',
-        'href="http://example.com"',
-        'Edit <span class="visually-hidden">Custom link</span>',
-    ], false);
-
-    $view->assertDontSee('Edit <span class="visually-hidden">Testing</span>', false);
+    )
+        ->assertSeeInOrder([
+            'h2',
+            'Testing',
+            'href="http://example.com"',
+            'Edit <span class="visually-hidden">Custom link</span>',
+        ], false)
+        ->assertDontSee('Edit <span class="visually-hidden">Testing</span>', false);
 });
 
 test('Escaped link text', function () {
-    $view = $this->actingAs($this->individual->user)->blade(
+    actingAs($this->individual->user)->blade(
         '<x-section-heading :name="$name" :model="$model" :href="$href" :linkText="$linkText"  />',
         [
             'name' => 'Testing',
@@ -100,14 +94,12 @@ test('Escaped link text', function () {
             'model' => $this->individual,
             'linkText' => '<strong>Link</strong>',
         ]
-    );
-
-    $view->assertSeeInOrder([
-        'h2',
-        'Testing',
-        'href="http://example.com"',
-        'Edit <span class="visually-hidden">&lt;strong&gt;Link&lt;/strong&gt;</span>',
-    ], false);
-
-    $view->assertDontSee('<strong>Link</strong>', false);
+    )
+        ->assertSeeInOrder([
+            'h2',
+            'Testing',
+            'href="http://example.com"',
+            'Edit <span class="visually-hidden">&lt;strong&gt;Link&lt;/strong&gt;</span>',
+        ], false)
+        ->assertDontSee('<strong>Link</strong>', false);
 });

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -3,6 +3,8 @@
 use App\Models\User;
 use App\Settings\GeneralSettings;
 
+use function Pest\Laravel\actingAs;
+
 test('only administrative users can access the settings page', function () {
     GeneralSettings::fake(
         ['email' => 'support@accessibilityexchange.ca', 'individual_orientation' => ['en' => 'english link'], 'org_orientation' => ['en' => 'english link'], 'fro_orientation' => ['en' => 'english link'], 'ac_application' => ['en' => 'english link'], 'cc_application' => ['en' => 'english link']]
@@ -10,37 +12,37 @@ test('only administrative users can access the settings page', function () {
     $user = User::factory()->create();
     $administrator = User::factory()->create(['context' => 'administrator']);
 
-    $response = $this->actingAs($user)->get(route('filament.admin.pages.settings'));
-    $response->assertForbidden();
+    actingAs($user)->get(route('filament.admin.pages.settings'))
+        ->assertForbidden();
 
-    $response = $this->actingAs($administrator)->get(route('filament.admin.pages.settings'));
-    $response->assertSuccessful();
-    $response->assertSeeInOrder([
-        'Website settings',
-        'Contact',
-        'Support email',
-        'Support phone',
-        'Mailing address',
-        'Social media',
-        'Facebook page',
-        'LinkedIn page',
-        'Twitter page',
-        'YouTube page',
-        'Registration',
-        'Individual orientation',
-        'English',
-        'French',
-        'Community organization orientation',
-        'English',
-        'French',
-        'Federally regulated organization orientation',
-        'English',
-        'French',
-        'Accessibility consultant application',
-        'English',
-        'French',
-        'Community connector application',
-        'English',
-        'French',
-    ]);
+    actingAs($administrator)->get(route('filament.admin.pages.settings'))
+        ->assertSuccessful()
+        ->assertSeeInOrder([
+            'Website settings',
+            'Contact',
+            'Support email',
+            'Support phone',
+            'Mailing address',
+            'Social media',
+            'Facebook page',
+            'LinkedIn page',
+            'Twitter page',
+            'YouTube page',
+            'Registration',
+            'Individual orientation',
+            'English',
+            'French',
+            'Community organization orientation',
+            'English',
+            'French',
+            'Federally regulated organization orientation',
+            'English',
+            'French',
+            'Accessibility consultant application',
+            'English',
+            'French',
+            'Community connector application',
+            'English',
+            'French',
+        ]);
 });

--- a/tests/Feature/SuspensionTest.php
+++ b/tests/Feature/SuspensionTest.php
@@ -11,17 +11,21 @@ use App\Models\Organization;
 use App\Models\Scopes\ReachableIdentityScope;
 use App\Models\Sector;
 use App\Models\User;
+use Database\Seeders\IdentitySeeder;
 use Database\Seeders\ImpactSeeder;
 use Database\Seeders\SectorSeeder;
 use Illuminate\Support\Carbon;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\seed;
 
 beforeEach(function () {
     $this->suspendedUser = User::factory()->create(['suspended_at' => now()]);
     $this->adminUser = User::factory()->create(['context' => 'administrator']);
 
-    $this->seed(IdentitySeeder::class);
-    $this->seed(ImpactSeeder::class);
-    $this->seed(SectorSeeder::class);
+    seed(IdentitySeeder::class);
+    seed(ImpactSeeder::class);
+    seed(SectorSeeder::class);
 
     $this->participantUser = User::factory()->create();
     $this->participantUser->individual->update([
@@ -142,36 +146,36 @@ beforeEach(function () {
 
 test('suspended user cannot access others’ models', function () {
     expect($this->consultant->checkStatus('published'))->toBeTrue();
-    $response = $this->actingAs($this->suspendedUser)->get(localized_route('individuals.show', $this->consultant));
-    $response->assertNotFound();
+    actingAs($this->suspendedUser)->get(localized_route('individuals.show', $this->consultant))
+        ->assertNotFound();
 
     expect($this->organization->checkStatus('published'))->toBeTrue();
-    $response = $this->actingAs($this->suspendedUser)->get(localized_route('organizations.show', $this->organization));
-    $response->assertNotFound();
+    actingAs($this->suspendedUser)->get(localized_route('organizations.show', $this->organization))
+        ->assertNotFound();
 
     expect($this->regulatedOrganization->checkStatus('published'))->toBeTrue();
-    $response = $this->actingAs($this->suspendedUser)->get(localized_route('regulated-organizations.show', $this->regulatedOrganization));
-    $response->assertNotFound();
+    actingAs($this->suspendedUser)->get(localized_route('regulated-organizations.show', $this->regulatedOrganization))
+        ->assertNotFound();
 
     expect($this->project->checkStatus('published'))->toBeTrue();
-    $response = $this->actingAs($this->suspendedUser)->get(localized_route('projects.show', $this->project));
-    $response->assertNotFound();
+    actingAs($this->suspendedUser)->get(localized_route('projects.show', $this->project))
+        ->assertNotFound();
 
     expect($this->engagement->checkStatus('published'))->toBeTrue();
-    $response = $this->actingAs($this->suspendedUser)->get(localized_route('engagements.show', $this->engagement));
-    $response->assertNotFound();
+    actingAs($this->suspendedUser)->get(localized_route('engagements.show', $this->engagement))
+        ->assertNotFound();
 
-    $response = $this->actingAs($this->suspendedUser)->get(localized_route('individuals.index'));
-    $response->assertForbidden();
+    actingAs($this->suspendedUser)->get(localized_route('individuals.index'))
+        ->assertForbidden();
 
-    $response = $this->actingAs($this->suspendedUser)->get(localized_route('organizations.index'));
-    $response->assertForbidden();
+    actingAs($this->suspendedUser)->get(localized_route('organizations.index'))
+        ->assertForbidden();
 
-    $response = $this->actingAs($this->suspendedUser)->get(localized_route('regulated-organizations.index'));
-    $response->assertForbidden();
+    actingAs($this->suspendedUser)->get(localized_route('regulated-organizations.index'))
+        ->assertForbidden();
 
-    $response = $this->actingAs($this->suspendedUser)->get(localized_route('projects.all-projects'));
-    $response->assertForbidden();
+    actingAs($this->suspendedUser)->get(localized_route('projects.all-projects'))
+        ->assertForbidden();
 });
 
 test('suspended users can view their own models', function () {
@@ -182,25 +186,25 @@ test('suspended users can view their own models', function () {
     $this->regulatedOrganizationUser->update(['suspended_at' => now()]);
     $this->regulatedOrganizationUser = $this->regulatedOrganizationUser->fresh();
 
-    $response = $this->actingAs($this->consultantUser)->get(localized_route('individuals.show', $this->consultant));
-    $response->assertOk();
-    $response->assertSee('Your account has been suspended');
+    actingAs($this->consultantUser)->get(localized_route('individuals.show', $this->consultant))
+        ->assertOk()
+        ->assertSee('Your account has been suspended');
 
-    $response = $this->actingAs($this->organizationUser)->get(localized_route('organizations.show', $this->organization));
-    $response->assertOk();
-    $response->assertSee('Your account has been suspended');
+    actingAs($this->organizationUser)->get(localized_route('organizations.show', $this->organization))
+        ->assertOk()
+        ->assertSee('Your account has been suspended');
 
-    $response = $this->actingAs($this->regulatedOrganizationUser)->get(localized_route('regulated-organizations.show', $this->regulatedOrganization));
-    $response->assertOk();
-    $response->assertSee('Your account has been suspended');
+    actingAs($this->regulatedOrganizationUser)->get(localized_route('regulated-organizations.show', $this->regulatedOrganization))
+        ->assertOk()
+        ->assertSee('Your account has been suspended');
 
-    $response = $this->actingAs($this->regulatedOrganizationUser)->get(localized_route('projects.show', $this->project));
-    $response->assertOk();
-    $response->assertSee('Your account has been suspended');
+    actingAs($this->regulatedOrganizationUser)->get(localized_route('projects.show', $this->project))
+        ->assertOk()
+        ->assertSee('Your account has been suspended');
 
-    $response = $this->actingAs($this->regulatedOrganizationUser)->get(localized_route('engagements.show', $this->engagement));
-    $response->assertOk();
-    $response->assertSee('Your account has been suspended');
+    actingAs($this->regulatedOrganizationUser)->get(localized_route('engagements.show', $this->engagement))
+        ->assertOk()
+        ->assertSee('Your account has been suspended');
 });
 
 test('suspended users cannot edit their own models', function () {
@@ -211,18 +215,18 @@ test('suspended users cannot edit their own models', function () {
     $this->regulatedOrganizationUser->update(['suspended_at' => now()]);
     $this->regulatedOrganizationUser = $this->regulatedOrganizationUser->fresh();
 
-    $response = $this->actingAs($this->consultantUser)->get(localized_route('individuals.edit', $this->consultant));
-    $response->assertForbidden();
+    actingAs($this->consultantUser)->get(localized_route('individuals.edit', $this->consultant))
+        ->assertForbidden();
 
-    $response = $this->actingAs($this->organizationUser)->get(localized_route('organizations.edit', $this->organization));
-    $response->assertForbidden();
+    actingAs($this->organizationUser)->get(localized_route('organizations.edit', $this->organization))
+        ->assertForbidden();
 
-    $response = $this->actingAs($this->regulatedOrganizationUser)->get(localized_route('regulated-organizations.edit', $this->regulatedOrganization));
-    $response->assertForbidden();
+    actingAs($this->regulatedOrganizationUser)->get(localized_route('regulated-organizations.edit', $this->regulatedOrganization))
+        ->assertForbidden();
 
-    $response = $this->actingAs($this->regulatedOrganizationUser)->get(localized_route('projects.manage', $this->project));
-    $response->assertForbidden();
+    actingAs($this->regulatedOrganizationUser)->get(localized_route('projects.manage', $this->project))
+        ->assertForbidden();
 
-    $response = $this->actingAs($this->regulatedOrganizationUser)->get(localized_route('engagements.manage', $this->engagement));
-    $response->assertForbidden();
+    actingAs($this->regulatedOrganizationUser)->get(localized_route('engagements.manage', $this->engagement))
+        ->assertForbidden();
 });

--- a/tests/Feature/TopicTest.php
+++ b/tests/Feature/TopicTest.php
@@ -5,23 +5,24 @@ use App\Filament\Resources\TopicResource\Pages\ListTopics;
 use App\Models\Topic;
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 test('only administrative users can access topic admin pages', function () {
     $user = User::factory()->create();
     $administrator = User::factory()->create(['context' => 'administrator']);
 
-    $this->actingAs($user)->get(TopicResource::getUrl('index'))->assertForbidden();
-    $this->actingAs($administrator)->get(TopicResource::getUrl('index'))->assertSuccessful();
+    actingAs($user)->get(TopicResource::getUrl('index'))->assertForbidden();
+    actingAs($administrator)->get(TopicResource::getUrl('index'))->assertSuccessful();
 
-    $this->actingAs($user)->get(TopicResource::getUrl('create'))->assertForbidden();
-    $this->actingAs($administrator)->get(TopicResource::getUrl('create'))->assertSuccessful();
+    actingAs($user)->get(TopicResource::getUrl('create'))->assertForbidden();
+    actingAs($administrator)->get(TopicResource::getUrl('create'))->assertSuccessful();
 
-    $this->actingAs($user)->get(TopicResource::getUrl('edit', [
+    actingAs($user)->get(TopicResource::getUrl('edit', [
         'record' => Topic::factory()->create(),
     ]))->assertForbidden();
 
-    $this->actingAs($administrator)->get(TopicResource::getUrl('edit', [
+    actingAs($administrator)->get(TopicResource::getUrl('edit', [
         'record' => Topic::factory()->create(),
     ]))->assertSuccessful();
 });

--- a/tests/Feature/TranslationTest.php
+++ b/tests/Feature/TranslationTest.php
@@ -2,18 +2,20 @@
 
 use App\Models\Individual;
 
+use function Pest\Laravel\actingAs;
+
 test('adding a translation succeeds for a valid translatable model', function () {
     $individual = Individual::factory()->create(['roles' => ['consultant']]);
 
-    $response = $this->actingAs($individual->user)
+    actingAs($individual->user)
         ->from(localized_route('individuals.edit', $individual))
         ->put(localized_route('translations.add'), [
             'translatable_type' => get_class($individual),
             'translatable_id' => $individual->id,
             'new_language' => 'asl',
-        ]);
+        ])
+        ->assertSessionHasNoErrors();
 
-    $response->assertSessionHasNoErrors();
     $individual = $individual->fresh();
 
     expect(in_array('asl', $individual->languages))->toBeTrue();
@@ -33,7 +35,7 @@ test('add translation validation errors', function ($data, ?array $errors = null
         'new_language' => 'asl',
     ];
 
-    $response = $this->actingAs($individual->user)
+    $response = actingAs($individual->user)
         ->put(localized_route('translations.add'), array_merge($baseData, $data));
 
     if (isset($errors)) {
@@ -46,15 +48,15 @@ test('add translation validation errors', function ($data, ?array $errors = null
 test('removing a translation succeeds for a valid translatable model', function () {
     $individual = Individual::factory()->create(['roles' => ['consultant']]);
 
-    $response = $this->actingAs($individual->user)
+    actingAs($individual->user)
         ->from(localized_route('individuals.edit', $individual))
         ->put(localized_route('translations.destroy'), [
             'translatable_type' => get_class($individual),
             'translatable_id' => $individual->id,
             'language' => 'fr',
-        ]);
+        ])
+        ->assertSessionHasNoErrors();
 
-    $response->assertSessionHasNoErrors();
     $individual = $individual->fresh();
 
     expect(in_array('fr', $individual->languages))->toBeFalse();
@@ -74,7 +76,7 @@ test('destroy translation validation errors', function ($data, ?array $errors = 
         'new_language' => 'asl',
     ];
 
-    $response = $this->actingAs($individual->user)
+    $response = actingAs($individual->user)
         ->put(localized_route('translations.destroy'), array_merge($baseData, $data));
 
     if (isset($errors)) {

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -9,23 +9,24 @@ use App\Models\Quiz;
 use App\Models\RegulatedOrganization;
 use App\Models\User;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
+
 test('users can view the introduction', function () {
     $user = User::factory()->create();
 
     $user->update(['context' => 'individual']);
 
-    $response = $this->actingAs($user)->get(localized_route('users.show-introduction'));
+    actingAs($user)->get(localized_route('users.show-introduction'))
+        ->assertOk()
+        ->assertSee('https://vimeo.com/850308866/22cf4718fc');
 
-    $response->assertOk();
-    $response->assertSee('https://vimeo.com/850308866/22cf4718fc');
-
-    $response = $this->actingAs($user)
+    actingAs($user)
         ->from(localized_route('users.show-introduction'))
         ->put(localized_route('users.update-introduction-status'), [
             'finished_introduction' => 1,
-        ]);
-
-    $response->assertRedirect(localized_route('individuals.show-role-selection'));
+        ])
+        ->assertRedirect(localized_route('individuals.show-role-selection'));
 
     $user = $user->fresh();
 
@@ -33,55 +34,47 @@ test('users can view the introduction', function () {
 
     $user->update(['context' => 'organization']);
 
-    $response = $this->actingAs($user)->get(localized_route('users.show-introduction'));
+    actingAs($user)->get(localized_route('users.show-introduction'))
+        ->assertOk()
+        ->assertSee('https://vimeo.com/850308900/39c5bb60a7');
 
-    $response->assertOk();
-    $response->assertSee('https://vimeo.com/850308900/39c5bb60a7');
-
-    $response = $this->actingAs($user)
+    actingAs($user)
         ->from(localized_route('users.show-introduction'))
         ->put(localized_route('users.update-introduction-status'), [
             'finished_introduction' => 1,
-        ]);
+        ])
+        ->assertRedirect(localized_route('organizations.show-type-selection'));
 
-    $response->assertRedirect(localized_route('organizations.show-type-selection'));
-
-    $response = $this->actingAs($user)->get(localized_route('dashboard'));
-
-    $response->assertRedirect(localized_route('organizations.show-type-selection'));
+    actingAs($user)->get(localized_route('dashboard'))
+        ->assertRedirect(localized_route('organizations.show-type-selection'));
 
     $user->update(['context' => 'regulated-organization']);
 
-    $response = $this->actingAs($user)->get(localized_route('users.show-introduction'));
+    actingAs($user)->get(localized_route('users.show-introduction'))
+        ->assertOk()
+        ->assertSee('https://vimeo.com/850308924/cab1e34418');
 
-    $response->assertOk();
-    $response->assertSee('https://vimeo.com/850308924/cab1e34418');
-
-    $response = $this->actingAs($user)
+    actingAs($user)
         ->from(localized_route('users.show-introduction'))
         ->put(localized_route('users.update-introduction-status'), [
             'finished_introduction' => 1,
-        ]);
+        ])
+        ->assertRedirect(localized_route('regulated-organizations.show-type-selection'));
 
-    $response->assertRedirect(localized_route('regulated-organizations.show-type-selection'));
-
-    $response = $this->actingAs($user)->get(localized_route('dashboard'));
-
-    $response->assertRedirect(localized_route('regulated-organizations.show-type-selection'));
+    actingAs($user)->get(localized_route('dashboard'))
+        ->assertRedirect(localized_route('regulated-organizations.show-type-selection'));
 
     $user->update(['context' => 'training-participant']);
 
-    $response = $this->actingAs($user)->get(localized_route('users.show-introduction'));
+    actingAs($user)->get(localized_route('users.show-introduction'))
+        ->assertOk();
 
-    $response->assertOk();
-
-    $response = $this->actingAs($user)
+    actingAs($user)
         ->from(localized_route('users.show-introduction'))
         ->put(localized_route('users.update-introduction-status'), [
             'finished_introduction' => 1,
-        ]);
-
-    $response->assertRedirect(localized_route('dashboard'));
+        ])
+        ->assertRedirect(localized_route('dashboard'));
 });
 
 test('user’s contact methods can be retrieved', function () {
@@ -272,17 +265,17 @@ test('user has pivot tables for module, course and quiz', function () {
     $user->quizzes()->sync($quiz->id);
     $user->courses()->sync($course->id);
 
-    $this->assertDatabaseHas('module_user', [
+    assertDatabaseHas('module_user', [
         'module_id' => $module->id,
         'user_id' => $user->id,
     ]);
 
-    $this->assertDatabaseHas('quiz_user', [
+    assertDatabaseHas('quiz_user', [
         'quiz_id' => $quiz->id,
         'user_id' => $user->id,
     ]);
 
-    $this->assertDatabaseHas('course_user', [
+    assertDatabaseHas('course_user', [
         'course_id' => $course->id,
         'user_id' => $user->id,
     ]);
@@ -299,13 +292,12 @@ test('users can view inprogress and completed Courses from their dashbaord', fun
     $user->courses()->attach($inProgressCourse->id, ['started_at' => now()]);
     $user->courses()->attach($completedCourse->id, ['received_certificate_at' => now()]);
 
-    $response = $this->actingAs($user)->get(localized_route('dashboard.trainings'));
-
-    $response->assertOk();
-    $response->assertSee('Author 1');
-    $response->assertSee('Author 2');
-    $response->assertSee('In progress');
-    $response->assertSee('Completed');
+    actingAs($user)->get(localized_route('dashboard.trainings'))
+        ->assertOk()
+        ->assertSee('Author 1')
+        ->assertSee('Author 2')
+        ->assertSee('In progress')
+        ->assertSee('Completed');
 });
 
 test('User hasTasksToComplete()', function ($data, $expected) {

--- a/tests/Feature/View/Components/InterpretationTest.php
+++ b/tests/Feature/View/Components/InterpretationTest.php
@@ -4,13 +4,13 @@ use App\Models\Interpretation;
 use App\Models\User;
 use Illuminate\Support\Str;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
 test('new Interpretation instance', function () {
     $user = User::factory()->create();
 
     app()->setLocale('asl');
-
-    $response = $this->actingAs($user)->get(localized_route('welcome'));
-    $response->assertStatus(200);
 
     $toSee = [
         '<h1 itemprop="name">',
@@ -19,7 +19,9 @@ test('new Interpretation instance', function () {
         'id="'.Str::slug('The Accessibility Exchange'),
     ];
 
-    $response->assertSeeInOrder($toSee, false);
+    actingAs($user)->get(localized_route('welcome'))
+        ->assertStatus(200)
+        ->assertSeeInOrder($toSee, false);
 
     $interpretation = Interpretation::firstWhere('name', 'The Accessibility Exchange');
 
@@ -37,8 +39,6 @@ test('existing Interpretation instance', function () {
 
     $user = User::factory()->create();
     app()->setLocale('asl');
-    $response = $this->actingAs($user)->get(localized_route('welcome'));
-    $response->assertStatus(200);
 
     $toSee = [
         '<h1 itemprop="name">',
@@ -48,8 +48,10 @@ test('existing Interpretation instance', function () {
         $interpretation->getTranslation('video', 'asl'),
     ];
 
-    $response->assertSeeInOrder($toSee, false);
-    $response->assertDontSee($interpretation->getTranslation('video', 'lsq'));
+    actingAs($user)->get(localized_route('welcome'))
+        ->assertStatus(200)
+        ->assertSeeInOrder($toSee, false)
+        ->assertDontSee($interpretation->getTranslation('video', 'lsq'));
 
     $interpretations = Interpretation::where('name', 'The Accessibility Exchange')->get();
 
@@ -64,8 +66,6 @@ test('existing Interpretation instance', function () {
 
 test('Interpretation instance using namespace', function () {
     app()->setLocale('asl');
-    $response = $this->get(localized_route('welcome'));
-    $response->assertStatus(200);
 
     $toSee = [
         '<h2 class="text-center" id="join">',
@@ -74,7 +74,9 @@ test('Interpretation instance using namespace', function () {
         'id="'.Str::slug('Join our accessibility community'),
     ];
 
-    $response->assertSeeInOrder($toSee, false);
+    get(localized_route('welcome'))
+        ->assertStatus(200)
+        ->assertSeeInOrder($toSee, false);
 
     $interpretation = Interpretation::firstWhere('name', 'Join our accessibility community');
 
@@ -93,8 +95,6 @@ test('in French and LSQ', function () {
     $user = User::factory()->create([
         'locale' => 'lsq',
     ]);
-    $response = $this->actingAs($user)->get(localized_route('welcome'));
-    $response->assertStatus(200);
 
     $localizedName = __($interpretation->name, [], 'lsq');
 
@@ -106,8 +106,10 @@ test('in French and LSQ', function () {
         $interpretation->getTranslation('video', 'lsq'),
     ];
 
-    $response->assertSeeInOrder($toSee, false);
-    $response->assertDontSee($interpretation->getTranslation('video', 'asl'));
+    actingAs($user)->get(localized_route('welcome'))
+        ->assertStatus(200)
+        ->assertSeeInOrder($toSee, false)
+        ->assertDontSee($interpretation->getTranslation('video', 'asl'));
 });
 
 test('do not fallback to ASL (asl)', function () {
@@ -123,8 +125,6 @@ test('do not fallback to ASL (asl)', function () {
     $user = User::factory()->create([
         'locale' => 'lsq',
     ]);
-    $response = $this->actingAs($user)->get(localized_route('welcome'));
-    $response->assertStatus(200);
 
     $localizedName = __($interpretation->name, [], 'lsq');
 
@@ -135,8 +135,10 @@ test('do not fallback to ASL (asl)', function () {
         'id="'.Str::slug($localizedName),
     ];
 
-    $response->assertSeeInOrder($toSee, false);
-    $response->assertDontSee($interpretation->getTranslation('video', 'asl'));
+    actingAs($user)->get(localized_route('welcome'))
+        ->assertStatus(200)
+        ->assertSeeInOrder($toSee, false)
+        ->assertDontSee($interpretation->getTranslation('video', 'asl'));
 });
 
 test('do not fallback to LSQ (lsq)', function () {
@@ -152,8 +154,6 @@ test('do not fallback to LSQ (lsq)', function () {
     $user = User::factory()->create([
         'locale' => 'asl',
     ]);
-    $response = $this->actingAs($user)->get(localized_route('welcome'));
-    $response->assertStatus(200);
 
     $toSee = [
         '<h1 itemprop="name">',
@@ -162,14 +162,15 @@ test('do not fallback to LSQ (lsq)', function () {
         'id="'.Str::slug('The Accessibility Exchange'),
     ];
 
-    $response->assertSeeInOrder($toSee, false);
-    $response->assertDontSee($interpretation->getTranslation('video', 'lsq'));
+    actingAs($user)->get(localized_route('welcome'))
+        ->assertStatus(200)
+        ->assertSeeInOrder($toSee, false)
+        ->assertDontSee($interpretation->getTranslation('video', 'lsq'));
 });
 
 test('no Interpretation without sign language translations setting enabled', function () {
-    $user = User::factory()->create();
-    $response = $this->get(localized_route('welcome'));
-    $response->assertStatus(200);
+    get(localized_route('welcome'))
+        ->assertStatus(200);
 
     $interpretations = Interpretation::all();
 


### PR DESCRIPTION
Resolves #1830 

- Fixes validation requirements for accepted formats 
- Expand test coverage for engagement related validation errors
- Refactor tests to make use of pest's helper functions

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
