### PR TITLE
fix: payment information missing from manage participants (resolves #2577)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1130,6 +1130,7 @@
     "Payment": "Payment",
     "Payment information": "Payment information",
     "Payment type": "Payment type",
+    "Payment Types": "Payment Types",
     "Payment types": "Payment types",
     "PDF": "PDF",
     "Pending": "Pending",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -1130,6 +1130,7 @@
     "Payment": "Paiement",
     "Payment information": "Informations de paiement",
     "Payment type": "Type de paiement",
+    "Payment Types": "Types de paiement",
     "Payment types": "Types de paiement",
     "PDF": "PDF",
     "Pending": "En attente",

--- a/resources/views/engagements/manage-participants.blade.php
+++ b/resources/views/engagements/manage-participants.blade.php
@@ -91,6 +91,7 @@
                             <th>{{ __('Name') }}</th>
                             <th>{{ __('Email') }}</th>
                             <th>{{ __('Phone') }}</th>
+                            <th>{{ __('Payment Types') }}</th>
                             <th>{{ __('Notes') }}</th>
                         </tr>
                     </thead>
@@ -131,6 +132,16 @@
                                         {{ __('Preferred contact method') }}
                                     </p>
                                 @endif
+                            </td>
+                            <td>
+                                <ul>
+                                    @foreach ($participant->paymentTypes as $paymentType)
+                                        <li>{{ $paymentType->name }}</li>
+                                    @endforeach
+                                    @if ($participant->other_payment_type)
+                                        <li>{{ $participant->other_payment_type }}</li>
+                                    @endif
+                                </ul>
                             </td>
                             <td>
                                 @if ($participant->accessSupports->contains($printVersion))

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -886,7 +886,7 @@ test('participant payment types show in manage participants', function () {
         $paymentType->name,
         $otherPaymentType,
     ]);
-})->only();
+});
 
 test('other access needs show in manage participants', function () {
     $engagement = Engagement::factory()->create(['recruitment' => 'open-call']);

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -770,7 +770,7 @@ test('admins can see engagement if it isPreviewable()', function () {
 
     expect($engagement->isPreviewable())->toBeTrue();
 
-    //Access draft engagement as Regulated Organization admin
+    // Access draft engagement as Regulated Organization admin
     $response = actingAs($regulatedOrganizationUser)->get(localized_route('projects.show', $project));
     $response->assertOk();
     expect($response['engagements']->contains($engagement))->toBeTrue();
@@ -778,7 +778,7 @@ test('admins can see engagement if it isPreviewable()', function () {
     actingAs($regulatedOrganizationUser)->get(localized_route('engagements.show', $engagement))
         ->assertOk();
 
-    //Access draft engagement as site admin
+    // Access draft engagement as site admin
     $response = actingAs($adminUser)->get(localized_route('projects.show', $project));
     $response->assertOk();
     expect($response['engagements']->contains($engagement))->toBeTrue();
@@ -786,7 +786,7 @@ test('admins can see engagement if it isPreviewable()', function () {
     actingAs($adminUser)->get(localized_route('engagements.show', $engagement))
         ->assertOk();
 
-    //Access draft engagement as an Individual user
+    // Access draft engagement as an Individual user
     $response = actingAs($individualUser)->get(localized_route('projects.show', $project));
     $response->assertOk();
     expect($response['engagements']->contains($engagement))->toBeFalse();
@@ -854,6 +854,40 @@ test('engagement participants can be listed by administrator or community connec
         ->assertOk();
 });
 
+test('participant payment types show in manage participants', function () {
+    $engagement = Engagement::factory()->create(['recruitment' => 'open-call']);
+    $project = $engagement->project;
+    $project->update(['estimate_requested_at' => now(), 'agreement_received_at' => now()]);
+    $regulatedOrganization = $project->projectable;
+    $regulatedOrganizationUser = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
+    $regulatedOrganization->users()->attach(
+        $regulatedOrganizationUser,
+        ['role' => 'admin']
+    );
+
+    $paymentType = PaymentType::factory()->create(['name' => __('Cash')]);
+    $otherPaymentType = 'Custom Payment Type';
+
+    $participant = User::factory()->create();
+    $participant->individual->update([
+        'roles' => ['participant'],
+        'region' => 'NS',
+        'locality' => 'Bridgewater',
+        'other_payment_type' => $otherPaymentType,
+    ]);
+    $participant->individual->paymentTypes()->attach($paymentType);
+    $engagement->participants()->save($participant->individual, ['status' => 'confirmed', 'share_access_needs' => '0']);
+
+    $response = actingAs($regulatedOrganizationUser)->get(localized_route('engagements.manage-participants', $engagement));
+    $response->assertOk();
+    $response->assertSeeTextInOrder([
+        __('Payment Types'),
+        $participant->name,
+        $paymentType->name,
+        $otherPaymentType,
+    ]);
+})->only();
+
 test('other access needs show in manage participants', function () {
     $engagement = Engagement::factory()->create(['recruitment' => 'open-call']);
     $project = $engagement->project;
@@ -865,10 +899,12 @@ test('other access needs show in manage participants', function () {
         ['role' => 'admin']
     );
 
+    $paymentType = PaymentType::factory()->create();
+
     // user no other access needs
     $noOtherAccessNeedsUser = User::factory()->create();
     $noOtherAccessNeedsUser->individual->update(['roles' => ['participant'], 'region' => 'NS', 'locality' => 'Bridgewater']);
-    $noOtherAccessNeedsUser->individual->paymentTypes()->attach(PaymentType::first());
+    $noOtherAccessNeedsUser->individual->paymentTypes()->attach($paymentType);
     $engagement->participants()->save($noOtherAccessNeedsUser->individual, ['status' => 'confirmed', 'share_access_needs' => '0']);
 
     $response = actingAs($regulatedOrganizationUser)->get(localized_route('engagements.manage-access-needs', $engagement));


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #2577 

- Adds a column in the managed participants screen to show the payment types for each participant
- Adds tests for showing payment type in manage participants page

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
