### PR TITLE
fix: remove reference to ac_application and cc_application (resolves #2203)

### DIFF
--- a/tests/Feature/Filament/SettingsTest.php
+++ b/tests/Feature/Filament/SettingsTest.php
@@ -1,14 +1,10 @@
 <?php
 
 use App\Models\User;
-use App\Settings\GeneralSettings;
 
 use function Pest\Laravel\actingAs;
 
 test('only administrative users can access the settings page', function () {
-    GeneralSettings::fake(
-        ['email' => 'support@accessibilityexchange.ca', 'individual_orientation' => ['en' => 'english link'], 'org_orientation' => ['en' => 'english link'], 'fro_orientation' => ['en' => 'english link'], 'ac_application' => ['en' => 'english link'], 'cc_application' => ['en' => 'english link']]
-    );
     $user = User::factory()->create();
     $administrator = User::factory()->create(['context' => 'administrator']);
 
@@ -22,6 +18,7 @@ test('only administrative users can access the settings page', function () {
             'Contact',
             'Support email',
             'Support phone',
+            'Privacy email',
             'Mailing address',
             'Social media',
             'Facebook page',


### PR DESCRIPTION
Resovles #2203 

Removes references to the old cc_application and ac_application settings.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
