### PR TITLE
fix: php values breaking alpine model data (resolves #2180)

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -114,6 +114,10 @@ class SettingsController extends Controller
 
         $individual = Auth::user()->individual;
 
+        if (! $data['other']) {
+            $data['other_access_need'] = null;
+        }
+
         if (! isset($data['meeting_access_needs']) || (isset($data['meeting_access_needs']) && ! in_array($signLanguageInterpretation, $data['meeting_access_needs']))) {
             $data['signed_language_for_interpretation'] = null;
         }

--- a/resources/views/components/date-picker.blade.php
+++ b/resources/views/components/date-picker.blade.php
@@ -8,7 +8,7 @@
 ])
 
 <fieldset class="field @error($name) field--error @enderror" id="{{ $name }}"
-    aria-describedby="{{ $name }}-hint {{ $name }}-output" x-data="datePicker('{{ $value }}')">
+    aria-describedby="{{ $name }}-hint {{ $name }}-output" x-data="datePicker(@js($value))">
     <legend>
         {{ $label ?? __('forms.label_date') }}
     </legend>

--- a/resources/views/components/expander.blade.php
+++ b/resources/views/components/expander.blade.php
@@ -1,6 +1,6 @@
-@props(['level', 'summary' => '', 'type' => null, 'expanded' => 'false'])
+@props(['level', 'summary' => '', 'type' => null, 'expanded' => false])
 <div {{ $attributes->class(['expander stack', 'expander--disclosure' => $type === 'disclosure'])->whereDoesntStartWith('x-data') }}
-    x-data="{ expanded: {{ $expanded }} }">
+    x-data="{ expanded: @js($expanded) }">
     <x-heading class="title" :level="$level">
         <button type="button" x-bind:aria-expanded="expanded.toString()" x-on:click="expanded = !expanded">
             <span>{{ $summary }}</span>

--- a/resources/views/components/interpretation.blade.php
+++ b/resources/views/components/interpretation.blade.php
@@ -7,7 +7,7 @@
                 {{ __('Sign Language video') }}
             </button>
             <div class="stack width:full" x-data="vimeoPlayer({
-                url: '{{ $videoSrc }}',
+                url: @js($videoSrc),
                 byline: false,
                 dnt: true,
                 pip: true,

--- a/resources/views/components/translatable-input.blade.php
+++ b/resources/views/components/translatable-input.blade.php
@@ -26,7 +26,11 @@
             @if (is_signed_language($language))
             @else
                 <div class="expander field @error($name . '.' . $language) field--error @enderror stack"
-                    x-data="{ expanded: false, value: '{{ old($name . '.' . $language, $model ? $model->getTranslation($name, $language, false) : '') }}', badgeText: '{{ __('Content added') }}' }">
+                    x-data="{
+                        expanded: false,
+                        value: @js(old($name . '.' . $language, $model ? $model->getTranslation($name, $language, false) : '')),
+                        badgeText: @js(__('Content added'))
+                    }">
                     <p class="title"
                         id="{{ Str::slug(__(':label (:locale)', ['label' => $label, 'locale' => get_language_exonym($language)])) }}">
                         <button type="button"

--- a/resources/views/components/translatable-textarea.blade.php
+++ b/resources/views/components/translatable-textarea.blade.php
@@ -26,7 +26,11 @@
             @if (is_signed_language($language))
             @else
                 <div class="expander field @error($name . '.' . $language) field--error @enderror stack"
-                    x-data="{ expanded: false, value: '{{ old($name . '.' . $language, $model ? $model->getTranslation($name, $language, false) : '') }}', badgeText: '{{ __('Content added') }}' }">
+                    x-data="{
+                        expanded: false,
+                        value: @js(old($name . '.' . $language, $model ? $model->getTranslation($name, $language, false) : '')),
+                        badgeText: @js(__('Content added'))
+                    }">
                     <p class="title"
                         id="{{ Str::slug(__(':label (:locale)', ['label' => $label, 'locale' => get_language_exonym($language)])) }}">
                         <button type="button"

