### PR TITLE
fix: add hearth translations to crowdin (resolves #2043)

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -3,6 +3,8 @@ files:
     translation: /resources/lang/%two_letters_code%/%original_file_name%
   - source: /resources/lang/en.json
     translation: /resources/lang/%two_letters_code%.json
+  - source: /resources/lang/vendor/hearth/en/*.php
+    translation: /resources/lang/vendor/hearth/%two_letters_code%/%original_file_name%
 pull_request_title: 'chore(localization): update translations'
 pull_request_labels:
   - localization

--- a/resources/lang/vendor/hearth/en/alert.php
+++ b/resources/lang/vendor/hearth/en/alert.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'error' => 'Error',
+    'warning' => 'Warning',
+    'success' => 'Success',
+    'notice' => 'Notice',
+];

--- a/resources/lang/vendor/hearth/en/auth.php
+++ b/resources/lang/vendor/hearth/en/auth.php
@@ -1,0 +1,48 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'sign_in' => 'Sign in',
+    'sign_out' => 'Sign out',
+    'create_account' => 'Create an account',
+    'label_password' => 'Password',
+    'label_password_confirmation' => 'Confirm password',
+    'existing_account_prompt' => 'Do you already have an account?',
+    'create_your_account' => 'Create your account',
+    'label_current_password' => 'Current password',
+    'change_password' => 'Change password',
+    'action_cancel' => 'Cancel',
+    'action_confirm' => 'Confirm',
+    'password_change_succeeded' => 'Your password has been changed.',
+    'label_remember_me' => 'Remember me',
+    'error_intro' => 'Sorry, something went wrong.',
+    'wrong_password' => 'The provided password is incorrect.',
+    'confirm_intro' => 'For your security, please confirm your password before continuing.',
+    'forget_prompt' => 'Forgot your password?',
+    'forgot_intro' => 'Forgot your password? Enter your email address and we will email you a password reset link that will let you choose a new one.',
+    'forgot_submit' => 'Send password reset link',
+    'reset_submit' => 'Reset password',
+    'verification_required' => 'Email verification required',
+    'verification_intro' => 'Please verify your email address by clicking on the link we emailed to you. If you didn’t receive the email, we will gladly send you another.',
+    'verification_sent' => 'A new verification link has been sent to the email address you provided.',
+    'resend_verification_email' => 'Resend verification email',
+    'verification_succeeded' => 'Your email address has been verified.',
+    'two_factor_auth_code_intro' => 'Please enter the code provided by your authenticator application to complete the sign in process.',
+    'label_two_factor_auth_code' => 'Authentication code',
+    'two_factor_auth_action_use_recovery_code' => 'Use a recovery code',
+    'two_factor_auth_recovery_code_intro' => 'Please enter one of your saved recovery codes to complete the sign in process.',
+    'label_two_factor_auth_recovery_code' => 'Recovery code',
+    'two_factor_auth_action_use_code' => 'Use an authentication code',
+    'invalid_two_factor_auth_code' => 'The provided two-factor authentication code was not valid.',
+];

--- a/resources/lang/vendor/hearth/en/dashboard.php
+++ b/resources/lang/vendor/hearth/en/dashboard.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'title' => 'Dashboard',
+    'welcome' => 'Welcome, :name!',
+];

--- a/resources/lang/vendor/hearth/en/errors.php
+++ b/resources/lang/vendor/hearth/en/errors.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Errors Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used for HTTP error messages that we need
+    | to display to the user. You are free to modify these language lines
+    | according to your application's requirements.
+    |
+    */
+
+    'error_401_title' => 'Not authorized',
+    'error_401_message' => 'You are not authorized to visit this page. You may need to log in.',
+    'error_403_title' => 'Access forbidden',
+    'error_403_message' => 'You do not have permission to visit this page.',
+    'error_404_title' => 'Not found',
+    'error_404_message' => 'The page you are trying to visit could not be found.',
+    'error_419_title' => 'Page expired',
+    'error_419_message' => 'The page has expired. Please try again.',
+    'error_429_title' => 'Too many requests',
+    'error_429_message' => 'You have sent too many requests to this page. Please wait a few moments and try again.',
+    'error_500_title' => 'Server error',
+    'error_500_message' => 'Sorry, it looks like something isn’t working properly on our end.',
+    'error_503_title' => 'Service unavailable',
+    'error_503_message' => 'Sorry, it looks like the website can’t respond to your request right now. Please wait a few moments and try again.',
+    'return_home' => 'Return to home page',
+];

