### PR TITLE
fix: syntax error when running prettier on blade files (resolves #2338)

### DIFF
--- a/resources/css/_tokens.css
+++ b/resources/css/_tokens.css
@@ -1,4 +1,4 @@
-/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2024-10-22.
+/* VARIABLES GENERATED WITH TAILWIND CONFIG ON 2024-10-29.
     Tokens location: ./tailwind.config.js */
 :root {
     --space-0: 0;

--- a/resources/css/components/_input.css
+++ b/resources/css/components/_input.css
@@ -36,8 +36,10 @@ select:hover {
 input:focus,
 textarea:focus,
 select:focus {
-    box-shadow: 0 0 0 var(--border-2) var(--input-border-focus) inset,
-        0 0 0 var(--border-2) var(--bg, var(--body-background)), 0 0 0 var(--border-4) var(--input-border-focus);
+    box-shadow:
+        0 0 0 var(--border-2) var(--input-border-focus) inset,
+        0 0 0 var(--border-2) var(--bg, var(--body-background)),
+        0 0 0 var(--border-4) var(--input-border-focus);
     outline: transparent;
 }
 
@@ -135,8 +137,10 @@ input[type="radio"]:hover {
 
 input[type="checkbox"]:focus,
 input[type="radio"]:focus {
-    box-shadow: 0 0 0 var(--border-2) var(--input-border-focus) inset,
-        0 0 0 var(--border-2) var(--bg, var(--body-background)), 0 0 0 var(--border-4) var(--input-border-focus);
+    box-shadow:
+        0 0 0 var(--border-2) var(--input-border-focus) inset,
+        0 0 0 var(--border-2) var(--bg, var(--body-background)),
+        0 0 0 var(--border-4) var(--input-border-focus);
     outline: transparent;
 }
 
@@ -174,7 +178,8 @@ input[type="checkbox"]:checked {
 }
 
 input[type="checkbox"]:checked:focus {
-    box-shadow: 0 0 0 var(--border-2) var(--bg, var(--body-background)),
+    box-shadow:
+        0 0 0 var(--border-2) var(--bg, var(--body-background)),
         0 0 0 var(--border-4) var(--checkbox-checked-border);
 }
 
@@ -183,14 +188,17 @@ input[type="radio"]:checked {
     background-position: center;
     background-repeat: no-repeat;
     border-color: var(--bg, var(--body-background));
-    box-shadow: 0 0 0 var(--border-3) var(--bg, var(--body-background)) inset,
+    box-shadow:
+        0 0 0 var(--border-3) var(--bg, var(--body-background)) inset,
         0 0 0 var(--border-2) var(--radio-checked-border);
 }
 
 input[type="radio"]:checked:focus {
     border-color: var(--bg, var(--body-background));
-    box-shadow: 0 0 0 var(--border-3) var(--bg, var(--body-background)) inset,
-        0 0 0 var(--border-2) var(--radio-checked-border), 0 0 0 var(--border-4) var(--bg, var(--body-background)),
+    box-shadow:
+        0 0 0 var(--border-3) var(--bg, var(--body-background)) inset,
+        0 0 0 var(--border-2) var(--radio-checked-border),
+        0 0 0 var(--border-4) var(--bg, var(--body-background)),
         0 0 0 var(--border-6) var(--radio-checked-border);
 }
 

--- a/resources/js/confirmPassword.js
+++ b/resources/js/confirmPassword.js
@@ -11,7 +11,7 @@ export default (confirmedPasswordStatusRoute = false, confirmPasswordRoute = fal
     showingModal: false,
     validationError: false,
     init() {
-        axios.get(this.routes.confirmedPasswordStatus).then(response => {
+        axios.get(this.routes.confirmedPasswordStatus).then((response) => {
             if (response.data.confirmed) {
                 this.confirmedPassword = true;
             }
@@ -32,7 +32,7 @@ export default (confirmedPasswordStatusRoute = false, confirmPasswordRoute = fal
         document.body.style.top = `-${scrollY}px`;
         this.$nextTick(() => {
             const elems = document.querySelectorAll("a, button, input, select, textarea, [contenteditable]");
-            Array.prototype.forEach.call(elems, elem => {
+            Array.prototype.forEach.call(elems, (elem) => {
                 if (!elem.closest(".modal")) {
                     elem.setAttribute("tabindex", "-1");
                 }
@@ -47,24 +47,27 @@ export default (confirmedPasswordStatusRoute = false, confirmPasswordRoute = fal
         document.body.style.top = "";
         window.scrollTo(0, parseInt(scrollY || "0") * -1);
         const elems = document.querySelectorAll("a, button, input, select, textarea, [contenteditable]");
-        Array.prototype.forEach.call(elems, elem => {
+        Array.prototype.forEach.call(elems, (elem) => {
             if (!elem.closest(".modal")) {
                 elem.removeAttribute("tabindex", "-1");
             }
         });
     },
     confirmPassword: function () {
-        axios.post(this.routes.confirmPassword, {
-            password: this.$refs.password.value
-        }).then(() => {
-            this.hideModal();
-            this.confirmPassword = true;
-            this.validationError = false;
-            this.targetForm.submit();
-        })["catch"](() => {
-            this.$refs.password.focus();
-            this.validationError = true;
-        });
+        axios
+            .post(this.routes.confirmPassword, {
+                password: this.$refs.password.value
+            })
+            .then(() => {
+                this.hideModal();
+                this.confirmPassword = true;
+                this.validationError = false;
+                this.targetForm.submit();
+            })
+            ["catch"](() => {
+                this.$refs.password.focus();
+                this.validationError = true;
+            });
     },
     cancel: function () {
         this.hideModal();

--- a/resources/js/enhancedCheckboxes.js
+++ b/resources/js/enhancedCheckboxes.js
@@ -4,12 +4,12 @@ export default () => ({
         this.checkboxes = this.$el.querySelectorAll("input[type='checkbox']");
     },
     selectAll() {
-        [...this.checkboxes].forEach(el => {
+        [...this.checkboxes].forEach((el) => {
             el.checked = true;
         });
     },
     selectNone() {
-        [...this.checkboxes].forEach(el => {
+        [...this.checkboxes].forEach((el) => {
             el.checked = false;
         });
     }

--- a/resources/views/components/block-modal.blade.php
+++ b/resources/views/components/block-modal.blade.php
@@ -16,8 +16,8 @@
 
                 @if (Auth::user()->individual)
                     @if (Auth::user()->individual->isConsultant() ||
-                        Auth::user()->individual->isConnector() ||
-                        Auth::user()->individual->isParticipant())
+                            Auth::user()->individual->isConnector() ||
+                            Auth::user()->individual->isParticipant())
                         <p>{{ __('They will not be able to:') }}</p>
 
                         <ul>

--- a/resources/views/components/card/project.blade.php
+++ b/resources/views/components/card/project.blade.php
@@ -11,7 +11,7 @@
         <strong>{{ __('Project by :projectable', ['projectable' => $model->projectable->name]) }}</strong><br />
         @if ($model->projectable->sectors()->count())
             <span class="font-semibold">{{ __('Sector:') }}</span>
-            {{ implode(', ',$model->projectable->sectors()->pluck('name')->toArray()) }}
+            {{ implode(', ', $model->projectable->sectors()->pluck('name')->toArray()) }}
         @endif
     </p>
     <p class="flex flex-wrap gap-3">

--- a/resources/views/components/card/regulated-organization.blade.php
+++ b/resources/views/components/card/regulated-organization.blade.php
@@ -10,7 +10,7 @@
     <p>
         @if ($model->sectors()->count())
             <span class="font-semibold">{{ __('Sector:') }}</span>
-            {{ implode(', ',$model->sectors()->pluck('name')->toArray()) }}<br />
+            {{ implode(', ', $model->sectors()->pluck('name')->toArray()) }}<br />
         @endif
         @isset($model->locality)
             <span class="font-semibold">{{ __('Location') }}:</span> {{ $model->locality }},

--- a/resources/views/components/progress-icon.blade.php
+++ b/resources/views/components/progress-icon.blade.php
@@ -6,7 +6,6 @@
             stroke-dashoffset="{{ 7 * 2 * pi() - 7 * 2 * pi() * $progress ?? 0 }}" fill="transparent" r="7"
             cx="12" cy="12" />
     @else
-        <circle fill="transparent" stroke="currentColor" stroke-width="2" r="9" cx="12"
-            cy="12" />
+        <circle fill="transparent" stroke="currentColor" stroke-width="2" r="9" cx="12" cy="12" />
     @endif
 </svg>

--- a/resources/views/engagements/edit.blade.php
+++ b/resources/views/engagements/edit.blade.php
@@ -288,15 +288,11 @@
             <x-interpretation name="{{ __('Sign up deadline', [], 'en') }}" />
 
             <div class="field @error('signup_by_date') field--error @enderror">
-                <x-date-picker name="signup_by_date" :label="$engagement->recruitment === 'open'
-                    ? __('Participants must sign up for this engagement by the following date') .
-                        ' ' .
-                        __('(required)') .
-                        ':'
-                    : __('Participants must respond to their invitation by the following date') .
-                        ' ' .
-                        __('(required)') .
-                        ':'" :value="old('signup_by_date', $engagement->signup_by_date?->format('Y-m-d') ?? '')" />
+                <x-date-picker name="signup_by_date"
+                    label="{{ $engagement->recruitment === 'open'
+                        ? __('Participants must sign up for this engagement by the following date') . ' ' . __('(required)') . ':'
+                        : __('Participants must respond to their invitation by the following date') . ' ' . __('(required)') . ':' }}"
+                    :value="old('signup_by_date', $engagement->signup_by_date?->format('Y-m-d') ?? '')" />
             </div>
         @endif
         <hr class="divider--thick" />

--- a/resources/views/engagements/leave.blade.php
+++ b/resources/views/engagements/leave.blade.php
@@ -19,26 +19,30 @@
                                 'support_person_name' => $engagement->connector->user->support_person_name,
                             ]) }}</strong><br />
                         @if ($engagement->connector->contact_email)
-                            <x-contact-point type='email' :value="$engagement->connector->contact_email" :preferred="$engagement->connector->preferred_contact_method === 'email' &&
-                                $engagement->connector->contact_phone" />
+                            <x-contact-point type='email' :value="$engagement->connector->contact_email"
+                                preferred="{{ $engagement->connector->preferred_contact_method === 'email' && $engagement->connector->contact_phone }}" />
                         @endif
                         @if ($engagement->connector->contact_phone)
-                            <x-contact-point type='phone' :value="$engagement->connector->contact_phone" :preferred="$engagement->connector->preferred_contact_method === 'phone' &&
-                                $engagement->connector->contact_email" :vrs="$engagement->connector->contact_vrs" />
+                            <x-contact-point type='phone' :value="$engagement->connector->contact_phone"
+                                preferred="{{ $engagement->connector->preferred_contact_method === 'phone' && $engagement->connector->contact_email }}"
+                                :vrs="$engagement->connector->contact_vrs" />
                         @endif
                     </p>
                 @elseif($engagement->organizationalConnector)
                     <p>
                         <strong>{{ $engagement->organizationalConnector->contact_person_name ? $engagement->organizationalConnector->contact_person_name . ' (' . $engagement->organizationalConnector->name . ')' : $engagement->organizationalConnector->name }}</strong><br />
                         @if ($engagement->organizationalConnector->contact_person_email)
-                            <x-contact-point type="email" :value="$engagement->organizationalConnector->contact_person_email" :preferred="$engagement->organizationalConnector->preferred_contact_method === 'email' &&
-                                $engagement->organizationalConnector->contact_person_phone" />
+                            <x-contact-point type="email" :value="$engagement->organizationalConnector->contact_person_email"
+                                preferred="{{ $engagement->organizationalConnector->preferred_contact_method === 'email' &&
+                                    $engagement->organizationalConnector->contact_person_phone }}" />
                         @endif
                         @if ($engagement->organizationalConnector->contact_person_phone)
                             <x-contact-point type="phone" :value="$engagement->organizationalConnector->contact_person_phone->formatForCountry(
                                 'CA',
-                            )" :preferred="$engagement->organizationalConnector->preferred_contact_method === 'phone' &&
-                                $engagement->organizationalConnector->contact_person_email" :vrs="$engagement->organizationalConnector->contact_person_vrs" />
+                            )"
+                                preferred="{{ $engagement->organizationalConnector->preferred_contact_method === 'phone' &&
+                                    $engagement->organizationalConnector->contact_person_email }}"
+                                :vrs="$engagement->organizationalConnector->contact_person_vrs" />
                         @endif
                     </p>
                 @endif

--- a/resources/views/engagements/show-format-selection.blade.php
+++ b/resources/views/engagements/show-format-selection.blade.php
@@ -17,7 +17,8 @@
     <!-- Form Validation Errors -->
     @include('partials.validation-errors')
 
-    <form class="stack" action="{{ localized_route('engagements.store-format', $engagement) }}" method="post" novalidate>
+    <form class="stack" action="{{ localized_route('engagements.store-format', $engagement) }}" method="post"
+        novalidate>
         @csrf
         @method('put')
 

--- a/resources/views/individuals/edit/groups-you-can-connect-to.blade.php
+++ b/resources/views/individuals/edit/groups-you-can-connect-to.blade.php
@@ -80,11 +80,11 @@
                     )"
                         required />
                     <div class="field">
-                        <x-hearth-checkbox name="has_other_disability_connection" :checked="old(
-                            'has_other_disability_connection',
-                            !is_null($individual->other_disability_connection) &&
-                                $individual->other_disability_connection !== '',
-                        )"
+                        <x-hearth-checkbox name="has_other_disability_connection"
+                            checked="{{ old(
+                                'has_other_disability_connection',
+                                !is_null($individual->other_disability_connection) && $individual->other_disability_connection !== '',
+                            ) }}"
                             x-model="otherDisability" />
                         <x-hearth-label
                             for='has_other_disability_connection'>{{ __('Something else') }}</x-hearth-label>

--- a/resources/views/individuals/show.blade.php
+++ b/resources/views/individuals/show.blade.php
@@ -1,9 +1,7 @@
 <x-app-layout page-width="wide">
     <x-slot name="title">{{ $individual->name }}</x-slot>
     <x-slot name="header">
-        @if (auth()->hasUser() &&
-                auth()->user()->isAdministrator() &&
-                $individual->user->checkStatus('suspended'))
+        @if (auth()->hasUser() && auth()->user()->isAdministrator() && $individual->user->checkStatus('suspended'))
             @push('banners')
                 <x-banner type="error" icon="heroicon-s-ban">{{ __('This account has been suspended.') }}</x-banner>
             @endpush

--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -18,7 +18,7 @@
                 </nav>
             @endif
             {{-- Don't show if no session available (i.e on error pages like 404) --}}
-            @unless(session()->missing('_token'))
+            @unless (session()->missing('_token'))
                 @include('components.navigation')
             @endunless
         </div>
@@ -29,8 +29,7 @@
         {{ safe_inlineMarkdown('**CAUTION!** This website is under active development. The database is reset nightly, and data you enter will not be preserved.') }}
     </x-banner>
     @endenv
-    @if (auth()->hasUser() &&
-        auth()->user()->checkStatus('suspended'))
+    @if (auth()->hasUser() && auth()->user()->checkStatus('suspended'))
         <x-banner type="error">
             {{ safe_inlineMarkdown(
                 'Your account has been suspended. Please [contact](:url) us if you need further assistance.',

--- a/resources/views/organizations/create.blade.php
+++ b/resources/views/organizations/create.blade.php
@@ -36,7 +36,10 @@
             @if ($message === __('A :type with this name already exists.', ['type' => App\Enums\OrganizationType::labels()[$type]]))
                 <div class="stack">
                     @php
-                        $organization = App\Models\Organization::where('name->' . $locale, old('name.' . $locale))->first();
+                        $organization = App\Models\Organization::where(
+                            'name->' . $locale,
+                            old('name.' . $locale),
+                        )->first();
                     @endphp
                     <x-live-region>
                         <x-hearth-alert type="error">

--- a/resources/views/organizations/partials/disability-types.blade.php
+++ b/resources/views/organizations/partials/disability-types.blade.php
@@ -24,11 +24,12 @@
             $organization->disabilityAndDeafConstituencies->pluck('id')->toArray() ?? [],
         )" required />
         <div class="field">
-            <x-hearth-checkbox name="has_other_disability_constituency" :checked="old(
-                'has_other_disability_constituency',
-                !is_null($organization->other_disability_constituency) &&
-                    $organization->other_disability_constituency !== '',
-            )" x-model="otherDisability" />
+            <x-hearth-checkbox name="has_other_disability_constituency"
+                checked="{{ old(
+                    'has_other_disability_constituency',
+                    !is_null($organization->other_disability_constituency) && $organization->other_disability_constituency !== '',
+                ) }}"
+                x-model="otherDisability" />
             <x-hearth-label for='has_other_disability_constituency'>{{ __('Something else') }}</x-hearth-label>
         </div>
 

--- a/resources/views/organizations/show.blade.php
+++ b/resources/views/organizations/show.blade.php
@@ -1,9 +1,7 @@
 <x-app-layout page-width="wide">
     <x-slot name="title">{{ $organization->getTranslation('name', $language) }}</x-slot>
     <x-slot name="header">
-        @if (auth()->hasUser() &&
-                auth()->user()->isAdministrator() &&
-                $organization->checkStatus('suspended'))
+        @if (auth()->hasUser() && auth()->user()->isAdministrator() && $organization->checkStatus('suspended'))
             @push('banners')
                 <x-banner type="error" icon="heroicon-s-ban">{{ __('This account has been suspended.') }}</x-banner>
             @endpush
@@ -131,10 +129,12 @@
                 <x-interpretation name="{{ __('About', [], 'en') }}" />
                 @include('organizations.partials.about')
             @elseif(request()->localizedRouteIs('organizations.show-constituencies'))
-                <x-section-heading :name="__('Communities we :represent_or_serve_and_support', [
-                    'represent_or_serve_and_support' =>
-                        $organization->type === 'representative' ? __('represent') : __('serve and support'),
-                ])" :model="$organization" :href="localized_route('organizations.edit', ['organization' => $organization, 'step' => 2])" />
+                <x-section-heading
+                    name="{{ __('Communities we :represent_or_serve_and_support', [
+                        'represent_or_serve_and_support' =>
+                            $organization->type === 'representative' ? __('represent') : __('serve and support'),
+                    ]) }}"
+                    :model="$organization" :href="localized_route('organizations.edit', ['organization' => $organization, 'step' => 2])" />
                 <x-interpretation
                     name="{{ __(
                         'Communities we :represent_or_serve_and_support',

--- a/resources/views/projects/edit/1.blade.php
+++ b/resources/views/projects/edit/1.blade.php
@@ -80,10 +80,11 @@
                 </legend>
                 <x-hearth-checkboxes name="outcome_analysis" :options="\Spatie\LaravelOptions\Options::forEnum(App\Enums\OutcomeAnalyzer::class)->toArray()" :checked="old('outcome_analysis', $project->outcome_analysis ?? [])" required />
                 <div class="field">
-                    <x-hearth-checkbox name="has_other_outcome_analysis" :checked="old(
-                        'has_other_outcome_analysis',
-                        !is_null($project->outcome_analysis_other) && $project->outcome_analysis_other !== '',
-                    )"
+                    <x-hearth-checkbox name="has_other_outcome_analysis"
+                        checked="{{ old(
+                            'has_other_outcome_analysis',
+                            !is_null($project->outcome_analysis_other) && $project->outcome_analysis_other !== '',
+                        ) }}"
                         x-model="otherOutcomeAnalysis" />
                     <x-hearth-label for='has_other_outcome_analysis'>{{ __('Other') }}</x-hearth-label>
                 </div>