--- a/resources/views/components/translation-picker.blade.php
+++ b/resources/views/components/translation-picker.blade.php
@@ -1,4 +1,4 @@
-<div class="translation-picker stack" x-data="translationPicker([@foreach ($languages as $language){ code: '{{ $language }}', exonym: '{{ get_language_exonym($language) }}' }@if (!$loop->last), @endif @endforeach], {
+<div class="translation-picker stack" x-data="translationPicker([@foreach ($languages as $language){ code: @js($language), exonym: @js(get_language_exonym($language)) }@if (!$loop->last), @endif @endforeach], {
     @foreach ($availableLanguages as $language)@if ($language['value'] !== '')'{{ $language['value'] }}': '{{ $language['label'] }}'@if (!$loop->last),
                 @endif @endif @endforeach
 })">

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -54,30 +54,27 @@
     <div class="border-divider mb-12 mt-14 border-x-0 border-b-0 border-t-3 border-solid pt-6">
         <h2>{{ __('Modules') }}</h2>
         <x-interpretation name="{{ __('Modules', [], 'en') }}" />
-        <div class="grid">
+        <div class="grid md:grid-cols-2">
             @foreach ($modules as $module)
-                <div class="grid">
-                    {{-- <div class="flex flex-col"> --}}
-                    <div class="card">
-                        <div class="flex items-start justify-between gap-8">
-                            <h3>
-                                <a
-                                    href="{{ localized_route('modules.module-content', ['course' => $course, 'module' => $module]) }}">
-                                    {{ $module->title }}
-                                </a>
-                            </h3>
-                            @if ($user->modules->find($module->id)?->getRelationValue('pivot')->finished_content_at)
-                                <span class="badge shrink-0">{{ __('completed') }}</span>
-                            @elseif ($user->modules->find($module->id)?->getRelationValue('pivot')->started_content_at)
-                                <span class="badge shrink-0">{{ __('In progress') }}</span>
-                            @endif
-                        </div>
-                        <div class="flex items-center gap-1">
-                            <x-heroicon-o-play />
-                            <p>{{ __('Video') }}</p>
-                        </div>
-                        <p>{{ $module->description }}</p>
+                <div class="card">
+                    <div class="flex items-start justify-between gap-8">
+                        <h3>
+                            <a
+                                href="{{ localized_route('modules.module-content', ['course' => $course, 'module' => $module]) }}">
+                                {{ $module->title }}
+                            </a>
+                        </h3>
+                        @if ($user->modules->find($module->id)?->getRelationValue('pivot')->finished_content_at)
+                            <span class="badge shrink-0">{{ __('completed') }}</span>
+                        @elseif ($user->modules->find($module->id)?->getRelationValue('pivot')->started_content_at)
+                            <span class="badge shrink-0">{{ __('In progress') }}</span>
+                        @endif
                     </div>
+                    <div class="flex items-center gap-1">
+                        <x-heroicon-o-play />
+                        <p>{{ __('Video') }}</p>
+                    </div>
+                    <p>{{ $module->description }}</p>
                 </div>
             @endforeach
         </div>

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -36,7 +36,7 @@
         <x-interpretation name="{{ __('About this course', [], 'en') }}" />
         @if ($course->video)
             <div class="stack w-full" x-data="vimeoPlayer({
-                url: '{{ $course->video }}',
+                url: @js($course->video),
                 byline: false,
                 dnt: true,
                 pip: true,

--- a/resources/views/engagements/show-criteria-selection.blade.php
+++ b/resources/views/engagements/show-criteria-selection.blade.php
@@ -47,7 +47,7 @@
             </div>
 
             <div class="box box--alt space-y-6 px-6 py-8" x-cloak x-show="editing">
-                <div class="stack" x-data="{ locationType: '{{ old('location_type', $engagement->matchingStrategy->location_type ?? App\Enums\LocationType::Regions->value) }}' }">
+                <div class="stack" x-data="{ locationType: @js(old('location_type', $engagement->matchingStrategy->location_type ?? App\Enums\LocationType::Regions->value)) }">
                     <fieldset class="field @error('location_type') field--error @enderror">
                         <legend>
                             {{ __('Are you looking for individuals in specific provinces or territories or specific cities or towns?') }}
@@ -96,7 +96,7 @@
             </div>
 
             <div class="box box--alt space-y-6 px-6 py-8" x-cloak x-show="editing">
-                <div class="stack" x-data="{ crossDisability: {{ old('cross_disability_and_deaf', $engagement->matchingStrategy->cross_disability_and_deaf ?? 1) }} }">
+                <div class="stack" x-data="{ crossDisability: @js(old('cross_disability_and_deaf', $engagement->matchingStrategy->cross_disability_and_deaf ?? 1)) }">
                     <fieldset class="field @error('cross_disability_and_deaf') field--error @enderror">
                         <legend>
                             {{ __('Is there a specific disability or Deaf group you are interested in engaging?') }}
