### PR TITLE
fix: unpublishing a users public page may return a 404 error (resolves #2366)

### DIFF
--- a/app/Http/Controllers/IndividualController.php
+++ b/app/Http/Controllers/IndividualController.php
@@ -328,7 +328,11 @@ class IndividualController extends Controller
             $individual->publish();
         }
 
-        return redirect(localized_route('individuals.show', $individual));
+        if ($individual->isPreviewable()) {
+            return redirect(localized_route('individuals.show', $individual));
+        } else {
+            return redirect(localized_route('dashboard'));
+        }
     }
 
     public function destroy(DestroyIndividualRequest $request, Individual $individual): RedirectResponse

--- a/app/Http/Controllers/OrganizationController.php
+++ b/app/Http/Controllers/OrganizationController.php
@@ -316,7 +316,11 @@ class OrganizationController extends Controller
             $organization->publish();
         }
 
-        return redirect(localized_route('organizations.show', $organization));
+        if ($organization->isPreviewable()) {
+            return redirect(localized_route('organizations.show', $organization));
+        } else {
+            return redirect(localized_route('dashboard'));
+        }
     }
 
     public function destroy(DestroyOrganizationRequest $request, Organization $organization): RedirectResponse

--- a/resources/views/organizations/partials/about.blade.php
+++ b/resources/views/organizations/partials/about.blade.php
@@ -41,7 +41,7 @@
     @endforeach
 </ul>
 
-@if ($organization->isConsultant())
+@if ($organization->isConsultant() && $organization->consulting_services)
     <h3>{{ __('Consulting services') }}</h3>
     <x-interpretation name="{{ __('Consulting services', [], 'en') }}" />
     <p>{{ __('As an Accessibility Consultant, we can help with:') }}</p>