--- a/resources/views/projects/partials/project-and-contracted-engagements.blade.php
+++ b/resources/views/projects/partials/project-and-contracted-engagements.blade.php
@@ -1,7 +1,9 @@
 <x-card.project :model="$project" :level="4" />
 @foreach ($project->engagements as $engagement)
-    @if (($engagement->individual_connector_id && $engagement->individual_connector_id === $user->individual?->id) ||
-        ($engagement->organizational_connector_id && $engagement->organizational_connector_id === $user->organization?->id))
+    @if (
+        ($engagement->individual_connector_id && $engagement->individual_connector_id === $user->individual?->id) ||
+            ($engagement->organizational_connector_id &&
+                $engagement->organizational_connector_id === $user->organization?->id))
         <x-card.engagement :model="$engagement" :level="5" />
     @endif
 @endforeach

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -1,9 +1,7 @@
 <x-app-layout page-width="wide">
     <x-slot name="title">{{ $project->getTranslation('name', $language) }}</x-slot>
     <x-slot name="header">
-        @if (auth()->hasUser() &&
-                auth()->user()->isAdministrator() &&
-                $project->projectable->checkStatus('suspended'))
+        @if (auth()->hasUser() && auth()->user()->isAdministrator() && $project->projectable->checkStatus('suspended'))
             @push('banners')
                 <x-banner type="error" icon="heroicon-s-ban">{{ __('This account has been suspended.') }}</x-banner>
             @endpush