@@ -145,8 +145,8 @@
 
             <div class="box box--alt space-y-6 px-6 py-8" x-cloak x-show="editing">
                 <div class="stack" x-data="{
-                    intersectional: {{ old('intersectional', $engagement->matchingStrategy->extra_attributes->get('intersectional', 1)) }},
-                    otherIdentityType: '{{ old('other_identity_type', $engagement->matchingStrategy->extra_attributes->get('other_identity_type', '')) }}'
+                    intersectional: @js(old('intersectional', $engagement->matchingStrategy->extra_attributes->get('intersectional', 1))),
+                    otherIdentityType: @js(old('other_identity_type', $engagement->matchingStrategy->extra_attributes->get('other_identity_type', '')))
                 }">
                     <fieldset class="field @error('intersectional') field--error @enderror">
                         <legend>

--- a/resources/views/individuals/edit/communication-and-consultation-preferences.blade.php
+++ b/resources/views/individuals/edit/communication-and-consultation-preferences.blade.php
@@ -14,7 +14,7 @@
 
             <hr class="divider--thick">
 
-            <div class="stack" x-data="{ contactPerson: '{{ old('preferred_contact_person', $individual->user->preferred_contact_person ?? 'me') }}' }">
+            <div class="stack" x-data="{ contactPerson: @js(old('preferred_contact_person', $individual->user->preferred_contact_person ?? 'me')) }">
                 <fieldset>
                     <legend>{{ __('Contact person') . ' ' . __('(required)') }}</legend>
                     <x-interpretation class="mt-0" name="{{ __('Contact person', [], 'en') }}"

--- a/resources/views/livewire/module-content.blade.php
+++ b/resources/views/livewire/module-content.blade.php
@@ -23,8 +23,8 @@
             responsive: true,
             speed: true,
             title: false
-        })" @play="Livewire.emit('onPlayerStart')"
-            @ended="Livewire.emit('onPlayerEnd')">
+        })" @play="Livewire.dispatch('onPlayerStart')"
+            @ended="Livewire.dispatch('onPlayerEnd')">
         </div>
         <p>{{ $module->introduction }}</p>
     </div>

--- a/resources/views/livewire/module-content.blade.php
+++ b/resources/views/livewire/module-content.blade.php
@@ -15,7 +15,7 @@
 <div>
     <div class="stack ml-2 mr-2">
         <div class="stack w-full" wire:ignore x-data="vimeoPlayer({
-            url: '{{ $module->video }}',
+            url: @js($module->video),
             byline: false,
             dnt: true,
             pip: true,

--- a/resources/views/livewire/theme-switcher.blade.php
+++ b/resources/views/livewire/theme-switcher.blade.php
@@ -1,5 +1,5 @@
 <nav class="themes" aria-label="{{ __('themes') }}" x-data="{
-    theme: '{{ $theme }}',
+    theme: @js($theme),
     preview(theme) {
         $wire.setTheme(theme);
         this.theme = theme;

--- a/resources/views/projects/edit/1.blade.php
+++ b/resources/views/projects/edit/1.blade.php
@@ -74,7 +74,7 @@
             <h3>{{ __('Project outcome') }}</h3>
             <x-interpretation name="{{ __('Project outcome', [], 'en') }}" />
 
-            <fieldset class="field @error('outcome_analysis') field--error @enderror stack" x-data="{ otherOutcomeAnalysis: {{ old('has_other_outcome_analysis', !is_null($project->outcome_analysis_other) && $project->outcome_analysis_other !== '' ? 'true' : 'false') }} }">
+            <fieldset class="field @error('outcome_analysis') field--error @enderror stack" x-data="{ otherOutcomeAnalysis: @js(old('has_other_outcome_analysis', !is_null($project->outcome_analysis_other) && $project->outcome_analysis_other !== '' ? true : false)) }">
                 <legend>
                     {{ __('Who will be going through the results and producing an outcome?') . ' ' . __('(required)') }}
                 </legend>

--- a/resources/views/projects/show-context-selection.blade.php
+++ b/resources/views/projects/show-context-selection.blade.php
@@ -15,7 +15,7 @@
     <x-interpretation name="{{ __('About your project', [], 'en') }}" />
 
     <form class="stack" id="create-project" action="{{ localized_route('projects.store-context') }}" method="post"
-        novalidate x-data="{ context: '{{ old('context', session('context')) ?? '' }}' }">
+        novalidate x-data="{ context: @js(old('context', session('context')) ?? '') }">
         @csrf
 
         <fieldset class="field @error('context') field--error @enderror stack">

--- a/resources/views/settings/access-needs.blade.php
+++ b/resources/views/settings/access-needs.blade.php
@@ -40,9 +40,9 @@
         </fieldset>
 
         <fieldset class="field @error('meeting_access_needs') field--error @enderror" x-data="{
-            interpretationSigned: {{ in_array($signLanguageInterpretation, old('meeting_access_needs', $selectedAccessSupports ?? [])) ? 'true' : 'false' }},
-            interpretationSpoken: {{ in_array($spokenLanguageInterpretation, old('meeting_access_needs', $selectedAccessSupports ?? [])) ? 'true' : 'false' }},
-            followUpNeeds: {{ in_array($followUpCallsOrEmails, old('meeting_access_needs', $selectedAccessSupports ?? [])) ? 'true' : 'false' }},
+            interpretationSigned: @js(in_array($signLanguageInterpretation, old('meeting_access_needs', $selectedAccessSupports ?? [])) ? true : false),
+            interpretationSpoken: @js(in_array($spokenLanguageInterpretation, old('meeting_access_needs', $selectedAccessSupports ?? [])) ? true : false),
+            followUpNeeds: @js(in_array($followUpCallsOrEmails, old('meeting_access_needs', $selectedAccessSupports ?? [])) ? true : false),
         }">
             <legend>
                 <h2>{{ __('For meeting in real time') }}</h2>

