### PR TITLE
fix: null language code when saving a language connection without picking a language (resolves #2347)

### DIFF
--- a/app/Http/Controllers/IndividualController.php
+++ b/app/Http/Controllers/IndividualController.php
@@ -230,7 +230,7 @@ class IndividualController extends Controller
 
         if (isset($data['language_connections'])) {
             $languages = [];
-            foreach ($data['language_connections'] as $code) {
+            foreach (array_filter($data['language_connections']) as $code) {
                 $language = Language::firstOrCreate(
                     ['code' => $code],
                     [


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #2347 

- removes null values from language connections before trying to store the values to the database.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