--- a/resources/views/regulated-organizations/create-initial.blade.php
+++ b/resources/views/regulated-organizations/create-initial.blade.php
@@ -44,7 +44,10 @@
             @if ($message === __('A :type with this name already exists.', ['type' => __('regulated-organization.types.' . $type)]))
                 <div class="stack">
                     @php
-                        $regulatedOrganization = App\Models\RegulatedOrganization::where('name->' . $locale, old('name.' . $locale))->first();
+                        $regulatedOrganization = App\Models\RegulatedOrganization::where(
+                            'name->' . $locale,
+                            old('name.' . $locale),
+                        )->first();
                     @endphp
                     <x-live-region>
                         <x-hearth-alert type="error">

--- a/resources/views/regulated-organizations/partials/contact-information.blade.php
+++ b/resources/views/regulated-organizations/partials/contact-information.blade.php
@@ -2,10 +2,11 @@
 <x-interpretation name="{{ __('contact person', [], 'en') }}" />
 
 @if ($regulatedOrganization->contact_person_email)
-    <x-contact-point type="email" :value="$regulatedOrganization->contact_person_email" :preferred="$regulatedOrganization->preferred_contact_method === 'email' &&
-        $regulatedOrganization->contact_person_phone" />
+    <x-contact-point type="email" :value="$regulatedOrganization->contact_person_email"
+        preferred="{{ $regulatedOrganization->preferred_contact_method === 'email' && $regulatedOrganization->contact_person_phone }}" />
 @endif
 @if ($regulatedOrganization->contact_person_phone)
