### PR TITLE
fix: return user to settings page after changing settings (resolves #2272)

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -163,7 +163,7 @@ class SettingsController extends Controller
             return redirect(localized_route('engagements.confirm-access-needs', ['engagement' => $data['return_to_engagement']]));
         }
 
-        return redirect(localized_route('settings.edit-access-needs'));
+        return redirect(localized_route('settings.show'));
     }
 
     public function editCommunicationAndConsultationPreferences(): View
@@ -216,7 +216,7 @@ class SettingsController extends Controller
 
         flash(__('Your communication and consultation preferences have been updated.'), 'success|'.__('Your communication and consultation preferences have been updated.', [], 'en'));
 
-        return redirect(localized_route('settings.edit-communication-and-consultation-preferences'));
+        return redirect(localized_route('settings.show'));
     }
 
     public function editLanguagePreferences(): View
@@ -256,7 +256,7 @@ class SettingsController extends Controller
 
         flash(__('Your language preferences have been updated.'), 'success|'.__('Your language preferences have been updated.', [], 'en'));
 
-        return redirect(localized_route('settings.edit-language-preferences'));
+        return redirect(localized_route('settings.show'));
     }
 
     public function editPaymentInformation(): View
@@ -287,7 +287,7 @@ class SettingsController extends Controller
 
         flash(__('Your payment information has been updated.'), 'success|'.__('Your payment information has been updated.', [], 'en'));
 
-        return redirect(localized_route('settings.edit-payment-information'));
+        return redirect(localized_route('settings.show'));
     }
 
     public function editAreasOfInterest(): View
@@ -313,7 +313,7 @@ class SettingsController extends Controller
 
         flash(__('Your areas of interest have been updated.'), 'success|'.__('Your areas of interest have been updated.', [], 'en'));
 
-        return redirect(localized_route('settings.edit-areas-of-interest'));
+        return redirect(localized_route('settings.show'));
     }
 
     public function editWebsiteAccessibilityPreferences(): View
@@ -336,7 +336,7 @@ class SettingsController extends Controller
 
         Cookie::queue('theme', $data['theme']);
 
-        return redirect(localized_route('settings.edit-website-accessibility-preferences'));
+        return redirect(localized_route('settings.show'));
     }
 
     public function editNotificationPreferences(): View
@@ -385,7 +385,7 @@ class SettingsController extends Controller
 
         flash(__('Your notification preferences have been updated.'), 'success|'.__('Your notification preferences have been updated.', [], 'en'));
 
-        return redirect(localized_route('settings.edit-notification-preferences'));
+        return redirect(localized_route('settings.show'));
     }
 
     public function editRolesAndPermissions(): View

--- a/tests/Feature/UserSettingsTest.php
+++ b/tests/Feature/UserSettingsTest.php
@@ -49,7 +49,7 @@ test('individual users can manage access needs', function () {
         'additional_needs_or_concerns' => $additionalNeeds->id,
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-access-needs'));
+        ->assertRedirect(localized_route('settings.show'));
 
     $individual = $individual->fresh();
     expect($individual->accessSupports->pluck('id')->toArray())->toContain($additionalNeeds->id);
@@ -83,7 +83,7 @@ test('other access need can be added and removed', function () {
         'other_access_need' => $otherAccessNeed,
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-access-needs'));
+        ->assertRedirect(localized_route('settings.show'));
 
     $individual = $individual->fresh();
     expect($individual->other_access_need)->toBe($otherAccessNeed);
@@ -96,7 +96,7 @@ test('other access need can be added and removed', function () {
         'other' => false,
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-access-needs'));
+        ->assertRedirect(localized_route('settings.show'));
 
     $individual = $individual->fresh();
     expect($individual->other_access_need)->toBe('');
@@ -150,7 +150,7 @@ test('individual users can manage communication and consultation preferences', f
         'consulting_methods' => ['survey'],
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-communication-and-consultation-preferences'));
+        ->assertRedirect(localized_route('settings.show'));
 
     expect($user->fresh()->email_verified_at)->toBeNull();
 
@@ -183,7 +183,7 @@ test('individual users can manage communication and consultation preferences', f
         'consulting_methods' => ['survey'],
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-communication-and-consultation-preferences'));
+        ->assertRedirect(localized_route('settings.show'));
 
     $user = $user->fresh();
 
@@ -214,7 +214,7 @@ test('users can manage language preferences', function () {
         'working_languages' => ['asl', 'en'],
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-language-preferences'));
+        ->assertRedirect(localized_route('settings.show'));
 
     expect($user->locale)->toEqual('asl');
     expect($user->individual->first_language)->toEqual('asl');
@@ -228,7 +228,7 @@ test('users can manage language preferences', function () {
         'locale' => 'lsq',
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-language-preferences'));
+        ->assertRedirect(localized_route('settings.show'));
 
     expect($newUser->locale)->toEqual('lsq');
 });
@@ -246,7 +246,7 @@ test('individual user can manage payment information settings', function () {
         'other_payment_type' => 'Square',
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-payment-information'));
+        ->assertRedirect(localized_route('settings.show'));
 
     expect($user->individual->other_payment_type)->toEqual('Square');
 
@@ -255,7 +255,7 @@ test('individual user can manage payment information settings', function () {
         'other_payment_type' => 'Square',
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-payment-information'));
+        ->assertRedirect(localized_route('settings.show'));
 
     expect($user->individual->fresh()->paymentTypes)->toHaveCount(1);
 });
@@ -312,7 +312,7 @@ test('users can edit areas of interest', function () {
 
     actingAs($user)->put(localized_route('settings.update-areas-of-interest'), [])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-areas-of-interest'));
+        ->assertRedirect(localized_route('settings.show'));
 });
 
 test('other users cannot edit areas of interest', function () {
@@ -338,7 +338,7 @@ test('users can edit website accessibility preferences', function () {
         'theme' => 'dark',
         'text_to_speech' => false,
     ])
-        ->assertRedirect(localized_route('settings.edit-website-accessibility-preferences'))
+        ->assertRedirect(localized_route('settings.show'))
         ->assertPlainCookie('theme', 'dark');
 });
 
@@ -357,7 +357,7 @@ test('individual and organization users can edit notification preferences', func
         'preferred_notification_method' => 'email',
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-notification-preferences'));
+        ->assertRedirect(localized_route('settings.show'));
 
     $user = User::factory()->create(['context' => 'organization']);
     Organization::factory()
@@ -371,7 +371,7 @@ test('individual and organization users can edit notification preferences', func
         'preferred_notification_method' => 'email',
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('settings.edit-notification-preferences'));
+        ->assertRedirect(localized_route('settings.show'));
 });
 
 test('other users cannot edit notification preferences', function () {


### PR DESCRIPTION
<!-- Explain what this PR does. -->

### Prerequisites

Resolves #2272 

- Updates settings redirects to the top level settings page instead of back to the same page.
  - some pages don't redirect to the top level settings page, for example changes to user account (e.g. password) and roles and permissions. 

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
