### PR TITLE
fix: accessing settings during database reset causes error (resolves #2106)

### DIFF
--- a/app/Console/Commands/RefreshDev.php
+++ b/app/Console/Commands/RefreshDev.php
@@ -32,7 +32,7 @@ class RefreshDev extends Command
             return 1;
         }
 
-        $this->call('down');
+        $this->call('down', ['--render' => 'errors::503']);
         $this->call('migrate:fresh', ['--seeder' => 'DevSeeder']);
         $this->call('up');
     }

--- a/app/Notifications/AccountSuspended.php
+++ b/app/Notifications/AccountSuspended.php
@@ -30,7 +30,7 @@ class AccountSuspended extends PlatformNotification
                 __('Your account on the Accessibility Exchange has been suspended.').' '.$this->getCapabilities($this->account).' '.__('Please contact us at :email or :phone if you need further assistance.',
                     [
                         'email' => settings('email'),
-                        'phone' => phone(settings('phone'), 'CA')->formatForCountry('CA'),
+                        'phone' => phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA'),
                     ]
                 )
             )

--- a/app/Notifications/AccountUnsuspended.php
+++ b/app/Notifications/AccountUnsuspended.php
@@ -30,7 +30,7 @@ class AccountUnsuspended extends PlatformNotification
                 __('Your account on the Accessibility Exchange is no longer suspended.').' '.$this->getCapabilities($this->account).' '.__('Please contact us at :email or :phone if you need further assistance.',
                     [
                         'email' => settings('email'),
-                        'phone' => phone(settings('phone'), 'CA')->formatForCountry('CA'),
+                        'phone' => phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA'),
                     ]
                 )
             )

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -5,6 +5,7 @@ use App\Settings\GeneralSettings;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route as RouteFacade;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
@@ -17,6 +18,10 @@ if (! function_exists('settings')) {
      */
     function settings(?string $key = null, mixed $default = null): mixed
     {
+        if (! Schema::hasTable('settings')) {
+            return $default;
+        }
+
         return app(GeneralSettings::class)->$key ?? $default;
     }
 }

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -38,9 +38,9 @@
                                 '</a>',
                         ]) }}
                         </h3>
-                        <p>{{ phone(settings('phone'), 'CA')->formatForCountry('CA') }}</p>
+                        <p>{{ phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA') }}</p>
                         <h3>{{ __('Mailing Address') }}</h3>
-                        {{ safe_nl2br(settings('address')) }}
+                        {{ safe_nl2br(settings('address', '')) }}
                     </address>
                 </div>
                 <nav class="stack" aria-labelledby="social">

--- a/resources/views/partials/contact-information.blade.php
+++ b/resources/views/partials/contact-information.blade.php
@@ -7,5 +7,5 @@
             htmlentities(__('VRS')) .
             '</a>',
     ]) }}:</strong>
-    {{ phone(settings('phone'), 'CA')->formatForCountry('CA') }}
+    {{ phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA') }}
 </p>

--- a/resources/views/partials/have-more-questions.blade.php
+++ b/resources/views/partials/have-more-questions.blade.php
@@ -1,5 +1,5 @@
 <p class="h3">
     {{ __('Have more questions?') }}<br />
-    {{ __('Call our support line at :number', ['number' => phone(settings('phone'), 'CA')->formatForCountry('CA')]) }}
+    {{ __('Call our support line at :number', ['number' => phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA')]) }}
 </p>
 <x-interpretation class="interpretation--center" name="{{ __('Have more questions?', [], 'en') }}" namespace="questions" />

--- a/resources/views/partials/help-bar.blade.php
+++ b/resources/views/partials/help-bar.blade.php
@@ -14,7 +14,7 @@
                                 '<a href="https://srvcanadavrs.ca/en/resources/resource-centre/vrs-basics/register/" rel="external">' .
                                 htmlentities(__('VRS')) .
                                 '</a>',
-                        ]) }}:</span>&nbsp;{{ phone(settings('phone'), 'CA')->formatForCountry('CA') }}
+                        ]) }}:</span>&nbsp;{{ phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA') }}
                 </div>
                 <div>
                     @svg('heroicon-o-envelope')&nbsp;<span class="font-semibold">{{ __('Email') }}:</span>&nbsp;<a

--- a/resources/views/partials/join.blade.php
+++ b/resources/views/partials/join.blade.php
@@ -11,7 +11,7 @@
                 </div>
                 <div class="stack">
                     <h3>{{ __('Sign up on the phone') }}</h3>
-                    <p>{{ __('Call our support line at :number', ['number' => phone(settings('phone'), 'CA')->formatForCountry('CA')]) }}
+                    <p>{{ __('Call our support line at :number', ['number' => phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA')]) }}
                     </p>
                 </div>
                 @if ($withPricing ?? false)


### PR DESCRIPTION
Resolves #2106 

- Updates `php artisan app:refresh-dev` to pre-render the 503 error page
- Updates the `settings` helper function to return the default if the settings database table isn't present
- Sets defaults when checking the settings for the phone number and address

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