--- a/tests/Datasets/AddOrganizationValidationErrors.php
+++ b/tests/Datasets/AddOrganizationValidationErrors.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\OrganizationRole;
 use App\Models\Organization;
 
 dataset('addOrganizationValidationErrors', function () {
@@ -15,7 +16,7 @@ dataset('addOrganizationValidationErrors', function () {
         'Organization is not a participant' => [
             'state' => fn () => ['organization_id' => Organization::factory()->create([
                 'name' => 'not a participant org',
-                'roles' => ['connector'],
+                'roles' => [OrganizationRole::CommunityConnector->value],
             ])->id],
             'errors' => fn () => ['organization_id' => __('The organization you have added does not participate in engagements.')],
         ],

--- a/tests/Datasets/EngagementIsPublishable.php
+++ b/tests/Datasets/EngagementIsPublishable.php
@@ -1,12 +1,18 @@
 <?php
 
+use App\Enums\AcceptedFormat;
+use App\Enums\EngagementFormat;
+use App\Enums\EngagementRecruitment;
+use App\Enums\MeetingType;
+use App\Enums\ProvinceOrTerritory;
+
 dataset('engagementIsPublishable', function () {
     $baseModel = [
         'name' => ['en' => 'Workshop'],
         'languages' => ['en', 'fr', 'asl', 'sql'],
         'who' => 'individuals',
-        'format' => 'workshop',
-        'recruitment' => 'open-call',
+        'format' => EngagementFormat::Workshop->value,
+        'recruitment' => EngagementRecruitment::OpenCall->value,
         'ideal_participants' => 25,
         'minimum_participants' => 15,
         'paid' => true,
@@ -15,7 +21,7 @@ dataset('engagementIsPublishable', function () {
     ];
 
     $interviewModel = array_merge($baseModel, [
-        'format' => 'interviews',
+        'format' => EngagementFormat::Interviews->value,
         'window_start_date' => '2022-11-01',
         'window_end_date' => '2022-11-15',
         'window_start_time' => '09:00',
@@ -30,28 +36,36 @@ dataset('engagementIsPublishable', function () {
             'saturday' => 'no',
             'sunday' => 'no',
         ],
-        'meeting_types' => ['in_person', 'web_conference', 'phone'],
+        'meeting_types' => [
+            MeetingType::InPerson->value,
+            MeetingType::WebConference->value,
+            MeetingType::Phone->value,
+        ],
         'street_address' => '1223 Main Street',
         'locality' => 'Anytown',
-        'region' => 'ON',
+        'region' => ProvinceOrTerritory::Ontario->value,
         'postal_code' => 'M46 17B',
         'meeting_software' => 'WebMeetingApp',
         'meeting_url' => 'https://example.com/meet',
         'meeting_phone' => '6476231847',
         'materials_by_date' => '2022-11-01',
         'complete_by_date' => '2022-11-15',
-        'accepted_formats' => ['writing', 'audio', 'video'],
+        'accepted_formats' => [
+            AcceptedFormat::Writing->value,
+            AcceptedFormat::Audio->value,
+            AcceptedFormat::Video->value,
+        ],
     ]);
 
     $surveyModel = array_merge($baseModel, [
-        'format' => 'survey',
+        'format' => EngagementFormat::Survey->value,
         'materials_by_date' => '2022-11-01',
         'complete_by_date' => '2022-11-15',
         'document_languages' => ['en', 'fr'],
     ]);
 
     $otherAsyncModel = array_merge($baseModel, [
-        'format' => 'other-async',
+        'format' => EngagementFormat::OtherAsync->value,
         'materials_by_date' => '2022-11-01',
         'complete_by_date' => '2022-11-15',
         'document_languages' => ['en', 'fr'],
@@ -100,13 +114,13 @@ dataset('engagementIsPublishable', function () {
         ],
         'not publishable when focus group and missing meeting' => [
             false,
-            array_replace_recursive($baseModel, ['format' => 'focus-group']),
+            array_replace_recursive($baseModel, ['format' => EngagementFormat::FocusGroup->value]),
             false,
             true,
         ],
         'not publishable when other synchronous and missing meeting' => [
             false,
-            array_replace_recursive($baseModel, ['format' => 'other-sync']),
+            array_replace_recursive($baseModel, ['format' => EngagementFormat::OtherSync->value]),
             false,
             true,
         ],

--- a/tests/Datasets/IndividualIsInProgress.php
+++ b/tests/Datasets/IndividualIsInProgress.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Enums\CommunityConnectorHasLivedExperience;
+use App\Enums\ConsultingService;
+use App\Enums\MeetingType;
+use App\Enums\ProvinceOrTerritory;
 use Illuminate\Support\Arr;
 
 dataset('individualIsInProgress', function () {
@@ -31,12 +34,12 @@ dataset('individualIsInProgress', function () {
     $filledData = [
         'pronouns' => ['she', 'her'],
         'bio' => 'This is my bio',
-        'region' => 'NS',
+        'region' => ProvinceOrTerritory::NovaScotia->value,
         'locality' => 'Halifax',
         'working_languages' => ['en'],
         'consulting_services' => [
-            'designing-consultation',
-            'running-consultation',
+            ConsultingService::DesigningConsultation->value,
+            ConsultingService::RunningConsultation->value,
         ],
         'social_links' => [
             'linked_in' => 'https://linkedin.com/in/someone',
@@ -56,7 +59,10 @@ dataset('individualIsInProgress', function () {
                 'current' => 1,
             ],
         ],
-        'meeting_types' => ['in_person', 'web_conference'],
+        'meeting_types' => [
+            MeetingType::InPerson->value,
+            MeetingType::WebConference->value,
+        ],
         'extra_attributes' => ['cross_disability_and_deaf_connections' => 1],
     ];
 

--- a/tests/Datasets/OrganizationIsInProgress.php
+++ b/tests/Datasets/OrganizationIsInProgress.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Enums\ConsultingService;
+use App\Enums\ProvinceOrTerritory;
+use App\Enums\StaffHaveLivedExperience;
 use Illuminate\Support\Arr;
 
 dataset('organizationIsInProgress', function () {
@@ -23,13 +26,13 @@ dataset('organizationIsInProgress', function () {
     ];
 
     $filledData = [
-        'region' => 'NS',
+        'region' => ProvinceOrTerritory::NovaScotia->value,
         'locality' => 'Halifax',
         'about' => 'About this org',
-        'service_areas' => ['NS'],
+        'service_areas' => [ProvinceOrTerritory::NovaScotia->value],
         'consulting_services' => [
-            'designing-consultation',
-            'running-consultation',
+            ConsultingService::DesigningConsultation->value,
+            ConsultingService::RunningConsultation->value,
         ],
         'social_links' => [
             'linked_in' => 'https://linkedin.com/in/someone',
@@ -37,7 +40,7 @@ dataset('organizationIsInProgress', function () {
         'website_link' => 'https://example.com',
         'other_disability_constituency' => 'Something not listed',
         'other_ethnoracial_identity_constituency' => 'Something else',
-        'staff_lived_experience' => 'prefer-not-to-answer',
+        'staff_lived_experience' => StaffHaveLivedExperience::PreferNotToAnswer->value,
         'extra_attributes' => ['disability_and_deaf_constituencies' => 1],
     ];
 

--- a/tests/Datasets/OrganizationIsPublishable.php
+++ b/tests/Datasets/OrganizationIsPublishable.php
@@ -3,6 +3,7 @@
 use App\Enums\ConsultingService;
 use App\Enums\OrganizationRole;
 use App\Enums\ProvinceOrTerritory;
+use App\Enums\StaffHaveLivedExperience;
 
 dataset('organizationIsPublishable', function () {
     $baseModel = [
@@ -12,10 +13,10 @@ dataset('organizationIsPublishable', function () {
         'contact_person_phone' => '4165555555',
         'locality' => 'Toronto',
         'preferred_contact_method' => 'email',
-        'region' => 'ON',
+        'region' => ProvinceOrTerritory::Ontario->value,
         'roles' => [OrganizationRole::AccessibilityConsultant],
         'service_areas' => [ProvinceOrTerritory::Ontario->value],
-        'staff_lived_experience' => 'yes',
+        'staff_lived_experience' => StaffHaveLivedExperience::Yes->value,
     ];
 
     return [

--- a/tests/Datasets/UpdateIndividualRequestValidationErrors.php
+++ b/tests/Datasets/UpdateIndividualRequestValidationErrors.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Enums\ConsultingService;
+
 dataset('updateIndividualRequestValidationErrors', function () {
     return array_map('array_values', [
         'Missing name' => [
@@ -63,7 +65,7 @@ dataset('updateIndividualRequestValidationErrors', function () {
             fn () => ['working_languages' => __('validation.array', ['attribute' => __('Working languages')])],
         ],
         'Consulting services not an array' => [
-            ['consulting_services' => 'analysis'],
+            ['consulting_services' => ConsultingService::Analysis->value],
             fn () => ['consulting_services' => __('validation.array', ['attribute' => __('Consulting services')])],
         ],
         'Consulting service invalid' => [

--- a/tests/Feature/IndividualTest.php
+++ b/tests/Feature/IndividualTest.php
@@ -1,10 +1,13 @@
 <?php
 
 use App\Enums\CommunityConnectorHasLivedExperience;
+use App\Enums\ConsultingService;
 use App\Enums\EngagementFormat;
 use App\Enums\IdentityCluster;
 use App\Enums\IndividualRole;
 use App\Enums\MeetingType;
+use App\Enums\TeamRole;
+use App\Enums\UserContext;
 use App\Http\Requests\UpdateIndividualCommunicationAndConsultationPreferencesRequest;
 use App\Http\Requests\UpdateIndividualConstituenciesRequest;
 use App\Http\Requests\UpdateIndividualRequest;
@@ -48,7 +51,10 @@ test('individual users can select an individual role', function () {
         ->followingRedirects()
         ->from(localized_route('individuals.show-role-selection'))
         ->put(localized_route('individuals.save-roles'), [
-            'roles' => ['participant', 'consultant'],
+            'roles' => [
+                IndividualRole::ConsultationParticipant->value,
+                IndividualRole::AccessibilityConsultant->value,
+            ],
         ])
         ->assertSee('Your roles have been saved.');
 
@@ -58,7 +64,7 @@ test('individual users can select an individual role', function () {
 
 test('non-individuals cannot select an individual role', function () {
     $nonCommunityUser = User::factory()->create([
-        'context' => 'regulated-organization',
+        'context' => UserContext::RegulatedOrganization->value,
     ]);
 
     actingAs($nonCommunityUser)->get(localized_route('individuals.show-role-selection'))->assertForbidden();
@@ -68,7 +74,10 @@ test('individuals can edit their roles', function () {
     $user = User::factory()->create();
 
     $individual = $user->individual;
-    $individual->roles = ['consultant', 'connector'];
+    $individual->roles = [
+        IndividualRole::AccessibilityConsultant->value,
+        IndividualRole::CommunityConnector->value,
+    ];
     $individual->save();
     $individual->publish();
 
@@ -82,7 +91,7 @@ test('individuals can edit their roles', function () {
         ->followingRedirects()
         ->from(localized_route('individuals.show-role-edit'))
         ->put(localized_route('individuals.save-roles'), [
-            'roles' => ['participant'],
+            'roles' => [IndividualRole::ConsultationParticipant->value],
         ])
         ->assertSee('Your roles have been saved.');
 
@@ -96,7 +105,7 @@ test('individuals can edit their roles', function () {
         ->followingRedirects()
         ->from(localized_route('individuals.show-role-edit'))
         ->put(localized_route('individuals.save-roles'), [
-            'roles' => ['consultant'],
+            'roles' => [IndividualRole::AccessibilityConsultant->value],
         ])
         ->assertSee('Your roles have been saved. Please review your page.');
 
@@ -106,7 +115,10 @@ test('individuals can edit their roles', function () {
         ->followingRedirects()
         ->from(localized_route('individuals.show-role-edit'))
         ->put(localized_route('individuals.save-roles'), [
-            'roles' => ['consultant', 'participant'],
+            'roles' => [
+                IndividualRole::AccessibilityConsultant->value,
+                IndividualRole::ConsultationParticipant->value,
+            ],
         ])
         ->assertDontSee('Your roles have been saved. Please review your page.')
         ->assertSee('Your roles have been saved.');
@@ -150,7 +162,7 @@ test('users can create individual pages', function () {
         'locale' => 'en',
         'name' => 'Test User',
         'email' => 'test@example.com',
-        'context' => 'individual',
+        'context' => UserContext::Individual->value,
     ])->post(localized_route('register-store'), [
         'password' => 'correctHorse-batteryStaple7',
         'password_confirmation' => 'correctHorse-batteryStaple7',
@@ -167,7 +179,7 @@ test('users can create individual pages', function () {
     $individual = $user->individual;
 
     $individual->fill([
-        'roles' => ['consultant'],
+        'roles' => [IndividualRole::AccessibilityConsultant->value],
         'connection_lived_experience' => CommunityConnectorHasLivedExperience::YesAll->value,
         'meeting_types' => [MeetingType::InPerson->value],
     ]);
@@ -185,8 +197,8 @@ test('users can create individual pages', function () {
         'pronouns' => [],
         'bio' => ['en' => 'This is my bio.'],
         'consulting_services' => [
-            'designing-consultation',
-            'running-consultation',
+            ConsultingService::DesigningConsultation->value,
+            ConsultingService::RunningConsultation->value,
         ],
         'social_links' => [
             'linked_in' => 'https://linkedin.com/in/someone',
@@ -209,8 +221,8 @@ test('users can create individual pages', function () {
         'region' => 'NS',
         'bio' => ['en' => 'This is my bio.'],
         'consulting_services' => [
-            'designing-consultation',
-            'running-consultation',
+            ConsultingService::DesigningConsultation->value,
+            ConsultingService::RunningConsultation->value,
         ],
         'publish' => __('Publish'),
     ])
@@ -223,8 +235,8 @@ test('users can create individual pages', function () {
         'region' => 'NS',
         'bio' => ['en' => 'This is my bio.'],
         'consulting_services' => [
-            'designing-consultation',
-            'running-consultation',
+            ConsultingService::DesigningConsultation->value,
+            ConsultingService::RunningConsultation->value,
         ],
         'save' => __('Save'),
     ])
@@ -235,8 +247,8 @@ test('users can create individual pages', function () {
         'region' => 'NS',
         'bio' => ['en' => 'This is my bio.'],
         'consulting_services' => [
-            'designing-consultation',
-            'running-consultation',
+            ConsultingService::DesigningConsultation->value,
+            ConsultingService::RunningConsultation->value,
         ],
         'unpublish' => __('Unpublish'),
     ])
@@ -249,8 +261,8 @@ test('users can create individual pages', function () {
         'region' => 'NS',
         'bio' => ['en' => 'This is my bio.'],
         'consulting_services' => [
-            'designing-consultation',
-            'running-consultation',
+            ConsultingService::DesigningConsultation->value,
+            ConsultingService::RunningConsultation->value,
         ],
         'preview' => __('Preview'),
     ])
@@ -266,8 +278,8 @@ test('users can create individual pages', function () {
             'pronouns' => '',
             'bio' => ['en' => 'This is my bio.'],
             'consulting_services' => [
-                'designing-consultation',
-                'running-consultation',
+                ConsultingService::DesigningConsultation->value,
+                ConsultingService::RunningConsultation->value,
             ],
             'save_and_next' => __('Save and next'),
         ])
@@ -339,7 +351,10 @@ test('users can create individual pages', function () {
         'vrs' => true,
         'preferred_contact_method' => 'email',
         'preferred_contact_person' => 'me',
-        'meeting_types' => ['in_person', 'web_conference'],
+        'meeting_types' => [
+            MeetingType::InPerson->value,
+            MeetingType::WebConference->value,
+        ],
         'save' => __('Save'),
     ]);
 
@@ -353,7 +368,10 @@ test('users can create individual pages', function () {
         'phone' => '902-444-4567',
         'preferred_contact_method' => 'email',
         'preferred_contact_person' => 'me',
-        'meeting_types' => ['in_person', 'web_conference'],
+        'meeting_types' => [
+            MeetingType::InPerson->value,
+            MeetingType::WebConference->value,
+        ],
         'save' => __('Save'),
     ]);
 
@@ -371,7 +389,10 @@ test('users can create individual pages', function () {
         'support_person_vrs' => true,
         'preferred_contact_method' => 'email',
         'preferred_contact_person' => 'support-person',
-        'meeting_types' => ['in_person', 'web_conference'],
+        'meeting_types' => [
+            MeetingType::InPerson->value,
+            MeetingType::WebConference->value,
+        ],
         'save' => __('Save'),
     ]);
 
@@ -391,7 +412,10 @@ test('users can create individual pages', function () {
         'support_person_phone' => '438-444-4567',
         'preferred_contact_method' => 'email',
         'preferred_contact_person' => 'support-person',
-        'meeting_types' => ['in_person', 'web_conference'],
+        'meeting_types' => [
+            MeetingType::InPerson->value,
+            MeetingType::WebConference->value,
+        ],
         'save' => __('Save'),
     ]);
 
@@ -408,8 +432,8 @@ test('update individual experiences request validation errors', function ($state
         ->for(User::factory())
         ->create([
             'roles' => [
-                IndividualRole::CommunityConnector,
-                IndividualRole::ConsultationParticipant,
+                IndividualRole::CommunityConnector->value,
+                IndividualRole::ConsultationParticipant->value,
             ],
         ]);
 
@@ -423,8 +447,8 @@ test('update individual interests request validation errors', function (array $s
         ->for(User::factory())
         ->create([
             'roles' => [
-                IndividualRole::CommunityConnector,
-                IndividualRole::ConsultationParticipant,
+                IndividualRole::CommunityConnector->value,
+                IndividualRole::ConsultationParticipant->value,
             ],
         ]);
 
@@ -438,8 +462,8 @@ test('update individual communication and consultation preferences request valid
         ->for(User::factory())
         ->create([
             'roles' => [
-                IndividualRole::CommunityConnector,
-                IndividualRole::ConsultationParticipant,
+                IndividualRole::CommunityConnector->value,
+                IndividualRole::ConsultationParticipant->value,
             ],
         ]);
 
@@ -458,7 +482,7 @@ test('entity users can not create individual pages', function () {
 test('individuals with connector role can represent individuals with disabilities', function () {
     $user = User::factory()->create();
     $individual = $user->individual;
-    $individual->roles = ['connector'];
+    $individual->roles = [IndividualRole::CommunityConnector->value];
     $individual->save();
 
     expect($individual->base_disability_type)->toEqual('');
@@ -505,7 +529,7 @@ test('individuals with connector role can represent individuals with disabilitie
 test('individuals with connector role can represent cross-disability individuals', function () {
     $user = User::factory()->create();
     $individual = $user->individual;
-    $individual->roles = ['connector'];
+    $individual->roles = [IndividualRole::CommunityConnector->value];
     $individual->save();
 
     $data = UpdateIndividualConstituenciesRequest::factory()->create([
@@ -537,7 +561,7 @@ test('individuals with connector role can represent cross-disability individuals
 test('individuals with connector role can represent individuals in specific age brackets', function () {
     $user = User::factory()->create();
     $individual = $user->individual;
-    $individual->roles = ['connector'];
+    $individual->roles = [IndividualRole::CommunityConnector->value];
     $individual->save();
 
     $ageBracket = Identity::whereJsonContains('clusters', IdentityCluster::Age)->first();
@@ -560,7 +584,7 @@ test('individuals with connector role can represent individuals in specific age 
 test('individuals with connector role can represent refugees and immigrants', function () {
     $user = User::factory()->create();
     $individual = $user->individual;
-    $individual->roles = ['connector'];
+    $individual->roles = [IndividualRole::CommunityConnector->value];
     $individual->save();
 
     $data = UpdateIndividualConstituenciesRequest::factory()->create([
@@ -579,7 +603,7 @@ test('individuals with connector role can represent refugees and immigrants', fu
 test('individuals with connector role can represent gender and sexual minorities', function () {
     $user = User::factory()->create();
     $individual = $user->individual;
-    $individual->roles = ['connector'];
+    $individual->roles = [IndividualRole::CommunityConnector->value];
     $individual->save();
 
     $genderAndSexualIdentities = array_merge(Identity::whereJsonContains('clusters', IdentityCluster::Gender)->whereNot(function ($query) {
@@ -609,7 +633,7 @@ test('individuals with connector role can represent gender and sexual minorities
 test('individuals with connector role can represent ethnoracial identities', function () {
     $user = User::factory()->create();
     $individual = $user->individual;
-    $individual->roles = ['connector'];
+    $individual->roles = [IndividualRole::CommunityConnector->value];
     $individual->save();
 
     $ethnoracialIdentity = Identity::whereJsonContains('clusters', IdentityCluster::Ethnoracial)->first();
@@ -634,8 +658,8 @@ test('update individual constituences request validation errors', function (arra
     $individual = Individual::factory()
         ->for(User::factory())
         ->create(['roles' => [
-            IndividualRole::CommunityConnector,
-            IndividualRole::ConsultationParticipant,
+            IndividualRole::CommunityConnector->value,
+            IndividualRole::ConsultationParticipant->value,
         ],
         ]);
 
@@ -650,7 +674,7 @@ test('individuals can have participant role', function () {
     $user = User::factory()->create();
     $individual = $user->individual;
 
-    $individual->roles = ['participant'];
+    $individual->roles = [IndividualRole::ConsultationParticipant->value];
     $individual->save();
 
     expect($individual->fresh()->isParticipant())->toBeTrue();
@@ -660,10 +684,20 @@ test('individuals can have consultant role', function () {
     $user = User::factory()->create();
     $individual = $user->individual;
 
-    $individual->roles = ['consultant'];
+    $individual->roles = [IndividualRole::AccessibilityConsultant->value];
     $individual->save();
 
     expect($individual->fresh()->isConsultant())->toBeTrue();
+});
+
+test('individuals can have connector role', function () {
+    $user = User::factory()->create();
+    $individual = $user->individual;
+
+    $individual->roles = [IndividualRole::CommunityConnector->value];
+    $individual->save();
+
+    expect($individual->fresh()->isConnector())->toBeTrue();
 });
 
 test('users can edit individual pages', function () {
@@ -672,12 +706,12 @@ test('users can edit individual pages', function () {
 
     expect($individual->isPublishable())->toBeFalse();
 
-    $individual->roles = ['participant'];
+    $individual->roles = [IndividualRole::ConsultationParticipant->value];
     $individual->save();
 
     actingAs($user)->get(localized_route('individuals.edit', $individual))->assertNotFound();
 
-    $individual->roles = ['consultant'];
+    $individual->roles = [IndividualRole::AccessibilityConsultant->value];
     $individual->save();
 
     actingAs($user)->get(localized_route('individuals.edit', $individual))->assertOk();
@@ -686,8 +720,8 @@ test('users can edit individual pages', function () {
         'name' => $individual->name,
         'bio' => ['en' => 'test bio'],
         'consulting_services' => [
-            'designing-consultation',
-            'running-consultation',
+            ConsultingService::DesigningConsultation->value,
+            ConsultingService::RunningConsultation->value,
         ],
         'locality' => 'St John’s',
         'region' => 'NL',
@@ -698,7 +732,7 @@ test('users can edit individual pages', function () {
     $draftUser = User::factory()->create();
     $draftIndividual = $draftUser->individual;
 
-    $draftIndividual->roles = ['consultant'];
+    $draftIndividual->roles = [IndividualRole::AccessibilityConsultant->value];
     $draftIndividual->save();
 
     actingAs($draftUser)->get(localized_route('individuals.edit', $draftIndividual))->assertOk();
@@ -707,8 +741,8 @@ test('users can edit individual pages', function () {
         'name' => $draftIndividual->name,
         'bio' => ['en' => 'draft bio'],
         'consulting_services' => [
-            'designing-consultation',
-            'running-consultation',
+            ConsultingService::DesigningConsultation->value,
+            ConsultingService::RunningConsultation->value,
         ],
         'locality' => 'St John’s',
         'region' => 'NL',
@@ -727,7 +761,7 @@ test('users can not edit others individual pages', function () {
     $otherUser = User::factory()->create();
 
     $individual = $user->individual;
-    $individual->roles = ['consultant'];
+    $individual->roles = [IndividualRole::AccessibilityConsultant->value];
     $individual->save();
 
     actingAs($otherUser)->get(localized_route('individuals.edit', $individual))->assertForbidden();
@@ -743,12 +777,12 @@ test('users can not edit others individual pages', function () {
 
 test('update individual request validation errors', function (array $state, array $errors, array $without = []) {
     $roles = [
-        IndividualRole::CommunityConnector,
-        IndividualRole::ConsultationParticipant,
+        IndividualRole::CommunityConnector->value,
+        IndividualRole::ConsultationParticipant->value,
     ];
 
     if (array_key_exists('consulting_services', $state)) {
-        $roles[] = IndividualRole::AccessibilityConsultant;
+        $roles[] = IndividualRole::AccessibilityConsultant->value;
     }
 
     $individual = Individual::factory()
@@ -767,8 +801,8 @@ test('updating social links without an array should ignore the change', function
         ->for(User::factory())
         ->create([
             'roles' => [
-                IndividualRole::CommunityConnector,
-                IndividualRole::ConsultationParticipant,
+                IndividualRole::CommunityConnector->value,
+                IndividualRole::ConsultationParticipant->value,
             ],
             'social_links' => [
                 'facebook' => 'https://facebook.com',
@@ -830,8 +864,8 @@ test('destroy individual request validation errors', function (array $state, arr
         ->for(User::factory())
         ->create([
             'roles' => [
-                IndividualRole::CommunityConnector,
-                IndividualRole::ConsultationParticipant,
+                IndividualRole::CommunityConnector->value,
+                IndividualRole::ConsultationParticipant->value,
             ],
         ]);
 
@@ -843,15 +877,15 @@ test('destroy individual request validation errors', function (array $state, arr
 test('users can view their own draft individual pages', function () {
     $individual = Individual::factory()->create([
         'published_at' => null,
-        'consulting_services' => ['analysis'],
-        'roles' => ['consultant'],
+        'consulting_services' => [ConsultingService::Analysis->value],
+        'roles' => [IndividualRole::AccessibilityConsultant->value],
         'extra_attributes' => [
             'has_age_brackets' => true,
             'has_ethnoracial_identities' => true,
             'has_gender_and_sexual_identities' => true,
             'has_indigenous_identities' => true,
         ],
-        'meeting_types' => ['in_person'],
+        'meeting_types' => [MeetingType::InPerson->value],
         'bio' => ['en' => 'ok'],
     ]);
 
@@ -861,7 +895,7 @@ test('users can view their own draft individual pages', function () {
 test('users can not view others draft individual pages', function () {
     $otherUser = User::factory()->create();
 
-    $individual = Individual::factory()->create(['published_at' => null, 'roles' => ['consultant']]);
+    $individual = Individual::factory()->create(['published_at' => null, 'roles' => [IndividualRole::AccessibilityConsultant->value]]);
 
     actingAs($otherUser)->get(localized_route('individuals.show', $individual))->assertNotFound();
 });
@@ -875,8 +909,8 @@ test('users can not view individual pages if they are not oriented', function ()
 });
 
 test('organization or regulated organization users can not view individual pages if they are not oriented', function () {
-    $organizationUser = User::factory()->create(['context' => 'organization', 'oriented_at' => null]);
-    $organization = Organization::factory()->hasAttached($organizationUser, ['role' => 'admin'])->create(['oriented_at' => null]);
+    $organizationUser = User::factory()->create(['context' => UserContext::Organization->value, 'oriented_at' => null]);
+    $organization = Organization::factory()->hasAttached($organizationUser, ['role' => TeamRole::Administrator->value])->create(['oriented_at' => null]);
     $organizationUser->refresh();
 
     actingAs($organizationUser)->get(localized_route('individuals.index'))
@@ -888,8 +922,8 @@ test('organization or regulated organization users can not view individual pages
     actingAs($organizationUser)->get(localized_route('individuals.index'))
         ->assertOk();
 
-    $regulatedOrganizationUser = User::factory()->create(['context' => 'regulated-organization', 'oriented_at' => null]);
-    $regulatedOrganization = RegulatedOrganization::factory()->hasAttached($regulatedOrganizationUser, ['role' => 'admin'])->create(['oriented_at' => null]);
+    $regulatedOrganizationUser = User::factory()->create(['context' => UserContext::RegulatedOrganization->value, 'oriented_at' => null]);
+    $regulatedOrganization = RegulatedOrganization::factory()->hasAttached($regulatedOrganizationUser, ['role' => TeamRole::Administrator->value])->create(['oriented_at' => null]);
     $regulatedOrganizationUser->refresh();
 
     actingAs($regulatedOrganizationUser)->get(localized_route('individuals.index'))
@@ -904,8 +938,8 @@ test('organization or regulated organization users can not view individual pages
 
 test('users can view individual pages', function () {
     $individual = Individual::factory()->create([
-        'consulting_services' => ['analysis'],
-        'roles' => ['consultant'],
+        'consulting_services' => [ConsultingService::Analysis->value],
+        'roles' => [IndividualRole::AccessibilityConsultant->value],
     ]);
 
     $individual->publish();
@@ -918,7 +952,7 @@ test('users can view individual pages', function () {
 
 test('users can not view individual pages if the individual is not a consultant or connector', function () {
     $individual = Individual::factory()->create([
-        'roles' => ['participant'],
+        'roles' => [IndividualRole::ConsultationParticipant->value],
     ]);
 
     $otherUser = User::factory()->create();
@@ -928,8 +962,8 @@ test('users can not view individual pages if the individual is not a consultant 
 
 test('users without a verified email can not view individual pages', function () {
     $individual = Individual::factory()->create([
-        'consulting_services' => ['analysis'],
-        'roles' => ['consultant'],
+        'consulting_services' => [ConsultingService::Analysis->value],
+        'roles' => [IndividualRole::AccessibilityConsultant->value],
     ]);
 
     $individual->publish();
@@ -943,7 +977,7 @@ test('users without a verified email can not view individual pages', function ()
 });
 
 test('guests can not view individual pages', function () {
-    $individual = Individual::factory()->create(['roles' => ['consultant']]);
+    $individual = Individual::factory()->create(['roles' => [IndividualRole::AccessibilityConsultant->value]]);
 
     get(localized_route('individuals.index'))
         ->assertRedirect(localized_route('login'));
@@ -953,7 +987,12 @@ test('guests can not view individual pages', function () {
 });
 
 test('individual pages can be published', function () {
-    $individual = Individual::factory()->create(['roles' => ['consultant']]);
+    $individual = Individual::factory()->create([
+        'roles' => [IndividualRole::AccessibilityConsultant->value],
+        'bio' => ['en' => 'Test bio'],
+        'consulting_services' => [ConsultingService::BookingServiceProviders->value],
+        'meeting_types' => [MeetingType::WebConference->value],
+    ]);
 
     actingAs($individual->user)->from(localized_route('individuals.show', $individual))->put(localized_route('individuals.update-publication-status', $individual), [
         'publish' => true,
@@ -967,7 +1006,12 @@ test('individual pages can be published', function () {
 });
 
 test('individual pages can be unpublished', function () {
-    $individual = Individual::factory()->create(['roles' => ['consultant']]);
+    $individual = Individual::factory()->create([
+        'roles' => [IndividualRole::AccessibilityConsultant->value],
+        'bio' => ['en' => 'Test bio'],
+        'consulting_services' => [ConsultingService::BookingServiceProviders->value],
+        'meeting_types' => [MeetingType::WebConference->value],
+    ]);
 
     actingAs($individual->user)->from(localized_route('individuals.show', $individual))->put(localized_route('individuals.update-publication-status', $individual), [
         'unpublish' => true,
@@ -980,10 +1024,32 @@ test('individual pages can be unpublished', function () {
     expect($individual->checkStatus('draft'))->toBeTrue();
 });
 
+test('individual pages redirect to dashboard when unpublished and not previewable', function () {
+    $individual = Individual::factory()->create([
+        'roles' => [
+            IndividualRole::AccessibilityConsultant->value,
+            IndividualRole::CommunityConnector->value,
+        ],
+        'bio' => ['en' => 'Test bio'],
+        'consulting_services' => [ConsultingService::BookingServiceProviders->value],
+        'meeting_types' => [MeetingType::WebConference->value],
+    ]);
+
+    actingAs($individual->user)->from(localized_route('individuals.show', $individual))->put(localized_route('individuals.update-publication-status', $individual), [
+        'unpublish' => true,
+    ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('dashboard'));
+
+    $individual = $individual->fresh();
+
+    expect($individual->checkStatus('draft'))->toBeTrue();
+});
+
 test('individual pages cannot be published by other users', function () {
     $user = User::factory()->create();
     $individual = Individual::factory()->create([
-        'roles' => ['consultant'],
+        'roles' => [IndividualRole::AccessibilityConsultant->value],
         'published_at' => null,
     ]);
 
@@ -1028,7 +1094,7 @@ test('draft individuals do not appear on individual index', function () {
     $user = User::factory()->create();
     $individual = Individual::factory()->create([
         'published_at' => null,
-        'roles' => ['consultant'],
+        'roles' => [IndividualRole::AccessibilityConsultant->value],
     ]);
 
     actingAs($user)->get(localized_route('individuals.index'))->assertDontSee($individual->name);
@@ -1037,14 +1103,14 @@ test('draft individuals do not appear on individual index', function () {
 test('published individuals appear on individual index', function () {
     $user = User::factory()->create();
     $individual = Individual::factory()->create([
-        'roles' => ['consultant'],
+        'roles' => [IndividualRole::AccessibilityConsultant->value],
     ]);
 
     actingAs($user)->get(localized_route('individuals.index'))->assertSee($individual->name);
 });
 
 test('individuals can participate in engagements', function () {
-    $participant = Individual::factory()->create(['roles' => ['participant']]);
+    $participant = Individual::factory()->create(['roles' => [IndividualRole::ConsultationParticipant->value]]);
     $engagement = Engagement::factory()->create();
     $engagement->participants()->attach($participant->id, ['status' => 'confirmed']);
 
@@ -1057,7 +1123,7 @@ test('individual view routes can be retrieved based on role', function () {
 
     expect($individual->steps()[2]['show'])->toEqual('individuals.show-experiences');
 
-    $individual->roles = ['connector'];
+    $individual->roles = [IndividualRole::CommunityConnector->value];
     $individual->save();
 
     $individual = $individual->fresh();
@@ -1066,7 +1132,11 @@ test('individual view routes can be retrieved based on role', function () {
 });
 
 test('individual relationships to projects can be derived from both projects and engagements', function () {
-    $individual = Individual::factory()->create(['roles' => ['participant', 'consultant', 'connector']]);
+    $individual = Individual::factory()->create(['roles' => [
+        IndividualRole::ConsultationParticipant->value,
+        IndividualRole::AccessibilityConsultant->value,
+        IndividualRole::CommunityConnector->value,
+    ]]);
 
     $individual = $individual->fresh();
 
@@ -1096,8 +1166,8 @@ test('individual relationships to projects can be derived from both projects and
 });
 
 test('individual consulting methods can be displayed', function () {
-    $individual = Individual::factory()->create(['consulting_methods' => ['survey']]);
-    expect($individual->display_consulting_methods)->toContain(EngagementFormat::labels()['survey']);
+    $individual = Individual::factory()->create(['consulting_methods' => [EngagementFormat::Survey->value]]);
+    expect($individual->display_consulting_methods)->toContain(EngagementFormat::labels()[EngagementFormat::Survey->value]);
 });
 
 test('identities can be attached to an individual', function () {
@@ -1119,7 +1189,7 @@ test('individuals with signed language can update about info', function () {
         ])
         ->create([
             'languages' => ['asl'],
-            'roles' => ['connector'],
+            'roles' => [IndividualRole::CommunityConnector->value],
         ]);
 
     $user = $individual->user;
@@ -1152,7 +1222,7 @@ test('individuals with signed language can update about experiences', function (
         ])
         ->create([
             'languages' => ['asl'],
-            'roles' => ['connector'],
+            'roles' => [IndividualRole::CommunityConnector->value],
         ]);
 
     $user = $individual->user;

--- a/tests/Feature/OrganizationTest.php
+++ b/tests/Feature/OrganizationTest.php
@@ -4,8 +4,11 @@ use App\Enums\BaseDisabilityType;
 use App\Enums\ConsultingService;
 use App\Enums\IdentityCluster;
 use App\Enums\OrganizationRole;
+use App\Enums\OrganizationType;
 use App\Enums\ProvinceOrTerritory;
 use App\Enums\StaffHaveLivedExperience;
+use App\Enums\TeamRole;
+use App\Enums\UserContext;
 use App\Http\Requests\StoreOrganizationRequest;
 use App\Http\Requests\UpdateOrganizationConstituenciesRequest;
 use App\Http\Requests\UpdateOrganizationContactInformationRequest;
@@ -38,22 +41,25 @@ use function Pest\Laravel\post;
 use function Pest\Laravel\seed;
 
 test('users can create organizations', function () {
-    $user = User::factory()->create(['context' => 'organization', 'locale' => 'asl']);
+    $user = User::factory()->create([
+        'context' => UserContext::Organization->value,
+        'locale' => 'asl',
+    ]);
 
     actingAs($user)->get(localized_route('organizations.show-type-selection'))->assertOk();
 
     actingAs($user)->post(localized_route('organizations.store-type'), [
-        'type' => 'representative',
+        'type' => OrganizationType::Representative->value,
     ])
         ->assertRedirect(localized_route('organizations.create'))
         ->assertSessionHasNoErrors()
-        ->assertSessionHas('type', 'representative');
+        ->assertSessionHas('type', OrganizationType::Representative->value);
 
     actingAs($user)->get(localized_route('organizations.create'))->assertOk();
 
     $response = actingAs($user)->post(localized_route('organizations.create'), [
         'name' => ['en' => $user->name.' Foundation'],
-        'type' => 'representative',
+        'type' => OrganizationType::Representative->value,
     ])
         ->assertSessionHasNoErrors();
 
@@ -65,21 +71,21 @@ test('users can create organizations', function () {
 
     actingAs($user)->get(localized_route('organizations.show-role-selection', $organization))->assertOk();
     actingAs($user)->from(localized_route('organizations.show-role-selection', $organization))->put(localized_route('organizations.save-roles', $organization), [
-        'roles' => ['consultant'],
+        'roles' => [OrganizationRole::AccessibilityConsultant->value],
     ])
         ->assertSessionHasNoErrors()
         ->assertRedirect(localized_route('dashboard'));
     expect($organization->fresh()->isConsultant())->toBeTrue();
 
     actingAs($user)->from(localized_route('organizations.show-role-selection', $organization))->put(localized_route('organizations.save-roles', $organization), [
-        'roles' => ['connector'],
+        'roles' => [OrganizationRole::CommunityConnector->value],
     ])
         ->assertSessionHasNoErrors()
         ->assertRedirect(localized_route('dashboard'));
     expect($organization->fresh()->isConnector())->toBeTrue();
 
     actingAs($user)->from(localized_route('organizations.show-role-selection', $organization))->put(localized_route('organizations.save-roles', $organization), [
-        'roles' => ['participant'],
+        'roles' => [OrganizationRole::ConsultationParticipant->value],
     ])
         ->assertSessionHasNoErrors()
         ->assertRedirect(localized_route('dashboard'));
@@ -90,7 +96,7 @@ test('users can create organizations', function () {
         ->assertSee('<input  type="checkbox" name="roles[]" id="roles-participant" value="participant" aria-describedby="roles-participant-hint" checked  />', false);
 
     actingAs($user)->from(localized_route('organizations.show-role-edit', $organization))->put(localized_route('organizations.save-roles', $organization), [
-        'roles' => ['consultant'],
+        'roles' => [OrganizationRole::AccessibilityConsultant->value],
     ])
         ->assertSessionHasNoErrors()
         ->assertRedirect(localized_route('dashboard'));
@@ -109,7 +115,7 @@ test('users can create organizations', function () {
 });
 
 test('store organization type request validation errors', function (array $state, array $errors) {
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
 
     actingAs($user)
         ->post(localized_route('organizations.store-type'), $state)
@@ -117,7 +123,7 @@ test('store organization type request validation errors', function (array $state
 })->with('storeOrganizationTypeRequestValidationErrors');
 
 test('store organization request validation errors', function (array $state, array $errors, array $without = []) {
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
 
     $data = StoreOrganizationRequest::factory()->without($without ?? [])->create($state);
 
@@ -127,9 +133,9 @@ test('store organization request validation errors', function (array $state, arr
 })->with('storeOrganizationRequestValidationErrors');
 
 test('save organization roles request validation errors', function (array $state, array $errors) {
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     actingAs($user)
@@ -138,9 +144,9 @@ test('save organization roles request validation errors', function (array $state
 })->with('saveOrganizationRolesRequestValidationErrors');
 
 test('store organization languages request validation errors', function (array $state, array $errors) {
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     actingAs($user)
@@ -151,15 +157,15 @@ test('store organization languages request validation errors', function (array $
 test('users with admin role can edit and publish organizations', function () {
     seed(IdentitySeeder::class);
 
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create([
             'contact_person_name' => fake()->name,
-            'staff_lived_experience' => 'yes',
+            'staff_lived_experience' => StaffHaveLivedExperience::Yes->value,
             'preferred_contact_method' => 'email',
             'about' => 'test about',
-            'region' => 'ON',
+            'region' => ProvinceOrTerritory::Ontario->value,
             'locality' => null,
             'service_areas' => [ProvinceOrTerritory::Ontario->value],
             'roles' => [OrganizationRole::ConsultationParticipant->value],
@@ -223,9 +229,9 @@ test('users with admin role can edit and publish organizations', function () {
 });
 
 test('update organization request validation errors', function (array $state, array $errors, array $without = []) {
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create(['roles' => [OrganizationRole::AccessibilityConsultant->value]]);
 
     $data = UpdateOrganizationRequest::factory()->without($without ?? [])->create($state);
@@ -238,9 +244,9 @@ test('update organization request validation errors', function (array $state, ar
 test('users with admin role can edit organization constituencies', function () {
     seed(IdentitySeeder::class);
 
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     expect($organization->hasConstituencies('areaTypeConstituencies'))->toBeNull();
@@ -283,7 +289,7 @@ test('users with admin role can edit organization constituencies', function () {
     $organization->refresh();
 
     expect($organization->disabilityAndDeafConstituencies)->toHaveCount(0);
-    expect($organization->base_disability_type)->toEqual('specific_disabilities');
+    expect($organization->base_disability_type)->toEqual(BaseDisabilityType::SpecificDisabilities->value);
     expect($organization->other_disability_constituency)->toEqual('Something else');
     expect($organization->areaTypeConstituencies)->toHaveCount(1);
     expect($organization->hasConstituencies('areaTypeConstituencies'))->toBeTrue();
@@ -294,7 +300,7 @@ test('users with admin role can edit organization constituencies', function () {
     expect($organization->statusConstituencies)->toHaveCount(2);
     expect($organization->ethnoracialIdentityConstituencies)->toHaveCount(1);
     expect($organization->languageConstituencies)->toHaveCount(2);
-    expect($organization->staff_lived_experience)->toEqual('prefer-not-to-answer');
+    expect($organization->staff_lived_experience)->toEqual(StaffHaveLivedExperience::PreferNotToAnswer->value);
 
     actingAs($user)->put(localized_route('organizations.update-constituencies', $organization), [
         'base_disability_type' => BaseDisabilityType::SpecificDisabilities->value,
@@ -310,14 +316,14 @@ test('users with admin role can edit organization constituencies', function () {
     $organization->refresh();
 
     expect($organization->disabilityAndDeafConstituencies)->toHaveCount(1);
-    expect($organization->base_disability_type)->toEqual('specific_disabilities');
+    expect($organization->base_disability_type)->toEqual(BaseDisabilityType::SpecificDisabilities->value);
     expect($organization->areaTypeConstituencies)->toHaveCount(1);
     expect($organization->indigenousConstituencies)->toHaveCount(0);
     expect($organization->genderIdentityConstituencies)->toHaveCount(0);
     expect($organization->ageBracketConstituencies)->toHaveCount(0);
     expect($organization->ethnoracialIdentityConstituencies)->toHaveCount(0);
     expect($organization->languageConstituencies)->toHaveCount(2);
-    expect($organization->staff_lived_experience)->toEqual('prefer-not-to-answer');
+    expect($organization->staff_lived_experience)->toEqual(StaffHaveLivedExperience::PreferNotToAnswer->value);
 
     actingAs($user)->put(localized_route('organizations.update-constituencies', $organization->fresh()), [
         'area_type_constituencies' => [$areaType->id],
@@ -330,7 +336,7 @@ test('users with admin role can edit organization constituencies', function () {
 
     $organization->refresh();
 
-    expect($organization->base_disability_type)->toEqual('cross_disability_and_deaf');
+    expect($organization->base_disability_type)->toEqual(BaseDisabilityType::CrossDisability->value);
 
     actingAs($user)->put(localized_route('organizations.update-constituencies', $organization->fresh()), [
         'lived_experience_constituencies' => [$livedExperience->id],
@@ -367,9 +373,9 @@ test('users with admin role can edit organization constituencies', function () {
 test('update organization constituencies request validation errors', function (array $orgState, array $state, array $errors, array $without = []) {
     seed(IdentitySeeder::class);
 
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create($orgState);
 
     $data = UpdateOrganizationConstituenciesRequest::factory()->without($without ?? [])->create($state);
@@ -383,9 +389,9 @@ test('users with admin role can edit organization interests', function () {
     seed(ImpactSeeder::class);
     seed(SectorSeeder::class);
 
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     actingAs($user)->get(localized_route('organizations.edit', ['organization' => $organization, 'step' => 3]))->assertOk();
@@ -427,9 +433,9 @@ test('users with admin role can edit organization interests', function () {
 });
 
 test('update organization interests request validation errors', function (array $state, array $errors) {
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     actingAs($user)
@@ -438,9 +444,9 @@ test('update organization interests request validation errors', function (array 
 })->with('updateOrganizationInterestsRequestValidationErrors');
 
 test('users with admin role can edit organization contact information', function () {
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     actingAs($user)->get(localized_route('organizations.edit', ['organization' => $organization, 'step' => 4]))->assertOk();
@@ -494,9 +500,9 @@ test('users with admin role can edit organization contact information', function
 test('update organization contact information request validation errors', function (array $state, array $errors, array $without = []) {
     seed(IdentitySeeder::class);
 
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     $data = UpdateOrganizationContactInformationRequest::factory()->without($without ?? [])->create($state);
@@ -507,9 +513,9 @@ test('update organization contact information request validation errors', functi
 })->with('updateOrganizationContactInformationRequestValidationErrors');
 
 test('users without admin role cannot edit or publish organizations', function () {
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'member'])
+        ->hasAttached($user, ['role' => TeamRole::Member->value])
         ->create();
 
     actingAs($user)->get(localized_route('organizations.edit', $organization))->assertForbidden();
@@ -538,11 +544,11 @@ test('users without admin role cannot edit or publish organizations', function (
 });
 
 test('non members cannot edit or publish organizations', function () {
-    $user = User::factory()->create(['context' => 'organization']);
-    $adminUser = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
+    $adminUser = User::factory()->create(['context' => UserContext::Organization->value]);
 
     $organization = Organization::factory()
-        ->hasAttached($adminUser, ['role' => 'admin'])
+        ->hasAttached($adminUser, ['role' => TeamRole::Administrator->value])
         ->create();
 
     actingAs($user)->get(localized_route('organizations.edit', $organization))->assertForbidden();
@@ -571,9 +577,10 @@ test('non members cannot edit or publish organizations', function () {
 });
 
 test('organization pages can be published', function () {
-    $user = User::factory()->create(['context' => 'organization']);
+    seed(IdentitySeeder::class);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create([
             'about' => 'test organization about',
             'consulting_services' => [ConsultingService::Analysis->value],
@@ -588,11 +595,14 @@ test('organization pages can be published', function () {
             ],
             'locality' => 'Toronto',
             'preferred_contact_method' => 'email',
-            'region' => 'ON',
+            'region' => ProvinceOrTerritory::Ontario->value,
             'roles' => [OrganizationRole::AccessibilityConsultant],
             'service_areas' => [ProvinceOrTerritory::Ontario->value],
-            'staff_lived_experience' => 'yes',
+            'staff_lived_experience' => StaffHaveLivedExperience::Yes->value,
         ]);
+
+    $areaType = Identity::whereJsonContains('clusters', IdentityCluster::Area)->first();
+    $organization->constituentIdentities()->sync([$areaType->id]);
 
     actingAs($user)->from(localized_route('organizations.show', $organization))->put(localized_route('organizations.update-publication-status', $organization), [
         'publish' => true,
@@ -606,9 +616,49 @@ test('organization pages can be published', function () {
 });
 
 test('organization pages can be unpublished', function () {
-    $user = User::factory()->create(['context' => 'organization']);
+    seed(IdentitySeeder::class);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
+        ->create([
+            'about' => ['en' => 'test organization about'],
+            'consulting_services' => [ConsultingService::Analysis->value],
+            'contact_person_name' => 'contact name',
+            'contact_person_phone' => '4165555555',
+            'extra_attributes' => [
+                'has_age_brackets' => 0,
+                'has_ethnoracial_identities' => 0,
+                'has_gender_and_sexual_identities' => 0,
+                'has_refugee_and_immigrant_constituency' => 0,
+                'has_indigenous_identities' => 0,
+            ],
+            'locality' => 'Toronto',
+            'preferred_contact_method' => 'email',
+            'region' => ProvinceOrTerritory::Ontario->value,
+            'roles' => [OrganizationRole::AccessibilityConsultant->value],
+            'service_areas' => [ProvinceOrTerritory::Ontario->value],
+            'staff_lived_experience' => StaffHaveLivedExperience::Yes->value,
+            'published_at' => date('Y-m-d h:i:s', time()),
+        ]);
+
+    $areaType = Identity::whereJsonContains('clusters', IdentityCluster::Area)->first();
+    $organization->constituentIdentities()->sync([$areaType->id]);
+
+    actingAs($user)->from(localized_route('organizations.show', $organization))->put(localized_route('organizations.update-publication-status', $organization), [
+        'unpublish' => true,
+    ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(localized_route('organizations.show', $organization));
+
+    $organization->refresh();
+
+    expect($organization->checkStatus('draft'))->toBeTrue();
+});
+
+test('organization pages redirect to dashboard when unpublished and not previewable', function () {
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
+    $organization = Organization::factory()
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create([
             'about' => 'test organization about',
             'consulting_services' => [ConsultingService::Analysis->value],
@@ -623,10 +673,10 @@ test('organization pages can be unpublished', function () {
             ],
             'locality' => 'Toronto',
             'preferred_contact_method' => 'email',
-            'region' => 'ON',
+            'region' => ProvinceOrTerritory::Ontario->value,
             'roles' => [OrganizationRole::AccessibilityConsultant],
             'service_areas' => [ProvinceOrTerritory::Ontario->value],
-            'staff_lived_experience' => 'yes',
+            'staff_lived_experience' => StaffHaveLivedExperience::Yes->value,
             'published_at' => date('Y-m-d h:i:s', time()),
         ]);
 
@@ -634,7 +684,7 @@ test('organization pages can be unpublished', function () {
         'unpublish' => true,
     ])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(localized_route('organizations.show', $organization));
+        ->assertRedirect(localized_route('dashboard'));
 
     $organization->refresh();
 
@@ -658,10 +708,10 @@ test('organization pages cannot be published by other users', function () {
             ],
             'locality' => 'Toronto',
             'preferred_contact_method' => 'email',
-            'region' => 'ON',
+            'region' => ProvinceOrTerritory::Ontario->value,
             'roles' => [OrganizationRole::AccessibilityConsultant],
             'service_areas' => [ProvinceOrTerritory::Ontario->value],
-            'staff_lived_experience' => 'yes',
+            'staff_lived_experience' => StaffHaveLivedExperience::Yes->value,
         ]);
 
     actingAs($user)->put(localized_route('organizations.update-publication-status', $organization), [
@@ -730,8 +780,8 @@ test('users with admin role can update other member roles', function () {
     $other_user = User::factory()->create();
 
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
-        ->hasAttached($other_user, ['role' => 'member'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
+        ->hasAttached($other_user, ['role' => TeamRole::Member->value])
         ->create();
 
     $membership = Membership::where('user_id', $other_user->id)
@@ -742,7 +792,7 @@ test('users with admin role can update other member roles', function () {
     actingAs($user)
         ->from(localized_route('memberships.edit', $membership))
         ->put(localized_route('memberships.update', $membership), [
-            'role' => 'admin',
+            'role' => TeamRole::Administrator->value,
         ])
         ->assertRedirect(localized_route('settings.edit-roles-and-permissions'));
 });
@@ -751,7 +801,7 @@ test('users without admin role cannot update member roles', function () {
     $user = User::factory()->create();
 
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'member'])
+        ->hasAttached($user, ['role' => TeamRole::Member->value])
         ->create();
 
     $membership = Membership::where('user_id', $user->id)
@@ -762,20 +812,20 @@ test('users without admin role cannot update member roles', function () {
     actingAs($user)
         ->from(localized_route('memberships.edit', $membership))
         ->put(localized_route('memberships.update', $membership), [
-            'role' => 'admin',
+            'role' => TeamRole::Administrator->value,
         ])
         ->assertForbidden();
 });
 
 test('only administrator cannot downgrade their role', function () {
-    $user = User::factory()->create(['context' => 'organization']);
-    $other_user = User::factory()->create(['context' => 'organization']);
-    $yet_another_user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
+    $other_user = User::factory()->create(['context' => UserContext::Organization->value]);
+    $yet_another_user = User::factory()->create(['context' => UserContext::Organization->value]);
 
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
-        ->hasAttached($other_user, ['role' => 'admin'])
-        ->hasAttached($yet_another_user, ['role' => 'member'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
+        ->hasAttached($other_user, ['role' => TeamRole::Administrator->value])
+        ->hasAttached($yet_another_user, ['role' => TeamRole::Member->value])
         ->create();
 
     $membership = Membership::where('user_id', $user->id)
@@ -786,7 +836,7 @@ test('only administrator cannot downgrade their role', function () {
     actingAs($user)
         ->from(localized_route('memberships.edit', $membership))
         ->put(localized_route('memberships.update', $membership), [
-            'role' => 'member',
+            'role' => TeamRole::Member->value,
         ])
         ->assertSessionHasNoErrors()
         ->assertRedirect(localized_route('organizations.show', $organization));
@@ -799,7 +849,7 @@ test('only administrator cannot downgrade their role', function () {
     actingAs($other_user)
         ->from(localized_route('memberships.edit', $membership))
         ->put(localized_route('memberships.update', $membership), [
-            'role' => 'member',
+            'role' => TeamRole::Member->value,
         ])
         ->assertSessionHasErrors(['role'])
         ->assertRedirect(localized_route('memberships.edit', $membership));
@@ -809,7 +859,7 @@ test('users with admin role can invite members', function () {
     $user = User::factory()->create();
 
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     actingAs($user)
@@ -818,7 +868,7 @@ test('users with admin role can invite members', function () {
             'invitationable_id' => $organization->id,
             'invitationable_type' => get_class($organization),
             'email' => 'newuser@here.com',
-            'role' => 'member',
+            'role' => TeamRole::Member->value,
         ])
         ->assertRedirect(localized_route('settings.edit-roles-and-permissions'));
 });
@@ -827,7 +877,7 @@ test('users without admin role cannot invite members', function () {
     $user = User::factory()->create();
 
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'member'])
+        ->hasAttached($user, ['role' => TeamRole::Member->value])
         ->create();
 
     actingAs($user)
@@ -836,7 +886,7 @@ test('users without admin role cannot invite members', function () {
             'invitationable_id' => $organization->id,
             'invitationable_type' => get_class($organization),
             'email' => 'newuser@here.com',
-            'role' => 'member',
+            'role' => TeamRole::Member->value,
         ])
         ->assertForbidden();
 });
@@ -844,7 +894,7 @@ test('users without admin role cannot invite members', function () {
 test('users with admin role can cancel invitations', function () {
     $user = User::factory()->create();
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
     $invitation = Invitation::factory()->create([
         'invitationable_id' => $organization->id,
@@ -862,7 +912,7 @@ test('users with admin role can cancel invitations', function () {
 test('users without admin role cannot cancel invitations', function () {
     $user = User::factory()->create();
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'member'])
+        ->hasAttached($user, ['role' => TeamRole::Member->value])
         ->create();
     $invitation = Invitation::factory()->create([
         'invitationable_id' => $organization->id,
@@ -881,8 +931,8 @@ test('existing members cannot be invited', function () {
     $other_user = User::factory()->create();
 
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
-        ->hasAttached($other_user, ['role' => 'member'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
+        ->hasAttached($other_user, ['role' => TeamRole::Member->value])
         ->create();
 
     actingAs($user)
@@ -891,7 +941,7 @@ test('existing members cannot be invited', function () {
             'invitationable_id' => $organization->id,
             'invitationable_type' => get_class($organization),
             'email' => $other_user->email,
-            'role' => 'member',
+            'role' => TeamRole::Member->value,
         ])
         ->assertSessionHasErrors(['email'])
         ->assertRedirect(localized_route('organizations.edit', $organization));
@@ -916,7 +966,7 @@ test('invitation can be accepted', function () {
 test('invitation cannot be accepted by user with existing membership', function () {
     $user = User::factory()->create();
     Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
     $other_organization = Organization::factory()->create();
     $invitation = Invitation::factory()->create([
@@ -938,7 +988,7 @@ test('invitation cannot be accepted by different user', function () {
     $user = User::factory()->create();
     $other_user = User::factory()->create();
     $organization = Organization::factory()
-        ->hasAttached($other_user, ['role' => 'admin'])
+        ->hasAttached($other_user, ['role' => TeamRole::Administrator->value])
         ->create();
     $invitation = Invitation::factory()->create([
         'invitationable_id' => $organization->id,
@@ -958,8 +1008,8 @@ test('users with admin role can remove members', function () {
     $other_user = User::factory()->create();
 
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
-        ->hasAttached($other_user, ['role' => 'member'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
+        ->hasAttached($other_user, ['role' => TeamRole::Member->value])
         ->create();
 
     $membership = Membership::where('user_id', $other_user->id)
@@ -979,8 +1029,8 @@ test('users without admin role cannot remove members', function () {
     $other_user = User::factory()->create();
 
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'member'])
-        ->hasAttached($other_user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Member->value])
+        ->hasAttached($other_user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     $membership = Membership::where('user_id', $other_user->id)
@@ -998,7 +1048,7 @@ test('only administrator cannot remove themself', function () {
     $user = User::factory()->create();
 
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     $membership = Membership::where('user_id', $user->id)
@@ -1016,7 +1066,7 @@ test('only administrator cannot remove themself', function () {
 test('users with admin role can delete organizations', function () {
     $user = User::factory()->create();
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     post(localized_route('login'), [
@@ -1032,7 +1082,7 @@ test('users with admin role can delete organizations', function () {
 test('users with admin role cannot delete organizations with wrong password', function () {
     $user = User::factory()->create();
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     post(localized_route('login'), [
@@ -1050,7 +1100,7 @@ test('users with admin role cannot delete organizations with wrong password', fu
 test('users without admin role cannot delete organizations', function () {
     $user = User::factory()->create();
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'member'])
+        ->hasAttached($user, ['role' => TeamRole::Member->value])
         ->create();
 
     post(localized_route('login'), [
@@ -1068,11 +1118,11 @@ test('non members cannot delete organizations', function () {
     $other_user = User::factory()->create();
 
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     $other_organization = Organization::factory()
-        ->hasAttached($other_user, ['role' => 'admin'])
+        ->hasAttached($other_user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     post(localized_route('login'), [
@@ -1086,9 +1136,9 @@ test('non members cannot delete organizations', function () {
 });
 
 test('destroy organization request validation errors', function (array $state, array $errors) {
-    $user = User::factory()->create(['context' => 'organization']);
+    $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create();
 
     actingAs($user)
@@ -1105,8 +1155,13 @@ test('users can not view organizations if they are not oriented', function () {
 });
 
 test('organization or regulated organization users can not view organizations if they are not oriented', function () {
-    $organizationUser = User::factory()->create(['context' => 'organization', 'oriented_at' => null]);
-    $organization = Organization::factory()->hasAttached($organizationUser, ['role' => 'admin'])->create(['oriented_at' => null]);
+    $organizationUser = User::factory()->create([
+        'context' => UserContext::Organization->value,
+        'oriented_at' => null,
+    ]);
+    $organization = Organization::factory()
+        ->hasAttached($organizationUser, ['role' => TeamRole::Administrator->value])
+        ->create(['oriented_at' => null]);
     $organizationUser->refresh();
 
     actingAs($organizationUser)->get(localized_route('organizations.index'))
@@ -1118,8 +1173,13 @@ test('organization or regulated organization users can not view organizations if
     actingAs($organizationUser)->get(localized_route('organizations.index'))
         ->assertOk();
 
-    $regulatedOrganizationUser = User::factory()->create(['context' => 'regulated-organization', 'oriented_at' => null]);
-    $regulatedOrganization = RegulatedOrganization::factory()->hasAttached($regulatedOrganizationUser, ['role' => 'admin'])->create(['oriented_at' => null]);
+    $regulatedOrganizationUser = User::factory()->create([
+        'context' => UserContext::RegulatedOrganization->value,
+        'oriented_at' => null,
+    ]);
+    $regulatedOrganization = RegulatedOrganization::factory()
+        ->hasAttached($regulatedOrganizationUser, ['role' => TeamRole::Administrator->value])
+        ->create(['oriented_at' => null]);
     $regulatedOrganizationUser->refresh();
 
     actingAs($regulatedOrganizationUser)->get(localized_route('organizations.index'))
@@ -1152,7 +1212,13 @@ test('guests cannot view organizations', function () {
 });
 
 test('organizational relationships to projects can be derived from both projects and engagements', function () {
-    $organization = Organization::factory()->create(['roles' => ['consultant', 'connector', 'participant']]);
+    $organization = Organization::factory()->create([
+        'roles' => [
+            OrganizationRole::AccessibilityConsultant->value,
+            OrganizationRole::CommunityConnector->value,
+            OrganizationRole::ConsultationParticipant->value,
+        ],
+    ]);
 
     $organization->refresh();
 
@@ -1187,7 +1253,11 @@ test('organizational relationships to projects can be derived from both projects
 
 test('organizations projects functions based on project state', function () {
     $organization = Organization::factory()->create([
-        'roles' => ['consultant', 'connector', 'participant'],
+        'roles' => [
+            OrganizationRole::AccessibilityConsultant->value,
+            OrganizationRole::CommunityConnector->value,
+            OrganizationRole::ConsultationParticipant->value,
+        ],
         'published_at' => now(),
     ]);
 
@@ -1306,9 +1376,12 @@ test('organization status checks return expected state', function () {
 });
 
 test('organization’s preferred locale is set based on contact person’s locale', function () {
-    $user = User::factory()->create(['context' => 'regulated-organization', 'locale' => 'en']);
+    $user = User::factory()->create([
+        'context' => UserContext::Organization->value,
+        'locale' => 'en',
+    ]);
     $organization = Organization::factory()
-        ->hasAttached($user, ['role' => 'admin'])
+        ->hasAttached($user, ['role' => TeamRole::Administrator->value])
         ->create(['contact_person_email' => $user->email]);
 
     expect($organization->preferredLocale())->toBe('en');

--- a/tests/Feature/SuspensionTest.php
+++ b/tests/Feature/SuspensionTest.php
@@ -4,6 +4,7 @@ use App\Enums\ConsultingService;
 use App\Enums\IdentityCluster;
 use App\Enums\OrganizationRole;
 use App\Enums\ProvinceOrTerritory;
+use App\Enums\StaffHaveLivedExperience;
 use App\Models\Engagement;
 use App\Models\Identity;
 use App\Models\Impact;
@@ -64,7 +65,7 @@ beforeEach(function () {
         'region' => 'ON',
         'roles' => [OrganizationRole::AccessibilityConsultant],
         'service_areas' => [ProvinceOrTerritory::Ontario->value],
-        'staff_lived_experience' => 'yes',
+        'staff_lived_experience' => StaffHaveLivedExperience::Yes->value,
         'published_at' => now(),
     ]);
     $this->organization->users()->attach(

--- a/tests/RequestFactories/UpdateOrganizationConstituenciesRequestFactory.php
+++ b/tests/RequestFactories/UpdateOrganizationConstituenciesRequestFactory.php
@@ -4,6 +4,7 @@ namespace Tests\RequestFactories;
 
 use App\Enums\BaseDisabilityType;
 use App\Enums\IdentityCluster;
+use App\Enums\StaffHaveLivedExperience;
 use App\Models\Identity;
 use Worksome\RequestFactories\RequestFactory;
 
@@ -22,7 +23,7 @@ class UpdateOrganizationConstituenciesRequestFactory extends RequestFactory
             'has_ethnoracial_identity_constituencies' => false,
             'has_other_ethnoracial_identity_constituency' => false,
             'area_type_constituencies' => Identity::query()->whereJsonContains('clusters', IdentityCluster::Area)->get()->modelKeys(),
-            'staff_lived_experience' => 'prefer-not-to-answer',
+            'staff_lived_experience' => StaffHaveLivedExperience::PreferNotToAnswer->value,
         ];
     }
 }


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #2366 

- If a public page is not previewable, unpublishing it will return the user to the dashboard
- Added tests
- Cleaned up some tests to replace hardcoded strings with values from related enums

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