--- a/resources/views/settings/communication-and-consultation-preferences.blade.php
+++ b/resources/views/settings/communication-and-consultation-preferences.blade.php
@@ -21,7 +21,7 @@
         <h2>{{ __('Communication') }}</h2>
         <x-interpretation name="{{ __('Communication', [], 'en') }}" />
 
-        <div class="stack" x-data="{ contactPerson: '{{ old('preferred_contact_person', $individual->user->preferred_contact_person ?? 'me') }}' }">
+        <div class="stack" x-data="{ contactPerson: @js(old('preferred_contact_person', $individual->user->preferred_contact_person ?? 'me')) }">
             <fieldset>
                 <legend>{{ __('Contact person') . ' ' . __('(required)') }}</legend>
                 <x-interpretation name="{{ __('Contact person', [], 'en') }}" />
@@ -105,7 +105,7 @@
         </div>
 
         @if ($individual->isParticipant())
-            <div class="stack" x-data="{ consultingMethods: {{ json_encode(old('consulting_methods', $individual->consulting_methods ?? [])) }} }">
+            <div class="stack" x-data="{ consultingMethods: @js(old('consulting_methods', $individual->consulting_methods ?? [])) }">
                 <h2>{{ __('Consultations') }}</h2>
                 <x-interpretation name="{{ __('Consultations', [], 'en') }}" />
 

--- a/resources/views/settings/payment-information.blade.php
+++ b/resources/views/settings/payment-information.blade.php
@@ -17,7 +17,7 @@
         @csrf
         @method('put')
 
-        <fieldset class="field @error('payment_types') field--error @enderror" x-data="{ other: {{ old('other', !is_null($individual->other_payment_type) && $individual->other_payment_type !== '' ? 'true' : 'false') }} }">
+        <fieldset class="field @error('payment_types') field--error @enderror" x-data="{ other: @js(old('other', !is_null($individual->other_payment_type) && $individual->other_payment_type !== '' ? true : false)) }">
             <legend>{{ __('What types of payment are you able to accept?') }}</legend>
             <x-interpretation name="{{ __('What types of payment are you able to accept?', [], 'en') }}" />
             <p class="field__hint">{{ __('Please check all that apply.') }}</p>

--- a/resources/views/users/show-introduction.blade.php
+++ b/resources/views/users/show-introduction.blade.php
@@ -38,7 +38,7 @@
     @if (array_key_exists(locale(), $user->introduction()))
         <div class="frame">
             <div class="stack w-full" x-data="vimeoPlayer({
-                url: '{{ $user->introduction()[locale()] }}',
+                url: @js($user->introduction()[locale()]),
                 byline: false,
                 dnt: true,
                 pip: true,
@@ -52,7 +52,7 @@
     @elseif (array_key_exists('en', $user->introduction()))
         <div class="frame">
             <div class="stack w-full" x-data="vimeoPlayer({