--- a/resources/lang/vendor/hearth/en/forms.php
+++ b/resources/lang/vendor/hearth/en/forms.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'save_changes' => 'Save changes',
+    'label_email' => 'Email address',
+    'errors_found' => 'Errors found',
+    'errors_found_message' => 'Sorry, some errors were found in your submission. Please correct these errors and try again.',
+];

--- a/resources/lang/vendor/hearth/en/mail.php
+++ b/resources/lang/vendor/hearth/en/mail.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'error' => 'Sorry!',
+    'greeting' => 'Hello!',
+    'salutation' => 'Regards',
+    'link_guidance' => 'If you’re having trouble clicking the ":actionText" button, copy and paste the URL below into your web browser:',
+];

--- a/resources/lang/vendor/hearth/en/nav.php
+++ b/resources/lang/vendor/hearth/en/nav.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'languages' => __('Languages'),
+];

--- a/resources/lang/vendor/hearth/en/passwords.php
+++ b/resources/lang/vendor/hearth/en/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'reset' => 'Your password has been reset!',
+    'sent' => 'We have emailed your password reset link!',
+    'throttled' => 'Please wait before retrying.',
+    'token' => 'This password reset token is invalid.',
+    'user' => "We can't find a user with that email address.",
+
+];

--- a/resources/lang/vendor/hearth/en/routes.php
+++ b/resources/lang/vendor/hearth/en/routes.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'dashboard' => 'dashboard',
+    'logout' => 'logout',
+    'login' => 'login',
+    'register' => 'register',
+];

--- a/resources/lang/vendor/hearth/en/user.php
+++ b/resources/lang/vendor/hearth/en/user.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'settings' => 'Settings',
+    'account' => 'Account',
+    'label_name' => 'Full name',
+    'label_locale' => 'Preferred language',
+    'two_factor_auth' => 'Two-factor authentication',
+    'two_factor_auth_intro' => 'Add additional security to your account using two-factor authentication.',
+    'two_factor_auth_not_enabled' => 'You have not enabled two-factor authentication.',
+    'two_factor_auth_enabled' => 'You have enabled two-factor authentication.',
+    'two_factor_auth_disabled' => 'You have disabled two-factor authentication.',
+    'two_factor_auth_qr_code' => 'Two factor authentication is now enabled. Scan the following QR code using your phone\'s authenticator application.',
+    'two_factor_auth_recovery_codes' => 'Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.',
+    'two_factor_auth_recovery_codes_regenerated' => 'New recovery codes have been generated.',
+    'action_enable_two_factor_auth' => 'Enable two-factor authentication',
+    'action_disable_two_factor_auth' => 'Disable two-factor authentication',
+    'action_regenerate_two_factor_auth_recovery_codes' => 'Regenerate recovery codes',
+    'delete_account' => 'Delete account',
+    'delete_account_intro' => 'Your account will be deleted and cannot be recovered. If you still want to delete your account, please enter your current password to proceed.',
+    'action_delete_account' => 'Delete my account',
+    'settings_update_succeeded' => 'Your settings have been saved.',
+    'destroy_succeeded' => 'Your account has been deleted.',
+];

--- a/resources/lang/vendor/hearth/en/validation.php
+++ b/resources/lang/vendor/hearth/en/validation.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'password' => [
+        'length-uppercase' => 'The :attribute must be at least :length characters and contain at least one uppercase character.',
+        'length-numeric' => 'The :attribute must be at least :length characters and contain at least one number.',
+        'length-specialcharacter' => 'The :attribute must be at least :length characters and contain at least one special character.',
+        'length-uppercase-numeric' => 'The :attribute must be at least :length characters and contain at least one uppercase character and one number.',
+        'length-uppercase-specialcharacter' => 'The :attribute must be at least :length characters and contain at least one uppercase character and one special character.',
+        'length-uppercase-numeric-specialcharacter' => 'The :attribute must be at least :length characters and contain at least one uppercase character, one number, and one special character.',
+        'length-numeric-specialcharacter' => 'The :attribute must be at least :length characters and contain at least one special character and one number.',
+        'length' => 'The :attribute must be at least :length characters.',
+    ],
+];

--- a/resources/lang/vendor/hearth/en/welcome.php
+++ b/resources/lang/vendor/hearth/en/welcome.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'intro' => 'Welcome to Hearth!',
+    'details' => 'Make yourself at home.',
+];


### PR DESCRIPTION
- updates the `crowdin.yml` configuration file to include Hearth translations
- publish Hearth's en translations to use as a source in crowdin

### Prerequisites

If this PR changes PHP code or dependencies:

- [ ] I've run `composer format` and fixed any code formatting issues.
- [ ] I've run `composer analyze` and addressed any static analysis issues.
- [ ] I've run `php artisan test` and ensured that all tests pass.
- [ ] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
