### PR TITLE
ci: automate merging releases to staging (resolves #2349)

### DIFF
--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -85,7 +85,7 @@ jobs:
           git merge ${{ inputs.tag || github.event.release.tag_name }}
 
     - name: Push merge to repository's "${{ env.BRANCH }}" branch
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v0.8.0
       with:
         github_token: ${{ steps.app-token.outputs.token }}
         branch: ${{ env.BRANCH }}

--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -1,0 +1,91 @@
+name: Merge Release
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to merge into'
+        required: true
+        type: string
+        default: production
+      tag:
+        description: 'Tag to merge'
+        required: true
+        type: string
+
+jobs:
+  merge-release:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: true
+
+    name: Merge tag
+
+    steps:
+    - name: Determine branch
+      run: |
+        echo 'BRANCH='${{ inputs.branch || 'staging' }} >> $GITHUB_ENV
+
+    - name: Checkout "${{ env.BRANCH }}" branch locally
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ env.BRANCH }}
+        fetch-tags: true
+        fetch-depth: 0
+
+    - uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ vars.GHA_APP_ID }}
+        private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+
+    - name: Get GitHub App User ID
+      if: ${{ github.event_name == 'release' }}
+      id: get-user-id
+      run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+    - name: Update values for git user config (release)
+      if: ${{ github.event_name == 'release' }}
+      run: |
+        echo "GIT_USER_NAME=${{ steps.app-token.outputs.app-slug }}[bot]" >> $GITHUB_ENV
+        echo "GIT_USER_EMAIL=${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>" >> $GITHUB_ENV
+
+    - name: Update values for git user config (workflow_dispatch)
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        # fetch user info
+        user=$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /user/$ACCOUNT_ID )
+
+        # get user's name and email
+        # email will be set to null if it is private
+        name=$(echo $user | jq '.name')
+        email=$(echo $user | jq '.email')
+
+        # store in environment variables to use for setting up git user
+        echo "GIT_USER_NAME=$name" >> $GITHUB_ENV
+        echo "GIT_USER_EMAIL=$email" >> $GITHUB_ENV
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ACCOUNT_ID: ${{ github.actor_id }}
+
+    - name: Merge tag to local "${{ env.BRANCH }}" branch
+      run: |
+          git config --local user.email "$GIT_USER_EMAIL"
+          git config --local user.name "$GIT_USER_NAME"
+          git merge ${{ inputs.tag || github.event.release.tag_name }}
+
+    - name: Push merge to repository's "${{ env.BRANCH }}" branch
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ steps.app-token.outputs.token }}
+        branch: ${{ env.BRANCH }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,10 +8,18 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: google-github-actions/release-please-action@v4
-        id: release
+      - uses: actions/create-github-app-token@v1
+        id: app-token
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ vars.GHA_APP_ID }}
+          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #2349 

- Will automerge a release to staging
- Provides a workflow that can be triggered to merge a release to production

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