-    <x-contact-point type="phone" :value="$regulatedOrganization->contact_person_phone" :preferred="$regulatedOrganization->preferred_contact_method === 'phone' &&
-        $regulatedOrganization->contact_person_email" :vrs="$regulatedOrganization->contact_person_vrs" />
+    <x-contact-point type="phone" :value="$regulatedOrganization->contact_person_phone"
+        preferred="{{ $regulatedOrganization->preferred_contact_method === 'phone' && $regulatedOrganization->contact_person_email }}"
+        :vrs="$regulatedOrganization->contact_person_vrs" />
 @endif

--- a/resources/views/regulated-organizations/show.blade.php
+++ b/resources/views/regulated-organizations/show.blade.php
@@ -1,9 +1,7 @@
 <x-app-layout page-width="wide">
     <x-slot name="title">{{ $regulatedOrganization->getTranslation('name', $language) }}</x-slot>
     <x-slot name="header">
-        @if (auth()->hasUser() &&
-                auth()->user()->isAdministrator() &&
-                $regulatedOrganization->checkStatus('suspended'))
+        @if (auth()->hasUser() && auth()->user()->isAdministrator() && $regulatedOrganization->checkStatus('suspended'))
             @push('banners')
                 <x-banner type="error" icon="heroicon-s-ban">{{ __('This account has been suspended.') }}</x-banner>
             @endpush

