### PR TITLE
feat: allow all website settings to be localizable in French and English (resolve #2276)

### DIFF
--- a/app/Filament/Pages/ManageGeneralSettings.php
+++ b/app/Filament/Pages/ManageGeneralSettings.php
@@ -30,48 +30,92 @@ class ManageGeneralSettings extends SettingsPage
             ->schema([
                 Section::make(__('Contact'))
                     ->schema([
-                        TextInput::make('email')
-                            ->label(__('Support email'))
-                            ->columnSpan('full')
-                            ->required()
-                            ->email(),
-                        TextInput::make('phone')
-                            ->label(__('Support phone'))
-                            ->columnSpan('full')
-                            ->required(),
-                        TextInput::make('email_privacy')
-                            ->label(__('Privacy email'))
-                            ->columnSpan('full')
-                            ->required()
-                            ->email(),
-                        Textarea::make('address')
-                            ->label(__('Mailing address'))
-                            ->columnSpan('full')
-                            ->required(),
-                    ]),
+                        Fieldset::make(__('Support email'))
+                            ->schema([
+                                TextInput::make('email.en')
+                                    ->label(get_language_exonym('en'))
+                                    ->required()
+                                    ->email(),
+                                TextInput::make('email.fr')
+                                    ->label(get_language_exonym('fr'))
+                                    ->email(),
+                            ]),
+                        Fieldset::make(__('Support phone'))
+                            ->schema([
+                                TextInput::make('phone.en')
+                                    ->label(get_language_exonym('en'))
+                                    ->required(),
+                                TextInput::make('phone.fr')
+                                    ->label(get_language_exonym('fr')),
+                            ]),
+                        Fieldset::make(__('Privacy email'))
+                            ->schema([
+                                TextInput::make('email_privacy.en')
+                                    ->label(get_language_exonym('en'))
+                                    ->required()
+                                    ->email(),
+                                TextInput::make('email_privacy.fr')
+                                    ->label(get_language_exonym('fr'))
+                                    ->email(),
+                            ]),
+                        Fieldset::make(__('Mailing address'))
+                            ->schema([
+                                Textarea::make('address.en')
+                                    ->label(get_language_exonym('en'))
+                                    ->rows(3)
+                                    ->autosize()
+                                    ->required(),
+                                Textarea::make('address.fr')
+                                    ->label(get_language_exonym('fr'))
+                                    ->rows(3)
+                                    ->autosize(),
+                            ]),
+                    ])
+                    ->columns(2),
                 Section::make(__('Social media'))
                     ->schema([
-                        TextInput::make('facebook')
-                            ->label(__('Facebook page'))
-                            ->columnSpan('full')
-                            ->required()
-                            ->activeUrl(),
-                        TextInput::make('linkedin')
-                            ->label(__('LinkedIn page'))
-                            ->columnSpan('full')
-                            ->required()
-                            ->activeUrl(),
-                        TextInput::make('twitter')
-                            ->label(__('Twitter page'))
-                            ->columnSpan('full')
-                            ->required()
-                            ->activeUrl(),
-                        TextInput::make('youtube')
-                            ->label(__('YouTube page'))
-                            ->columnSpan('full')
-                            ->required()
-                            ->activeUrl(),
-                    ]),
+                        Fieldset::make(__('Facebook page'))
+                            ->schema([
+                                TextInput::make('facebook.en')
+                                    ->label(get_language_exonym('en'))
+                                    ->required()
+                                    ->activeUrl(),
+                                TextInput::make('facebook.fr')
+                                    ->label(get_language_exonym('fr'))
+                                    ->activeUrl(),
+                            ]),
+                        Fieldset::make(__('LinkedIn page'))
+                            ->schema([
+                                TextInput::make('linkedin.en')
+                                    ->label(get_language_exonym('en'))
+                                    ->required()
+                                    ->activeUrl(),
+                                TextInput::make('linkedin.fr')
+                                    ->label(get_language_exonym('fr'))
+                                    ->activeUrl(),
+                            ]),
+                        Fieldset::make(__('Twitter page'))
+                            ->schema([
+                                TextInput::make('twitter.en')
+                                    ->label(get_language_exonym('en'))
+                                    ->required()
+                                    ->activeUrl(),
+                                TextInput::make('twitter.fr')
+                                    ->label(get_language_exonym('fr'))
+                                    ->activeUrl(),
+                            ]),
+                        Fieldset::make(__('YouTube page'))
+                            ->schema([
+                                TextInput::make('youtube.en')
+                                    ->label(get_language_exonym('en'))
+                                    ->required()
+                                    ->activeUrl(),
+                                TextInput::make('youtube.fr')
+                                    ->label(get_language_exonym('fr'))
+                                    ->activeUrl(),
+                            ]),
+                    ])
+                    ->columns(2),
                 Section::make(__('Registration'))
                     ->schema([
                         Fieldset::make(__('Individual orientation'))

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -56,8 +56,8 @@ class PageController extends Controller
 
         return new HtmlString(html_replacements($html, [
             'home' => locale() === config('app.fallback_locale') ? config('app.url') : localized_route('welcome'),
-            'email' => settings('email'),
-            'email_privacy' => settings('email_privacy'),
+            'email' => settings_localized('email', locale()),
+            'email_privacy' => settings_localized('email_privacy', locale()),
             'privacy_policy' => localized_route('about.privacy-policy'),
             'tos' => localized_route('about.terms-of-service'),
         ]));

--- a/app/Notifications/AccountSuspended.php
+++ b/app/Notifications/AccountSuspended.php
@@ -29,8 +29,8 @@ class AccountSuspended extends PlatformNotification
             ->content(
                 __('Your account on the Accessibility Exchange has been suspended.').' '.$this->getCapabilities($this->account).' '.__('Please contact us at :email or :phone if you need further assistance.',
                     [
-                        'email' => settings('email'),
-                        'phone' => phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA'),
+                        'email' => settings_localized('email', locale()),
+                        'phone' => phone(settings_localized('phone', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA'),
                     ]
                 )
             )

--- a/app/Notifications/AccountUnsuspended.php
+++ b/app/Notifications/AccountUnsuspended.php
@@ -29,8 +29,8 @@ class AccountUnsuspended extends PlatformNotification
             ->content(
                 __('Your account on the Accessibility Exchange is no longer suspended.').' '.$this->getCapabilities($this->account).' '.__('Please contact us at :email or :phone if you need further assistance.',
                     [
-                        'email' => settings('email'),
-                        'phone' => phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA'),
+                        'email' => settings_localized('email', locale()),
+                        'phone' => phone(settings_localized('ac_cc_application', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA'),
                     ]
                 )
             )

--- a/app/Notifications/AccountUnsuspended.php
+++ b/app/Notifications/AccountUnsuspended.php
@@ -30,7 +30,7 @@ class AccountUnsuspended extends PlatformNotification
                 __('Your account on the Accessibility Exchange is no longer suspended.').' '.$this->getCapabilities($this->account).' '.__('Please contact us at :email or :phone if you need further assistance.',
                     [
                         'email' => settings_localized('email', locale()),
-                        'phone' => phone(settings_localized('ac_cc_application', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA'),
+                        'phone' => phone(settings_localized('phone', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA'),
                     ]
                 )
             )

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -6,21 +6,21 @@ use Spatie\LaravelSettings\Settings;
 
 class GeneralSettings extends Settings
 {
-    public string $email;
+    public array $email;
 
-    public string $email_privacy;
+    public array $email_privacy;
 
-    public string $phone;
+    public array $phone;
 
-    public string $address;
+    public array $address;
 
-    public string $facebook;
+    public array $facebook;
 
-    public string $linkedin;
+    public array $linkedin;
 
-    public string $twitter;
+    public array $twitter;
 
-    public string $youtube;
+    public array $youtube;
 
     public array $individual_orientation;
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -420,7 +420,7 @@ if (! function_exists('settings_localized')) {
     function settings_localized(?string $key = null, ?string $locale = null, mixed $default = null): mixed
     {
         $locale = to_written_language($locale ?? config('app.locale'));
-        $settings = settings($key, []);
+        $settings = settings($key, $default);
 
         return $settings[$locale] ?? $settings[config('app.fallback_locale')];
     }

--- a/config/settings.php
+++ b/config/settings.php
@@ -7,7 +7,7 @@ return [
      * put them (manually) here.
      */
     'settings' => [
-        GeneralSettings::class,
+        App\Settings\GeneralSettings::class,
     ],
 
     /*

--- a/database/settings/2024_10_28_191140_localize_settings.php
+++ b/database/settings/2024_10_28_191140_localize_settings.php
@@ -1,0 +1,81 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->update(
+            'general.email',
+            fn (string $email) => [
+                'en' => $email,
+                'fr' => 'support@connecteuraccessibilite.ca',
+            ]
+        );
+        $this->migrator->update(
+            'general.phone',
+            fn (string $phone) => ['en' => $phone]
+        );
+        $this->migrator->update(
+            'general.email_privacy',
+            fn (string $email_privacy) => ['en' => $email_privacy]
+        );
+        $this->migrator->update(
+            'general.address',
+            fn (string $address) => ['en' => $address]
+        );
+        $this->migrator->update(
+            'general.facebook',
+            fn (string $facebook) => ['en' => $facebook]
+        );
+        $this->migrator->update(
+            'general.linkedin',
+            fn (string $linkedin) => ['en' => $linkedin]
+        );
+        $this->migrator->update(
+            'general.twitter',
+            fn (string $twitter) => ['en' => $twitter]
+        );
+        $this->migrator->update(
+            'general.youtube',
+            fn (string $youtube) => ['en' => $youtube]
+        );
+    }
+
+    public function down(): void
+    {
+        $this->migrator->update(
+            'general.email',
+            fn ($email) => $email->en
+        );
+        $this->migrator->update(
+            'general.phone',
+            fn ($phone) => $phone->en
+        );
+        $this->migrator->update(
+            'general.email_privacy',
+            fn ($email_privacy) => $email_privacy->en
+        );
+        $this->migrator->update(
+            'general.address',
+            fn ($address) => $address->en
+        );
+        $this->migrator->update(
+            'general.facebook',
+            fn ($facebook) => $facebook->en
+        );
+        $this->migrator->update(
+            'general.linkedin',
+            fn ($linkedin) => $linkedin->en
+        );
+        $this->migrator->update(
+            'general.twitter',
+            fn ($twitter) => $twitter->en
+        );
+        $this->migrator->update(
+            'general.youtube',
+            fn ($youtube) => $youtube->en
+        );
+    }
+};

--- a/resources/views/dashboard/partials/getting-started-individual.blade.php
+++ b/resources/views/dashboard/partials/getting-started-individual.blade.php
@@ -9,7 +9,7 @@
         namespace="getting_started-individual-link" />
     <p>{{ __('Before you do anything else, you must attend an orientation session to learn about this website and your options.') }}
     </p>
-    {{ safe_markdown('Please check your email for a confirmation of your session date. Please email <:email> if you did not get the email, or if you need to reschedule or cancel. If you’ve gone to your orientation session, it may take 2-3 business days to be updated here on the website.', ['email' => settings('email')]) }}
+    {{ safe_markdown('Please check your email for a confirmation of your session date. Please email <:email> if you did not get the email, or if you need to reschedule or cancel. If you’ve gone to your orientation session, it may take 2-3 business days to be updated here on the website.', ['email' => settings_localized('email', locale())]) }}
 @else
     @push('completed-steps')
         <li>

--- a/resources/views/engagements/leave.blade.php
+++ b/resources/views/engagements/leave.blade.php
@@ -75,9 +75,9 @@
 
             <p>
                 <strong>{{ __('Email') }}:</strong>
-                {{ settings('email', 'support@accessibilityexchange.ca') }}<br />
+                {{ settings_localized('email', locale(), 'support@accessibilityexchange.ca') }}<br />
                 <strong>{{ __('Phone') }}:</strong>
-                {{ phone(settings('phone', '+1-888-867-0053'))->formatForCountry('CA') }}<br />
+                {{ phone(settings_localized('phone', locale(), '+1-888-867-0053'))->formatForCountry('CA') }}<br />
                 <strong>{{ __('Hours') }}:</strong> {{ '9:00am to 5:00pm Eastern Time' }}
             </p>
             <hr class="divider--thick" />

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -29,7 +29,8 @@
                     <x-interpretation name="{{ __('Contact', [], 'en') }}" namespace="contact-footer" />
                     <address class="stack">
                         <h3>{{ __('Email') }}</h3>
-                        <p><a href="mailto:{{ settings('email') }}">{{ settings('email') }}</a>
+                        <p><a
+                                href="mailto:{{ settings_localized('email', locale()) }}">{{ settings_localized('email', locale()) }}</a>
                         </p>
                         <h3>{{ safe_inlineMarkdown('Call or :!vrs', [
                             'vrs' =>
@@ -38,18 +39,19 @@
                                 '</a>',
                         ]) }}
                         </h3>
-                        <p>{{ phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA') }}</p>
+                        <p>{{ phone(settings_localized('phone', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA') }}
+                        </p>
                         <h3>{{ __('Mailing Address') }}</h3>
-                        {{ safe_nl2br(settings('address', '')) }}
+                        {{ safe_nl2br(settings_localized('address', locale(), '')) }}
                     </address>
                 </div>
                 <nav class="stack" aria-labelledby="social">
                     <h2 id="social">{{ __('Social Media') }}</h2>
                     <ul class="stack" role="list">
-                        <li><a href="{{ settings('linkedin') }}" rel="external">LinkedIn</a></li>
-                        <li><a href="{{ settings('facebook') }}" rel="external">Facebook</a></li>
-                        <li><a href="{{ settings('twitter') }}" rel="external">Twitter</a></li>
-                        <li><a href="{{ settings('youtube') }}" rel="external">YouTube</a></li>
+                        <li><a href="{{ settings_localized('linkedin', locale()) }}" rel="external">LinkedIn</a></li>
+                        <li><a href="{{ settings_localized('facebook', locale()) }}" rel="external">Facebook</a></li>
+                        <li><a href="{{ settings_localized('twitter', locale()) }}" rel="external">Twitter</a></li>
+                        <li><a href="{{ settings_localized('youtube', locale()) }}" rel="external">YouTube</a></li>
                     </ul>
                 </nav>
             </div>

--- a/resources/views/mail/estimate-approved.blade.php
+++ b/resources/views/mail/estimate-approved.blade.php
@@ -5,5 +5,5 @@
 {{ __('Review project details') }}
 @endcomponent
 
-{{ safe_markdown('They have been instructed to send their signed agreement to <:email>.', ['email' => settings('email')]) }}
+{{ safe_markdown('They have been instructed to send their signed agreement to <:email>.', ['email' => settings_localized('email', locale())]) }}
 @endcomponent

--- a/resources/views/partials/contact-information.blade.php
+++ b/resources/views/partials/contact-information.blade.php
@@ -1,5 +1,6 @@
 <p>
-    <strong>{{ __('Email') }}:</strong> <a href="mailto:{{ settings('email') }}">{{ settings('email') }}</a>
+    <strong>{{ __('Email') }}:</strong> <a
+        href="mailto:{{ settings_localized('email', locale()) }}">{{ settings_localized('email', locale()) }}</a>
     <br>
     <strong>{{ safe_inlineMarkdown('Call or :!vrs', [
         'vrs' =>
@@ -7,5 +8,5 @@
             htmlentities(__('VRS')) .
             '</a>',
     ]) }}:</strong>
-    {{ phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA') }}
+    {{ phone(settings_localized('phone', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA') }}
 </p>

--- a/resources/views/partials/have-more-questions.blade.php
+++ b/resources/views/partials/have-more-questions.blade.php
@@ -1,5 +1,5 @@
 <p class="h3">
     {{ __('Have more questions?') }}<br />
-    {{ __('Call our support line at :number', ['number' => phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA')]) }}
+    {{ __('Call our support line at :number', ['number' => phone(settings_localized('email', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA')]) }}
 </p>
 <x-interpretation class="interpretation--center" name="{{ __('Have more questions?', [], 'en') }}" namespace="questions" />

--- a/resources/views/partials/have-more-questions.blade.php
+++ b/resources/views/partials/have-more-questions.blade.php
@@ -1,5 +1,5 @@
 <p class="h3">
     {{ __('Have more questions?') }}<br />
-    {{ __('Call our support line at :number', ['number' => phone(settings_localized('email', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA')]) }}
+    {{ __('Call our support line at :number', ['number' => phone(settings_localized('phone', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA')]) }}
 </p>
 <x-interpretation class="interpretation--center" name="{{ __('Have more questions?', [], 'en') }}" namespace="questions" />

--- a/resources/views/partials/help-bar.blade.php
+++ b/resources/views/partials/help-bar.blade.php
@@ -14,12 +14,12 @@
                                 '<a href="https://srvcanadavrs.ca/en/resources/resource-centre/vrs-basics/register/" rel="external">' .
                                 htmlentities(__('VRS')) .
                                 '</a>',
-                        ]) }}:</span>&nbsp;{{ phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA') }}
+                        ]) }}:</span>&nbsp;{{ phone(settings_localized('phone', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA') }}
                 </div>
                 <div>
                     @svg('heroicon-o-envelope')&nbsp;<span class="font-semibold">{{ __('Email') }}:</span>&nbsp;<a
-                        href="mailto:{{ settings('email') }}">
-                        {{ settings('email') }}
+                        href="mailto:{{ settings_localized('email', locale()) }}">
+                        {{ settings_localized('email', locale()) }}
                     </a>
                 </div>
             </div>

--- a/resources/views/partials/join.blade.php
+++ b/resources/views/partials/join.blade.php
@@ -11,7 +11,7 @@
                 </div>
                 <div class="stack">
                     <h3>{{ __('Sign up on the phone') }}</h3>
-                    <p>{{ __('Call our support line at :number', ['number' => phone(settings('phone', '+1-888-867-0053'), 'CA')->formatForCountry('CA')]) }}
+                    <p>{{ __('Call our support line at :number', ['number' => phone(settings_localized('phone', locale(), '+1-888-867-0053'), 'CA')->formatForCountry('CA')]) }}
                     </p>
                 </div>
                 @if ($withPricing ?? false)

--- a/resources/views/projects/manage-estimates-and-agreements.blade.php
+++ b/resources/views/projects/manage-estimates-and-agreements.blade.php
@@ -27,7 +27,7 @@
                         @include('projects.partials.included-engagements')
                     <div class="flex items-center gap-6">
                         <livewire:estimate-approver :model="$project" />
-                        <a href="mailto:{{ settings('email') }}">{{ __('Contact us') }}
+                        <a href="mailto:{{ settings_localized('email', locale()) }}">{{ __('Contact us') }}
                             @svg('heroicon-s-chevron-right')
                         </a>
                     </div>
@@ -76,7 +76,7 @@
             <x-interpretation name="{{ __('Agreements', [], 'en') }}" />
             {{ safe_markdown(
                 'The agreement will be sent with your estimate. Please sign this agreement and send it to <:email>.',
-                ['email' => settings('email')],
+                ['email' => settings_localized('email', locale())],
             ) }}
             <p><strong>{{ __('Status') }}</strong></p>
             <x-interpretation name="{{ __('Status', [], 'en') }}" />

--- a/tests/Feature/PageTest.php
+++ b/tests/Feature/PageTest.php
@@ -71,11 +71,11 @@ test('ToS contents with interpolated data', function (string $routeName, string 
         ->assertSeeInOrder([
             $page->title,
             'href="'.config('app.url').'"',
-            'href="mailto:'.settings('email').'"',
+            'href="mailto:'.settings_localized('email', locale()).'"',
             'href="'.localized_route('about.privacy-policy').'"',
             'privacy policy',
             localized_route('about.terms-of-service'),
-            'href="mailto:'.settings('email_privacy').'"',
+            'href="mailto:'.settings_localized('email_privacy', locale()).'"',
         ], false);
 })->with([
     'Terms of Service' => [

--- a/tests/Feature/SettingsHelperTest.php
+++ b/tests/Feature/SettingsHelperTest.php
@@ -4,8 +4,8 @@ use App\Settings\GeneralSettings;
 
 test('get an existing value', function () {
     // value in the database is stored as JSON
-    $generalSettings = GeneralSettings::fake(['email' => 'support@accessibilityexchange.ca']);
-    expect(settings('email'))->toBe($generalSettings->email);
+    $generalSettings = GeneralSettings::fake(['test' => 'test value']);
+    expect(settings('test'))->toBe($generalSettings->test);
 });
 
 test('get a nonexistent setting', function () {
@@ -15,8 +15,8 @@ test('get a nonexistent setting', function () {
 
 test('get a default setting', function () {
     $default = 'default value';
-    $generalSettings = GeneralSettings::fake(['example' => $default]);
-    expect(settings('example', $default))->toEqual($generalSettings->example);
+    $generalSettings = GeneralSettings::fake([]);
+    expect(settings('example', $default))->toEqual($default);
 });
 
 test('get a settings value when locale is English', function () {


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #2276 

- updates website settings to accept English and French versions
- uses the `settings_localized` function to access settings
- fixes bug that prevented using the updated method in settings migrations
- provides a migration to move existing settings to localized structure
- adds the default for the French version of the support email: [support@connecteuraccessibilite.ca](mailto:support@connecteuraccessibilite.ca)

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