-                url: '{{ $user->introduction()['en'] }}',
+                url: @js($user->introduction()['en']),
                 byline: false,
                 dnt: true,
                 pip: true,

--- a/tests/Feature/UserSettingsTest.php
+++ b/tests/Feature/UserSettingsTest.php
@@ -68,6 +68,44 @@ test('other users cannot manage access needs', function () {
         ->assertForbidden();
 });
 
+test('other access need can be added and removed', function () {
+    seed(AccessSupportSeeder::class);
+
+    $otherAccessNeed = 'Other access need';
+    $user = User::factory()->create(['context' => 'individual']);
+    $individual = $user->individual;
+
+    actingAs($user)->get(localized_route('settings.edit-access-needs'))
+        ->assertOk();
+
+    actingAs($user)->put(localized_route('settings.update-access-needs'), [
+        'other' => true,
+        'other_access_need' => $otherAccessNeed,
+    ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('settings.edit-access-needs'));
+
+    $individual = $individual->fresh();
+    expect($individual->other_access_need)->toBe($otherAccessNeed);
+
+    actingAs($user)->get(localized_route('settings.edit-access-needs'))
+        ->assertOk()
+        ->assertSee($otherAccessNeed);
+
+    actingAs($user)->put(localized_route('settings.update-access-needs'), [
+        'other' => false,
+    ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('settings.edit-access-needs'));
+
+    $individual = $individual->fresh();
+    expect($individual->other_access_need)->toBe('');
+
+    actingAs($user)->get(localized_route('settings.edit-access-needs'))
+        ->assertOk()
+        ->assertDontSee($otherAccessNeed);
+});
+
 test('access needs save redirect', function () {
     seed(AccessSupportSeeder::class);
 

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -14,12 +14,11 @@ use function Pest\Laravel\assertDatabaseHas;
 
 test('users can view the introduction', function () {
     $user = User::factory()->create();
-
     $user->update(['context' => 'individual']);
 
     actingAs($user)->get(localized_route('users.show-introduction'))
         ->assertOk()
-        ->assertSee('https://vimeo.com/850308866/22cf4718fc');
+        ->assertSee(str_replace('"', '', json_encode('https://vimeo.com/850308866/22cf4718fc')));
 
     actingAs($user)
         ->from(localized_route('users.show-introduction'))
@@ -36,7 +35,7 @@ test('users can view the introduction', function () {
 
     actingAs($user)->get(localized_route('users.show-introduction'))
         ->assertOk()
-        ->assertSee('https://vimeo.com/850308900/39c5bb60a7');
+        ->assertSee(str_replace('"', '', json_encode('https://vimeo.com/850308900/39c5bb60a7')));
 
     actingAs($user)
         ->from(localized_route('users.show-introduction'))
@@ -52,7 +51,7 @@ test('users can view the introduction', function () {
 
     actingAs($user)->get(localized_route('users.show-introduction'))
         ->assertOk()
-        ->assertSee('https://vimeo.com/850308924/cab1e34418');
+        ->assertSee(str_replace('"', '', json_encode('https://vimeo.com/850308924/cab1e34418')));
 
     actingAs($user)
         ->from(localized_route('users.show-introduction'))

--- a/tests/Feature/View/Components/InterpretationTest.php
+++ b/tests/Feature/View/Components/InterpretationTest.php
@@ -45,7 +45,7 @@ test('existing Interpretation instance', function () {
         'The Accessibility Exchange',
         '</h1>',
         'id="'.Str::slug('The Accessibility Exchange'),
-        $interpretation->getTranslation('video', 'asl'),
+        str_replace('"', '', json_encode($interpretation->getTranslation('video', 'asl'))),
     ];
 
     actingAs($user)->get(localized_route('welcome'))
@@ -103,7 +103,7 @@ test('in French and LSQ', function () {
         $localizedName,
         '</h1>',
         'id="'.Str::slug($localizedName),
-        $interpretation->getTranslation('video', 'lsq'),
+        str_replace('"', '', json_encode($interpretation->getTranslation('video', 'lsq'))),
     ];
 
     actingAs($user)->get(localized_route('welcome'))


### PR DESCRIPTION
Resolves #2180 

- passes data from PHP through the `@js()` directive before sending it to alpine, unless it was already json encoded.
- fixes an issue where other_access_needs couldn't be removed
- fixes broken training modules by updating livewire event to `dispatch` from `emit`.
- fixes styling of modules on course page by setting it to use 2 columns

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
