### PR TITLE
test: fix deprecation errors

### DIFF
--- a/tests/Datasets/AddOrganizationValidationErrors.php
+++ b/tests/Datasets/AddOrganizationValidationErrors.php
@@ -3,7 +3,7 @@
 use App\Models\Organization;
 
 dataset('addOrganizationValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Organization id is missing' => [
             'state' => ['organization_id' => null],
             'errors' => fn () => ['organization_id' => __('validation.required', ['attribute' => __('organization.singular_name')])],
@@ -19,5 +19,5 @@ dataset('addOrganizationValidationErrors', function () {
             ])->id],
             'errors' => fn () => ['organization_id' => __('The organization you have added does not participate in engagements.')],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/BrowseEngagementsFormat.php
+++ b/tests/Datasets/BrowseEngagementsFormat.php
@@ -33,5 +33,5 @@ dataset('browseEngagementsFormat', function () {
         ];
     }
 
-    return $testCases;
+    return array_map('array_values', $testCases);
 });

--- a/tests/Datasets/DestroyIndividualRequestValidationErrors.php
+++ b/tests/Datasets/DestroyIndividualRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('destroyIndividualRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Current password is missing' => [
             'state' => ['current_password' => null],
             'errors' => fn () => ['current_password' => __('validation.required', ['attribute' => __('current password')])],
@@ -14,5 +14,5 @@ dataset('destroyIndividualRequestValidationErrors', function () {
             'state' => ['current_password' => 'fake_password'],
             'errors' => fn () => ['current_password' => __('The provided password does not match your current password.')],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/DestroyOrganizationRequestValidationErrors.php
+++ b/tests/Datasets/DestroyOrganizationRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('destroyOrganizationRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Current password is missing' => [
             'state' => ['current_password' => null],
             'errors' => fn () => ['current_password' => __('validation.required', ['attribute' => __('current password')])],
@@ -14,5 +14,5 @@ dataset('destroyOrganizationRequestValidationErrors', function () {
             'state' => ['current_password' => 'fake_password'],
             'errors' => fn () => ['current_password' => __('validation.current_password', ['attribute' => __('current password')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/DestroyProjectRequestValidationErrors.php
+++ b/tests/Datasets/DestroyProjectRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('destroyProjectRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Current password is missing' => [
             'state' => [],
             'errors' => fn () => ['current_password' => __('validation.required', ['attribute' => __('current password')])],
@@ -14,5 +14,5 @@ dataset('destroyProjectRequestValidationErrors', function () {
             'state' => ['current_password' => 'WrongPassword'],
             'errors' => fn () => ['current_password' => __('The provided password does not match your current password.')],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/DestroyRegulatedOrganizationRequestValidationErrors.php
+++ b/tests/Datasets/DestroyRegulatedOrganizationRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('destroyRegulatedOrganizationRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Current password is missing' => [
             'state' => ['current_password' => null],
             'errors' => fn () => ['current_password' => __('validation.required', ['attribute' => __('current password')])],
@@ -14,5 +14,5 @@ dataset('destroyRegulatedOrganizationRequestValidationErrors', function () {
             'state' => ['current_password' => 'fake_password'],
             'errors' => fn () => ['current_password' => __('The provided password does not match your current password.')],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/InviteParticipantValidationErrors.php
+++ b/tests/Datasets/InviteParticipantValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('inviteParticipantValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Email is missing' => [
             'state' => ['email' => null],
             'errors' => fn () => ['email' => __('You must enter an email address.')],
@@ -22,5 +22,5 @@ dataset('inviteParticipantValidationErrors', function () {
             'state' => ['email' => 'not-individual@example.com'],
             'errors' => fn () => ['email' => __('The person with the email address you provided is not a consultation participant.')],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/SaveOrganizationRolesRequestValidationErrors.php
+++ b/tests/Datasets/SaveOrganizationRolesRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('saveOrganizationRolesRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Roles is missing' => [
             'state' => ['roles' => null],
             'errors' => fn () => ['roles' => __('You must select a role for your organization.')],
@@ -14,5 +14,5 @@ dataset('saveOrganizationRolesRequestValidationErrors', function () {
             'state' => ['roles' => ['other']],
             'errors' => fn () => ['roles.0' => __('validation.exists', ['attribute' => __('roles')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreAccessNeedsPermissionsValidationErrors.php
+++ b/tests/Datasets/StoreAccessNeedsPermissionsValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeAccessNeedsPermissionsValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Share access needs is missing' => [
             'state' => [],
             'errors' => fn () => ['share_access_needs' => __('validation.required', ['attribute' => __('share access needs')])],
@@ -10,5 +10,5 @@ dataset('storeAccessNeedsPermissionsValidationErrors', function () {
             'state' => ['share_access_needs' => 123],
             'errors' => fn () => ['share_access_needs' => __('validation.boolean', ['attribute' => __('share access needs')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreEngagementFormatRequestValidationErrors.php
+++ b/tests/Datasets/StoreEngagementFormatRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeEngagementFormatRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Format is missing' => [
             'state' => ['format' => null],
             'errors' => fn () => ['format' => __('validation.required', ['attribute' => __('engagement format')])],
@@ -10,5 +10,5 @@ dataset('storeEngagementFormatRequestValidationErrors', function () {
             'state' => ['format' => ['xyz']],
             'errors' => fn () => ['format' => __('validation.exists', ['attribute' => __('engagement format')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreEngagementLanguagesRequestValidationErrors.php
+++ b/tests/Datasets/StoreEngagementLanguagesRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeEngagementLanguagesRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Languages is missing' => [
             'state' => ['languages' => null],
             'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('languages')])],
@@ -18,5 +18,5 @@ dataset('storeEngagementLanguagesRequestValidationErrors', function () {
             'state' => ['languages' => ['xyz']],
             'errors' => fn () => ['languages.0' => __('validation.exists', ['attribute' => __('languages')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreEngagementRecruitmentRequestValidationErrors.php
+++ b/tests/Datasets/StoreEngagementRecruitmentRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeEngagementRecruitmentRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Recruitment is missing' => [
             'state' => ['recruitment' => null],
             'errors' => fn () => ['recruitment' => __('validation.required', ['attribute' => __('recruitment method')])],
@@ -10,5 +10,5 @@ dataset('storeEngagementRecruitmentRequestValidationErrors', function () {
             'state' => ['recruitment' => ['xyz']],
             'errors' => fn () => ['recruitment' => __('validation.exists', ['attribute' => __('recruitment method')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreEngagementRequestValidationErrors.php
+++ b/tests/Datasets/StoreEngagementRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeEngagementRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Project id is missing' => [
             'state' => ['project_id' => null],
             'errors' => fn () => ['project_id' => __('validation.required', ['attribute' => __('project id')])],
@@ -29,5 +29,5 @@ dataset('storeEngagementRequestValidationErrors', function () {
             'state' => ['who' => 'other'],
             'errors' => fn () => ['who' => __('validation.exists', ['attribute' => __('who')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreOrganizationLanguagesRequestValidationErrors.php
+++ b/tests/Datasets/StoreOrganizationLanguagesRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeOrganizationLanguagesRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Languages is missing' => [
             'state' => ['roles' => null],
             'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('languages')])],
@@ -14,5 +14,5 @@ dataset('storeOrganizationLanguagesRequestValidationErrors', function () {
             'state' => ['languages' => []],
             'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('languages')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreOrganizationRequestValidationErrors.php
+++ b/tests/Datasets/StoreOrganizationRequestValidationErrors.php
@@ -3,7 +3,7 @@
 use App\Models\Organization;
 
 dataset('storeOrganizationRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Type is missing' => [
             'state' => ['type' => null],
             'errors' => fn () => ['type' => __('validation.required', ['attribute' => __('organization type')])],
@@ -26,5 +26,5 @@ dataset('storeOrganizationRequestValidationErrors', function () {
                 'name.fr' => __('An organization with this name already exists on our website. Please contact your colleagues to get an invitation. If this isn’t your organization, please use a different name.'),
             ],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreOrganizationTypeRequestValidationErrors.php
+++ b/tests/Datasets/StoreOrganizationTypeRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeOrganizationTypeRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Type is missing' => [
             'state' => ['type' => null],
             'errors' => fn () => ['type' => __('You must select what type of organization you are.')],
@@ -10,5 +10,5 @@ dataset('storeOrganizationTypeRequestValidationErrors', function () {
             'state' => ['type' => 'other'],
             'errors' => fn () => ['type' => __('validation.exists', ['attribute' => __('organization type')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreProjectContextRequestValidationErrors.php
+++ b/tests/Datasets/StoreProjectContextRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeProjectContextRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Context type is missing' => [
             'state' => ['context' => null],
             'errors' => fn () => ['context' => __('validation.required', ['attribute' => __('project context')])],
@@ -26,5 +26,5 @@ dataset('storeProjectContextRequestValidationErrors', function () {
             'state' => ['ancestor' => 1000000, 'context' => 'new'],
             'errors' => fn () => ['ancestor' => __('validation.exists', ['attribute' => __('previous project')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreProjectLanguagesRequestValidationErrors.php
+++ b/tests/Datasets/StoreProjectLanguagesRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeProjectLanguagesRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Languages type is missing' => [
             'state' => ['languages' => null],
             'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('project languages')])],
@@ -14,5 +14,5 @@ dataset('storeProjectLanguagesRequestValidationErrors', function () {
             'state' => ['languages' => []],
             'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('project languages')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreProjectRequestValidationErrors.php
+++ b/tests/Datasets/StoreProjectRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeProjectRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Projectable type is missing' => [
             'state' => ['projectable_type' => null],
             'errors' => fn () => ['projectable_type' => __('validation.required', ['attribute' => __('projectable type')])],
@@ -53,5 +53,5 @@ dataset('storeProjectRequestValidationErrors', function () {
             'state' => ['name.en' => false],
             'errors' => fn () => ['name.en' => __('validation.string', ['attribute' => __('project name (English)')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreRegulatedOrganizationLanguagesRequestValidationErrors.php
+++ b/tests/Datasets/StoreRegulatedOrganizationLanguagesRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeRegulatedOrganizationLanguagesRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Languages is missing' => [
             'state' => ['languages' => null],
             'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('languages')])],
@@ -10,5 +10,5 @@ dataset('storeRegulatedOrganizationLanguagesRequestValidationErrors', function (
             'state' => ['languages' => false],
             'errors' => fn () => ['languages' => __('validation.array', ['attribute' => __('languages')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreRegulatedOrganizationRequestValidationErrors.php
+++ b/tests/Datasets/StoreRegulatedOrganizationRequestValidationErrors.php
@@ -6,7 +6,7 @@ use App\Models\RegulatedOrganization;
 dataset('storeRegulatedOrganizationRequestValidationErrors', function () {
     $businessType = RegulatedOrganizationType::Business->value;
 
-    return [
+    return array_map('array_values', [
         'Type is missing' => [
             'state' => ['type' => null],
             'errors' => fn () => ['type' => __('validation.required', ['attribute' => __('organization type')])],
@@ -36,5 +36,5 @@ dataset('storeRegulatedOrganizationRequestValidationErrors', function () {
                 'name.fr' => __('A :type with this name already exists.', ['type' => $businessType]),
             ],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/StoreRegulatedOrganizationTypeRequestValidationErrors.php
+++ b/tests/Datasets/StoreRegulatedOrganizationTypeRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('storeRegulatedOrganizationTypeRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Type is missing' => [
             'state' => ['type' => null],
             'errors' => fn () => ['type' => __('You must select what type of organization you are.')],
@@ -14,5 +14,5 @@ dataset('storeRegulatedOrganizationTypeRequestValidationErrors', function () {
             'state' => ['type' => 'other'],
             'errors' => fn () => ['type' => __('validation.exists', ['attribute' => __('organization type')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateEngagementLanguagesRequestValidationErrors.php
+++ b/tests/Datasets/UpdateEngagementLanguagesRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('updateEngagementLanguagesRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Languages is missing' => [
             'state' => ['languages' => null],
             'errors' => fn () => ['languages' => __('validation.required', ['attribute' => __('languages')])],
@@ -18,5 +18,5 @@ dataset('updateEngagementLanguagesRequestValidationErrors', function () {
             'state' => ['languages' => ['xyz']],
             'errors' => fn () => ['languages.0' => __('validation.exists', ['attribute' => __('languages')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateEngagementRequestValidationErrors.php
+++ b/tests/Datasets/UpdateEngagementRequestValidationErrors.php
@@ -6,7 +6,7 @@ use App\Enums\EngagementFormat;
 use App\Enums\MeetingType;
 
 dataset('updateEngagementRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Name is missing' => [
             ['name' => null],
             fn () => [
@@ -648,5 +648,5 @@ dataset('updateEngagementRequestValidationErrors', function () {
                 'meetingType' => MeetingType::InPerson->value,
             ],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateIndividualCommunicationAndConsultationPreferencesRequestValidationErrors.php
+++ b/tests/Datasets/UpdateIndividualCommunicationAndConsultationPreferencesRequestValidationErrors.php
@@ -4,7 +4,7 @@ use App\Enums\ContactPerson;
 use App\Models\User;
 
 dataset('updateIndividualCommunicationAndConsultationPreferencesRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Preferred contact person is missing' => [
             'state' => ['preferred_contact_person' => null],
             'errors' => fn () => ['preferred_contact_person' => __('validation.required', ['attribute' => __('Preferred contact person')])],
@@ -121,5 +121,5 @@ dataset('updateIndividualCommunicationAndConsultationPreferencesRequestValidatio
             'state' => ['meeting_types' => ['other']],
             'errors' => fn () => ['meeting_types.0' => __('validation.exists', ['attribute' => __('Ways to attend')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateIndividualConstituenciesRequestValidationErrors.php
+++ b/tests/Datasets/UpdateIndividualConstituenciesRequestValidationErrors.php
@@ -3,7 +3,7 @@
 use App\Enums\BaseDisabilityType;
 
 dataset('updateIndividualConstituenciesRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Disability and deaf is missing' => [
             'state' => [
                 'disability_and_deaf' => null,
@@ -321,5 +321,5 @@ dataset('updateIndividualConstituenciesRequestValidationErrors', function () {
             'state' => ['connection_lived_experience' => 'other'],
             'errors' => fn () => ['connection_lived_experience' => __('validation.exists', ['attribute' => __('connection lived experience')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateIndividualExperiencesRequestValidationErrors.php
+++ b/tests/Datasets/UpdateIndividualExperiencesRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('updateIndividualExperiencesRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Lived experience is not an array' => [
             'state' => ['lived_experience' => 123],
             'errors' => fn () => ['lived_experience' => __('validation.array', ['attribute' => __('Lived experience')])],
@@ -230,5 +230,5 @@ dataset('updateIndividualExperiencesRequestValidationErrors', function () {
             ]],
             'errors' => fn () => ['relevant_experiences.0.current' => __('validation.boolean', ['attribute' => __('I currently work or volunteer here')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateIndividualInterestsRequestValidationErrors.php
+++ b/tests/Datasets/UpdateIndividualInterestsRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('updateIndividualInterestsRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Sectors is not an array' => [
             'state' => ['sectors' => 123],
             'errors' => fn () => ['sectors' => __('validation.array', ['attribute' => __('Regulated Organization type')])],
@@ -18,5 +18,5 @@ dataset('updateIndividualInterestsRequestValidationErrors', function () {
             'state' => ['impacts' => [100000]],
             'errors' => fn () => ['impacts.0' => __('validation.exists', ['attribute' => __('area of accessibility planning and design')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateIndividualRequestValidationErrors.php
+++ b/tests/Datasets/UpdateIndividualRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('updateIndividualRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Missing name' => [
             ['name' => null],
             fn () => ['name' => __('validation.required', ['attribute' => __('full name')])],
@@ -78,5 +78,5 @@ dataset('updateIndividualRequestValidationErrors', function () {
             ['website_link' => 'https://example.fake/'],
             fn () => ['website_link' => __('You must enter a valid website link.')],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateOrganizationConstituenciesRequestValidationErrors.php
+++ b/tests/Datasets/UpdateOrganizationConstituenciesRequestValidationErrors.php
@@ -6,7 +6,7 @@ use App\Enums\OrganizationType;
 dataset('updateOrganizationConstituenciesRequestValidationErrors', function () {
     $orgState = ['type' => OrganizationType::Representative->value];
 
-    return [
+    return array_map('array_values', [
         'Disability and deaf is not a boolean' => [
             'orgState' => $orgState,
             'state' => ['disability_and_deaf' => 123],
@@ -372,5 +372,5 @@ dataset('updateOrganizationConstituenciesRequestValidationErrors', function () {
             'state' => ['staff_lived_experience' => 'other'],
             'errors' => fn () => ['staff_lived_experience' => __('validation.exists', ['attribute' => __('Staff lived experience')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateOrganizationContactInformationRequestValidationErrors.php
+++ b/tests/Datasets/UpdateOrganizationContactInformationRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('updateOrganizationContactInformationRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Contact person name is missing' => [
             'state' => ['contact_person_name' => null],
             'errors' => fn () => ['contact_person_name' => __('validation.required', ['attribute' => __('Contact person')])],
@@ -69,5 +69,5 @@ dataset('updateOrganizationContactInformationRequestValidationErrors', function 
             'state' => ['preferred_contact_language' => 'xx'],
             'errors' => fn () => ['preferred_contact_language' => __('validation.exists', ['attribute' => __('preferred contact language')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateOrganizationInterestsRequestValidationErrors.php
+++ b/tests/Datasets/UpdateOrganizationInterestsRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('updateOrganizationInterestsRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Impacts is not an array' => [
             'state' => ['impacts' => 123],
             'errors' => fn () => ['impacts' => __('validation.array', ['attribute' => __('area of accessibility planning and design')])],
@@ -18,5 +18,5 @@ dataset('updateOrganizationInterestsRequestValidationErrors', function () {
             'state' => ['sectors' => [1000000]],
             'errors' => fn () => ['sectors.0' => __('validation.exists', ['attribute' => __('Regulated Organization type')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateOrganizationRequestValidationErrors.php
+++ b/tests/Datasets/UpdateOrganizationRequestValidationErrors.php
@@ -3,7 +3,7 @@
 use App\Models\Organization;
 
 dataset('updateOrganizationRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Name is missing' => [
             'state' => ['name' => null],
             'errors' => fn () => [
@@ -103,5 +103,5 @@ dataset('updateOrganizationRequestValidationErrors', function () {
             'state' => ['website_link' => 'fake.example.com'],
             'errors' => fn () => ['website_link' => __('validation.active_url', ['attribute' => __('Website link')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateProjectRequestValidationErrors.php
+++ b/tests/Datasets/UpdateProjectRequestValidationErrors.php
@@ -3,7 +3,7 @@
 use Carbon\Carbon;
 
 dataset('updateProjectRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Name is missing' => [
             'state' => ['name' => null],
             'errors' => fn () => [
@@ -163,5 +163,5 @@ dataset('updateProjectRequestValidationErrors', function () {
             'state' => ['public_outcomes' => 123],
             'errors' => fn () => ['public_outcomes' => __('validation.boolean', ['attribute' => __('public outcomes')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateProjectTeamRequestValidationErrors.php
+++ b/tests/Datasets/UpdateProjectTeamRequestValidationErrors.php
@@ -1,7 +1,7 @@
 <?php
 
 dataset('updateProjectTeamRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Team size is not an array' => [
             'state' => ['team_size' => 'test'],
             'errors' => fn () => ['team_size' => __('validation.array', ['attribute' => __('team size')])],
@@ -85,5 +85,5 @@ dataset('updateProjectTeamRequestValidationErrors', function () {
             ],
             'without' => ['contact_person_response_time'],
         ],
-    ];
+    ]);
 });

--- a/tests/Datasets/UpdateRegulatedOrganizationRequestValidationErrors.php
+++ b/tests/Datasets/UpdateRegulatedOrganizationRequestValidationErrors.php
@@ -3,7 +3,7 @@
 use App\Models\RegulatedOrganization;
 
 dataset('updateRegulatedOrganizationRequestValidationErrors', function () {
-    return [
+    return array_map('array_values', [
         'Name is missing' => [
             'state' => ['name' => null],
             'errors' => fn () => [
@@ -194,5 +194,5 @@ dataset('updateRegulatedOrganizationRequestValidationErrors', function () {
             'state' => ['preferred_contact_language' => 'xx'],
             'errors' => fn () => ['preferred_contact_language' => __('validation.exists', ['attribute' => __('preferred contact language')])],
         ],
-    ];
+    ]);
 });

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -1517,7 +1517,7 @@ test('Engagements I’ve joined pages redirect incomplete orgs', function () {
         ->assertRedirect($redirectRoute);
 });
 
-dataset('joinedEngagementsAccessByRoles', [
+dataset('joinedEngagementsAccessByRoles', array_map('array_values', [
     'no roles' => [
         'roles' => [],
         'routes' => [
@@ -1550,9 +1550,9 @@ dataset('joinedEngagementsAccessByRoles', [
             'engagements.joined-participating' => true,
         ],
     ],
-]);
+]));
 
-dataset('joinedByEngagement', [
+dataset('joinedByEngagement', array_map('array_values', [
     'no engagements' => [
         'engagements' => [],
         'engagementRoutes' => [],
@@ -1604,7 +1604,7 @@ dataset('joinedByEngagement', [
             'engagements.joined-participating' => true,
         ],
     ],
-]);
+]));
 
 test('Engagements I’ve joined pages for Individuals', function ($roles, $routes, $engagements, $engagementRoutes) {
     $user = User::factory()->create();
@@ -1741,7 +1741,7 @@ test('Engagements I’ve joined pages for Organizations', function ($roles, $rou
     ->with('joinedEngagementsAccessByRoles')
     ->with('joinedByEngagement');
 
-dataset('joinedEngagementsByRoles', [
+dataset('joinedEngagementsByRoles', array_map('array_values', [
     'community connector' => [
         'roles' => [IndividualRole::CommunityConnector->value],
         'routes' => [
@@ -1756,9 +1756,9 @@ dataset('joinedEngagementsByRoles', [
             'engagements.joined-participating',
         ],
     ],
-]);
+]));
 
-dataset('engagementActiveStates', [
+dataset('engagementActiveStates', array_map('array_values', [
     'no engagements' => [
         'engagementStates' => [
             'active' => false,
@@ -1783,7 +1783,7 @@ dataset('engagementActiveStates', [
             'complete' => true,
         ],
     ],
-]);
+]));
 
 test('Engagements I’ve joined engagement lists for Individuals', function ($roles, $routes, $engagementStates) {
     $user = User::factory()->create();

--- a/tests/Feature/PageTest.php
+++ b/tests/Feature/PageTest.php
@@ -27,7 +27,7 @@ test('Page content rendering', function (string $routeName, string $title, bool 
             $rendered,
         ], false)
         ->assertViewIs('about.show-page');
-})->with([
+})->with(array_map('array_values', [
     'Terms of Service' => [
         'routeName' => 'about.terms-of-service',
         'title' => 'Terms of Service',
@@ -43,7 +43,7 @@ test('Page content rendering', function (string $routeName, string $title, bool 
         'title' => 'Test Page',
         'withParam' => true,
     ],
-])->with([
+]))->with(array_map('array_values', [
     'Null content' => [
         'input' => null,
         'output' => 'Coming soon',
@@ -56,7 +56,7 @@ test('Page content rendering', function (string $routeName, string $title, bool 
         'input' => '## Heading',
         'output' => '<h2 id="heading">Heading</h2>',
     ],
-]);
+]));
 
 test('ToS contents with interpolated data', function (string $routeName, string $title, bool $withParam = false) {
     $page = Page::factory()->create([
@@ -77,7 +77,7 @@ test('ToS contents with interpolated data', function (string $routeName, string 
             localized_route('about.terms-of-service'),
             'href="mailto:'.settings_localized('email_privacy', locale()).'"',
         ], false);
-})->with([
+})->with(array_map('array_values', [
     'Terms of Service' => [
         'routeName' => 'about.terms-of-service',
         'title' => 'Terms of Service',
@@ -91,4 +91,4 @@ test('ToS contents with interpolated data', function (string $routeName, string 
         'title' => 'Test Page',
         'withParam' => true,
     ],
-]);
+]));

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -921,7 +921,7 @@ test('my projects page displays projects by status', function ($userContext, $mo
         $response->assertDontSee($item);
     }
 
-})->with([
+})->with(array_map('array_values', [
     'organization' => [
         'userContext' => UserContext::Organization->value,
         'modelClass' => Organization::class,
@@ -930,7 +930,7 @@ test('my projects page displays projects by status', function ($userContext, $mo
         'userContext' => UserContext::RegulatedOrganization->value,
         'modelClass' => RegulatedOrganization::class,
     ],
-])->with([
+]))->with(array_map('array_values', [
     'draft' => [
         'projectState' => [
             'published_at' => null,
@@ -959,7 +959,7 @@ test('my projects page displays projects by status', function ($userContext, $mo
         'toSee' => ['Completed'],
         'dontSee' => ['Draft', 'In progress', 'Upcoming'],
     ],
-]);
+]));
 
 test('test project statuses scope', function () {
     $upcomingProject = Project::factory()->create([

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -20,7 +20,7 @@ uses(DuskTestCase::class)->in('Browser');
 uses(TestCase::class, CreatesApplication::class, FastRefreshDatabase::class)->in('Feature');
 uses(TestCase::class, CreatesApplication::class, FastRefreshDatabase::class)->in('Unit');
 
-uses()->compact();
+// uses()->compact();
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -20,7 +20,7 @@ uses(DuskTestCase::class)->in('Browser');
 uses(TestCase::class, CreatesApplication::class, FastRefreshDatabase::class)->in('Feature');
 uses(TestCase::class, CreatesApplication::class, FastRefreshDatabase::class)->in('Unit');
 
-// uses()->compact();
+uses()->compact();
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/SafeNL2BRHelperTest.php
+++ b/tests/Unit/SafeNL2BRHelperTest.php
@@ -11,7 +11,7 @@ test('encoding of N2BL content', function (bool $use_xhtml, string $input, strin
 })->with([
     'xhtml compatible breaks' => true,
     'xhmtl incompatible breaks' => false,
-])->with([
+])->with(array_map('array_values', [
     'plain string' => [
         'input' => 'Text',
         'output' => 'Text',
@@ -28,4 +28,4 @@ test('encoding of N2BL content', function (bool $use_xhtml, string $input, strin
         'output' => '&lt;strong&gt;Before&lt;/strong&gt;%break%
                     After',
     ],
-]);
+]));


### PR DESCRIPTION
Fixes deprecation errors related to named parameters in test datasets. See Matrix discussion: https://matrix.to/#/!QRQCoXAWrIjYQVYaai:matrix.org/$NddpSUztTX62Uvwi-12C-750zXpWVxtDBV5ObBmIf8c?via=matrix.org

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
