### PR TITLE
fix: invalid instruction for URL format entry (resolves #2170)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1775,7 +1775,7 @@
     "Website accessibility preferences": "Website accessibility preferences",
     "Website language": "Website language",
     "Website link": "Website link",
-    "Website links must be in the format “https:\/\/example.com”, or “example.com”.": "Website links must be in the format “https:\/\/example.com”, or “example.com”.",
+    "Website links must be in the format “https:\/\/example.com”.": "Website links must be in the format “https:\/\/example.com”.",
     "Website settings": "Website settings",
     "Website title": "Website title",
     "We can offer some time flexibility if it does not match with participants’ schedules.": "We can offer some time flexibility if it does not match with participants’ schedules.",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -1775,7 +1775,7 @@
     "Website accessibility preferences": "Préférences d’accessibilité du site Internet",
     "Website language": "Langue du site internet",
     "Website link": "Lien de votre site Internet",
-    "Website links must be in the format “https:\/\/example.com”, or “example.com”.": "Les liens vers les sites Internet doivent être au format \"https:\/\/example.com\", ou \"exemple.com.",
+    "Website links must be in the format “https:\/\/example.com”.": "Les liens vers les sites Internet doivent être au format \"https:\/\/example.com\".",
     "Website settings": "Réglages du site",
     "Website title": "Titre du site Internet",
     "We can offer some time flexibility if it does not match with participants’ schedules.": "Nous sommes en mesure d’offrir une certaine flexibilité au niveau des horaires si ceux-ci ne correspondent pas à l’emploi du temps des personnes participantes.",

--- a/resources/views/individuals/edit/about-you.blade.php
+++ b/resources/views/individuals/edit/about-you.blade.php
@@ -111,7 +111,7 @@
             <fieldset>
                 <legend class="h4">{{ __('Social media links') }}</legend>
                 <x-hearth-hint for="social_links">
-                    {{ __('Website links must be in the format “https://example.com”, or “example.com”.') }}
+                    {{ __('Website links must be in the format “https://example.com”.') }}
                 </x-hearth-hint>
                 <x-interpretation name="{{ __('Social media links', [], 'en') }}" />
                 @foreach (['linked_in', 'twitter', 'instagram', 'facebook'] as $key)
@@ -132,7 +132,7 @@
                 <x-hearth-label class="h4"
                     for="website_link"><x-optional>{{ __('Website link') }}</x-optional></x-hearth-label>
                 <x-hearth-hint
-                    for="website_link">{{ __('This could be your personal website, blog or portfolio.') }}<br />{{ __('Website links must be in the format “https://example.com”, or “example.com”.') }}
+                    for="website_link">{{ __('This could be your personal website, blog or portfolio.') }}<br />{{ __('Website links must be in the format “https://example.com”.') }}
                 </x-hearth-hint>
                 <x-interpretation name="{{ __('Website link', [], 'en') }}" namespace="website_link-optional" />
                 <x-hearth-input name="website_link" type="url" :value="old('website_link', $individual->website_link)" hinted />

--- a/resources/views/livewire/team-trainings.blade.php
+++ b/resources/views/livewire/team-trainings.blade.php
@@ -33,7 +33,7 @@
                             <x-hearth-label :for="'team_trainings_' . $i . '_trainer_url'" :value="__('Website')" />
                             <x-interpretation name="{{ __('Website', [], 'en') }}" namespace="team_trainings" />
                             <x-hearth-hint :for="'team_trainings_' . $i . '_trainer_url'">
-                                {{ __('Website links must be in the format “https://example.com”, or “example.com”.') }}
+                                {{ __('Website links must be in the format “https://example.com”.') }}
                             </x-hearth-hint>
                             <x-hearth-input type="url" :id="'team_trainings_' . $i . '_trainer_url'" :name="'team_trainings[' . $i . '][trainer_url]'" :value="$training['trainer_url'] ?? ''"
                                 required hinted />

--- a/resources/views/organizations/edit/1.blade.php
+++ b/resources/views/organizations/edit/1.blade.php
@@ -87,7 +87,7 @@
             <fieldset class="stack">
                 <legend>{{ __('Social media links') }}</legend>
                 <x-hearth-hint for="social_links">
-                    {{ __('Website links must be in the format “https://example.com”, or “example.com”.') }}
+                    {{ __('Website links must be in the format “https://example.com”.') }}
                 </x-hearth-hint>
                 @foreach (['linked_in', 'twitter', 'instagram', 'facebook'] as $key)
                     <div class="field @error('social_links.' . $key) field--error @enderror">
@@ -106,7 +106,7 @@
             <div class="field @error('website_link') field--error @enderror">
                 <x-hearth-label for="website_link" :value="__('Website link') . ' ' . __('(optional)')" />
                 <x-hearth-hint
-                    for="website_link">{{ __('Website links must be in the format “https://example.com”, or “example.com”.') }}</x-hearth-hint>
+                    for="website_link">{{ __('Website links must be in the format “https://example.com”.') }}</x-hearth-hint>
                 <x-hearth-input name="website_link" type="url" :value="old('website_link', $organization->website_link)" hinted />
                 <x-hearth-error for="website_link" />
             </div>

--- a/resources/views/regulated-organizations/edit.blade.php
+++ b/resources/views/regulated-organizations/edit.blade.php
@@ -125,7 +125,7 @@
                     <legend>{{ __('Social media links') }}</legend>
                     <x-interpretation name="{{ __('Social media links', [], 'en') }}" />
                     <x-hearth-hint for="social_links">
-                        {{ __('Website links must be in the format “https://example.com”, or “example.com”.') }}
+                        {{ __('Website links must be in the format “https://example.com”.') }}
                     </x-hearth-hint>
                     @foreach (['linked_in', 'twitter', 'instagram', 'facebook'] as $key)
                         <div class="field @error('social_links.' . $key) field--error @enderror">
@@ -148,7 +148,7 @@
                 <div class="field @error('website_link') field--error @enderror">
                     <x-hearth-label for="website_link" :value="__('Website link') . ' ' . __('(optional)')" />
                     <x-hearth-hint
-                        for="website_link">{{ __('Website links must be in the format “https://example.com”, or “example.com”.') }}</x-hearth-hint>
+                        for="website_link">{{ __('Website links must be in the format “https://example.com”.') }}</x-hearth-hint>
                     <x-hearth-input name="website_link" type="url" :value="old('website_link', $regulatedOrganization->website_link)" hinted />
                     <x-hearth-error for="website_link" />
                 </div>


### PR DESCRIPTION
Resolves #2170 

Updates the instructions to remove the schemeless URL example (e.g. example.com), as this format will fail validation.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