--- a/resources/views/settings/notifications/organization.blade.php
+++ b/resources/views/settings/notifications/organization.blade.php
@@ -24,12 +24,13 @@
 
             <p><strong>{{ __('Name') }}:</strong> {{ $user->organization->contact_person_name }}</p>
             @if ($user->organization->contact_person_email)
-                <x-contact-point type="email" :value="$user->organization->contact_person_email" :preferred="$user->organization->preferred_contact_method === 'email' &&
-                    $user->organization->contact_person_phone" />
+                <x-contact-point type="email" :value="$user->organization->contact_person_email"
+                    preferred="{{ $user->organization->preferred_contact_method === 'email' && $user->organization->contact_person_phone }}" />
             @endif
             @if ($user->organization->contact_person_phone)
-                <x-contact-point type="phone" :value="$user->organization->contact_person_phone" :preferred="$user->organization->preferred_contact_method === 'phone' &&
-                    $user->organization->contact_person_email" :vrs="$user->organization->contact_person_vrs" />
+                <x-contact-point type="phone" :value="$user->organization->contact_person_phone"
+                    preferred="{{ $user->organization->preferred_contact_method === 'phone' && $user->organization->contact_person_email }}"
+                    :vrs="$user->organization->contact_person_vrs" />
             @endif
 
             <p><a

