### PR TITLE
feat: select cp role by default for individual users (resolves #2135)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .php-cs-fixer.cache
 .phpstorm.meta.php
 .phpunit.result.cache
+.phpunit.cache
 .vscode
 Homestead.json
 Homestead.yaml

--- a/app/Http/Controllers/IndividualController.php
+++ b/app/Http/Controllers/IndividualController.php
@@ -54,6 +54,7 @@ class IndividualController extends Controller
             'roles' => Options::forEnum(IndividualRole::class)->append(fn (IndividualRole $role) => [
                 'hint' => $role->description(),
             ])->toArray(),
+            'defaultRoles' => [IndividualRole::ConsultationParticipant->value],
         ]);
     }
 

--- a/app/Livewire/WebLinks.php
+++ b/app/Livewire/WebLinks.php
@@ -27,7 +27,7 @@ class WebLinks extends Component
     }
 
     /**
-     * @param  int  $i The index of the link to remove.
+     * @param  int  $i  The index of the link to remove.
      */
     public function removeLink(int $i): void
     {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -13,8 +13,8 @@ if (! function_exists('settings')) {
     /**
      * Retrieve a setting from the general settings table.
      *
-     * @param  string|null  $key The setting key.
-     * @param  mixed|null  $default A default value for the setting.
+     * @param  string|null  $key  The setting key.
+     * @param  mixed|null  $default  A default value for the setting.
      */
     function settings(?string $key = null, mixed $default = null): mixed
     {
@@ -30,7 +30,7 @@ if (! function_exists('get_available_languages')) {
     /**
      * Get available languages.
      *
-     * @param  bool  $all Should all languages be shown? Otherwise, only supported locales will be included.
+     * @param  bool  $all  Should all languages be shown? Otherwise, only supported locales will be included.
      */
     function get_available_languages(bool $all = false, bool $signed = true): array
     {
@@ -124,7 +124,7 @@ if (! function_exists('is_signed_language')) {
      *
      * @link https://iso639-3.sil.org/code_tables/639/data ISO 639 code table.
      *
-     * @param  string  $code An ISO 639 code.
+     * @param  string  $code  An ISO 639 code.
      */
     function is_signed_language(string $code): bool
     {
@@ -136,7 +136,7 @@ if (! function_exists('get_supported_locales')) {
     /**
      * Get supported locales. Mostly used to filter out signed locales.
      *
-     * @param  bool  $signed Determines if signed locales (e.g. asl, lsq) are included.
+     * @param  bool  $signed  Determines if signed locales (e.g. asl, lsq) are included.
      */
     function get_supported_locales(bool $signed = true): array
     {
@@ -155,8 +155,8 @@ if (! function_exists('to_written_language')) {
      *
      * @link https://iso639-3.sil.org/code_tables/639/data ISO 639 code table.
      *
-     * @param  string  $code Either 'asl' or 'lsq'
-     * @return string  An ISO 639 code
+     * @param  string  $code  Either 'asl' or 'lsq'
+     * @return string An ISO 639 code
      */
     function to_written_language(string $code): string
     {
@@ -174,7 +174,7 @@ if (! function_exists('get_signed_language_for_written_language')) {
      *
      * @link https://iso639-3.sil.org/code_tables/639/data ISO 639 code table.
      *
-     * @param  string  $code An ISO 639 code.
+     * @param  string  $code  An ISO 639 code.
      */
     function get_signed_language_for_written_language(string $code): string
     {
@@ -193,7 +193,7 @@ if (! function_exists('to_written_languages')) {
      * @link https://iso639-3.sil.org/code_tables/639/data ISO 639 code table.
      *
      * @param  array<string>  $codes
-     * @return array<string>  An array of ISO 639 codes
+     * @return array<string> An array of ISO 639 codes
      */
     function to_written_languages(array $codes): array
     {
@@ -209,9 +209,9 @@ if (! function_exists('get_language_exonym')) {
     /**
      * Get the name of a locale from its code.
      *
-     * @param  string  $code An ISO 639 language code, or 'asl'/'lsq'.
-     * @param  ?string  $locale An ISO 639-1 language code (in which the locale name should be returned).
-     * @param  bool  $capitalize Whether the returned language exonym should be capitalized.
+     * @param  string  $code  An ISO 639 language code, or 'asl'/'lsq'.
+     * @param  ?string  $locale  An ISO 639-1 language code (in which the locale name should be returned).
+     * @param  bool  $capitalize  Whether the returned language exonym should be capitalized.
      * @return null|string The localized name of the locale, if found.
      */
     function get_language_exonym(string $code, ?string $locale = null, bool $capitalize = true, bool $acronym = false): ?string
@@ -413,9 +413,9 @@ if (! function_exists('settings_localized')) {
     /**
      * Retrieve a setting from the general settings table.
      *
-     * @param  string|null  $key The setting key.
-     * @param  string|null  $locale The requested locale for the setting to be returned in
-     * @param  mixed|null  $default A default value for the setting.
+     * @param  string|null  $key  The setting key.
+     * @param  string|null  $locale  The requested locale for the setting to be returned in
+     * @param  mixed|null  $default  A default value for the setting.
      */
     function settings_localized(?string $key = null, ?string $locale = null, mixed $default = null): mixed
     {

--- a/resources/views/individuals/show-role-selection.blade.php
+++ b/resources/views/individuals/show-role-selection.blade.php
@@ -17,7 +17,7 @@
 
     <form class="stack" action="{{ localized_route('individuals.save-roles') }}" method="post" novalidate>
         <fieldset class="field @error('roles') field--error @enderror">
-            <x-hearth-checkboxes name="roles" :options="$roles" :checked="old('roles', [])" />
+            <x-hearth-checkboxes name="roles" :options="$roles" :checked="old('roles', $defaultRoles)" />
             <x-hearth-error for="roles" />
         </fieldset>
 

--- a/tests/Feature/IndividualTest.php
+++ b/tests/Feature/IndividualTest.php
@@ -41,7 +41,9 @@ test('individual users can select an individual role', function () {
 
     actingAs($user)->get(localized_route('dashboard'))->assertRedirect(localized_route('individuals.show-role-selection'));
 
-    actingAs($user)->get(localized_route('individuals.show-role-selection'))->assertOk();
+    actingAs($user)->get(localized_route('individuals.show-role-selection'))
+        ->assertOk()
+        ->assertViewHas('defaultRoles', [IndividualRole::ConsultationParticipant->value]);
 
     actingAs($user)
         ->followingRedirects()


### PR DESCRIPTION
Resolves #2135 

- Provides a default role (set to consultation participant) when selecting an Individual user's role

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