--- a/resources/views/settings/payment-information.blade.php
+++ b/resources/views/settings/payment-information.blade.php
@@ -24,10 +24,9 @@
 
             <x-hearth-checkboxes name="payment_types" :options="$paymentTypes" :checked="old('payment_types', $individual->paymentTypes->pluck('id')->toArray())" />
             <div class="field @error('payment_types') field--error @enderror">
-                <x-hearth-checkbox name="other" :checked="old(
-                    'other',
-                    (!is_null($individual->other_payment_type) && $individual->other_payment_type !== '') || 1,
-                )" x-model="other" />
+                <x-hearth-checkbox name="other"
+                    checked="{{ old('other', (!is_null($individual->other_payment_type) && $individual->other_payment_type !== '') || 1) }}"
+                    x-model="other" />
                 <x-hearth-label for='other'>{{ __('Other (please specify)') }}</x-hearth-label>
             </div>
             <div class="field__subfield @error('other_payment_type') field--error @enderror stack" x-show="other"

--- a/resources/views/settings/website-accessibility-preferences.blade.php
+++ b/resources/views/settings/website-accessibility-preferences.blade.php
@@ -14,8 +14,8 @@
     <!-- Form Validation Errors -->
     @include('partials.validation-errors')
 
-    <form class="stack" action="{{ localized_route('settings.update-website-accessibility-preferences') }}" method="POST"
-        novalidate>
+    <form class="stack" action="{{ localized_route('settings.update-website-accessibility-preferences') }}"
+        method="POST" novalidate>
         @csrf
         @method('put')
 


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #2338 

- Fixes syntax issues in blade files that were preventing prettier from running
- Runs prettier on CSS, JS, and Blade files

_**NOTE:** Currently eslint-config-prettier hasn't been updated to support eslint stylistic rules; which means that there is now a conflict between linting and prettier. This is seen in the datePicker.js file for the indentation of the switch/case. For now these are left to work with eslint's rules. See: https://github.com/prettier/eslint-config-prettier/pull/272_

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
