### PR TITLE
ci: add documentation for running artisan commands in nix environment (resolves #2506)

### DIFF
--- a/.kube/app/Dockerfile
+++ b/.kube/app/Dockerfile
@@ -9,6 +9,8 @@ ENV APP_DIR /app
 ENV KUBE_DIR .kube/app
 
 ARG CIPHERSWEET_KEY
+ARG USER_ID
+RUN [ -z "$USER_ID" ] || usermod -u $USER_ID www-data # If argument passed then swap out numerical id for www-data user to allow for mirroring volumes from local to host
 
 RUN apt-get update
 
@@ -82,17 +84,19 @@ RUN . "$NVM_DIR/nvm.sh" && nvm install $NODE_VERSION
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 COPY $KUBE_DIR/php.ini /etc/php/$PHP_VERSION/cli/conf.d/99-sail.ini
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" # explicitly setup production PHP settings
 COPY $KUBE_DIR/nginx.conf /etc/nginx/nginx.conf
 COPY $KUBE_DIR/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-RUN mkdir $APP_DIR
 WORKDIR $APP_DIR
-COPY . $APP_DIR
+COPY --chown=www-data . $APP_DIR # Change ownership as the files are copied rather than having to change after
+RUN mkdir -p $APP_DIR/node_modules # Prevents error on npm ci when directory doesn not yet exist
+RUN chown www-data $NVM_DIR/nvm.sh $APP_DIR/node_modules /var/www # Set proper ownership to prevent errors when installed with php-fpm user
 
+# run installers as the user that PHP runs under to keep ownership aligned
+USER www-data
 RUN composer install
-
 RUN . "$NVM_DIR/nvm.sh" && nvm use $NODE_VERSION && npm ci
-
-RUN chown -R www-data:root $APP_DIR/public/ $NVM_DIR
+USER root
 
 ENTRYPOINT $APP_DIR/$KUBE_DIR/entrypoint.sh

--- a/.kube/app/Dockerfile
+++ b/.kube/app/Dockerfile
@@ -10,7 +10,8 @@ ENV KUBE_DIR .kube/app
 
 ARG CIPHERSWEET_KEY
 ARG USER_ID
-RUN [ -z "$USER_ID" ] || usermod -u $USER_ID www-data # If argument passed then swap out numerical id for www-data user to allow for mirroring volumes from local to host
+# If argument passed then swap out numerical id for www-data user to allow for mirroring volumes from local to host set via .env file variable WWWUSER and is auto-generate when starting nix-shell for the first time
+RUN [ -z "$USER_ID" ] || usermod -u $USER_ID www-data
 
 RUN apt-get update
 
@@ -51,7 +52,8 @@ RUN apt-get install -y \
 
 RUN mkdir -p /tmp/imagick
 WORKDIR /tmp/imagick
-RUN curl -L -o /tmp/imagick.tar.gz https://github.com/Imagick/imagick/archive/refs/tags/3.7.0.tar.gz # upgrade version when bumping PHP version
+# upgrade version when bumping PHP version
+RUN curl -L -o /tmp/imagick.tar.gz https://github.com/Imagick/imagick/archive/refs/tags/3.7.0.tar.gz
 RUN tar --strip-components=1 -xf /tmp/imagick.tar.gz
 RUN phpize
 RUN ./configure
@@ -84,14 +86,18 @@ RUN . "$NVM_DIR/nvm.sh" && nvm install $NODE_VERSION
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 COPY $KUBE_DIR/php.ini /etc/php/$PHP_VERSION/cli/conf.d/99-sail.ini
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" # explicitly setup production PHP settings
+# explicitly setup production PHP settings
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY $KUBE_DIR/nginx.conf /etc/nginx/nginx.conf
 COPY $KUBE_DIR/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 WORKDIR $APP_DIR
-COPY --chown=www-data . $APP_DIR # Change ownership as the files are copied rather than having to change after
-RUN mkdir -p $APP_DIR/node_modules # Prevents error on npm ci when directory doesn not yet exist
-RUN chown www-data $NVM_DIR/nvm.sh $APP_DIR/node_modules /var/www # Set proper ownership to prevent errors when installed with php-fpm user
+# Change ownership as the files are copied rather than having to change after
+COPY --chown=www-data:www-data . $APP_DIR
+# Prevents error on npm ci when directory doesn not yet exist
+RUN mkdir -p $APP_DIR/node_modules
+# Set proper ownership to prevent errors when installed with php-fpm user
+RUN chown www-data:www-data $NVM_DIR/nvm.sh $APP_DIR/node_modules /var/www
 
 # run installers as the user that PHP runs under to keep ownership aligned
 USER www-data

--- a/.kube/app/entrypoint.sh
+++ b/.kube/app/entrypoint.sh
@@ -1,37 +1,27 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
-# TODO permanent remove cache lines once testing on per/pod caching is tested
-
 mkdir -p $FILES_PATH
-# mkdir -p $CACHE_PATH removed per https://github.com/accessibility-exchange/platform/issues/1596
 
-## fix permissions before syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1226
-chown -R www-data:root /app/storage /app/bootstrap/cache $FILES_PATH $VIEW_COMPILED_PATH # $CACHE_PATH removed per https://github.com/accessibility-exchange/platform/issues/1596
+# Removing in favor of changing ownership in the syncing stream
+# chown -R www-data:www-data /app/storage /app/bootstrap/cache $FILES_PATH $VIEW_COMPILED_PATH
 
 ## sync files from container storage to permanent storage then remove container storage
-rsync -a /app/storage/ $FILES_PATH
+rsync -a --chown=www-data:www-data /app/storage/ $FILES_PATH
 rm -rf /app/storage
-
-## sync files from container cache to permanent storage then remove container cache
-## removed syncing to shared/permenant storage https://github.com/accessibility-exchange/platform/issues/1596
-# rsync -a /app/bootstrap/cache/ $CACHE_PATH
-# rm -rf /app/bootstrap/cache
 
 ## create symlinks from permanent storage & cache to application directory folders
 ln -s $FILES_PATH /app/storage
-## removed linked to shared/permenant storage https://github.com/accessibility-exchange/platform/issues/1596
-# ln -s $CACHE_PATH /app/bootstrap/cache
 
 php artisan deploy:local
 
 flock -n -E 0 /opt/data -c "php artisan deploy:global" # run exclusively on a single instance at once
 
-## fix permissions after syncing to existing storage and cache https://github.com/accessibility-exchange/platform/issues/1236
-chown -R www-data:root /app/bootstrap/cache $FILES_PATH # $CACHE_PATH removed per and added path to cache in the pod https://github.com/accessibility-exchange/platform/issues/1596
-
 # Generate the robots.txt and sitemap.xml files
 php artisan seo:generate
+
+# Add in symlink to ownership update, add in public folder where assets are compiled
+chown -R www-data:www-data /app/storage /app/bootstrap/cache /app/public/build /app/public/*.{xml,txt} $FILES_PATH
 
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/.local-deploy/accessibility-app/Dockerfile
+++ b/.local-deploy/accessibility-app/Dockerfile
@@ -2,8 +2,10 @@
 
 INCLUDE+ ./.kube/app/Dockerfile
 
-RUN apt install -y procps # for development add in command for showing running processes
+# for development add in command for showing running processes
+RUN apt install -y procps
 
 COPY .local-deploy/accessibility-app/php.ini-development "$PHP_INI_DIR/conf.d/99-sail.ini"
-RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini" # explicitly setup development php settings
+# explicitly setup development php settings
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 COPY .local-deploy/accessibility-app/etc /etc

--- a/.local-deploy/accessibility-app/Dockerfile
+++ b/.local-deploy/accessibility-app/Dockerfile
@@ -2,11 +2,8 @@
 
 INCLUDE+ ./.kube/app/Dockerfile
 
-ARG USER_ID
+RUN apt install -y procps # for development add in command for showing running processes
 
-RUN usermod -u $USER_ID www-data
-RUN chown -R www-data:root /app $NVM_DIR
-RUN chown www-data:root /var/www
-
-COPY .local-deploy/accessibility-app/php.ini-development /usr/local/etc/php/conf.d/php.ini
+COPY .local-deploy/accessibility-app/php.ini-development "$PHP_INI_DIR/conf.d/99-sail.ini"
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini" # explicitly setup development php settings
 COPY .local-deploy/accessibility-app/etc /etc

--- a/.local-deploy/accessibility-app/etc/nginx/nginx.conf
+++ b/.local-deploy/accessibility-app/etc/nginx/nginx.conf
@@ -31,13 +31,9 @@ http {
         listen 8080;
         server_name _;
 
-        location /nginx_status {
+        # change to match production path
+        location /status/nginx {
             stub_status on;
-            # don't need ip restrictions for local testing
-            # allow 127.0.0.1;
-            # allow 10.0.0.0/8;
-            # allow 172.0.0.0/8;
-            # deny all;
         }
 
         include /etc/nginx/includes/laravel.conf;

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Herd supports debuging via XDebug. The article "[Activating XDebug on Visual Stu
 ### Local development using Docker and Nix  
 
 #### Setup Instructions  
+
 1. Install [Nix](https://nixos.org/download/) for your system.  
 2. Run `nix-shell`.  
 3. If you are wanting to run Docker, follow the steps for your platform:  
@@ -193,60 +194,157 @@ Herd supports debuging via XDebug. The article "[Activating XDebug on Visual Stu
        ```  
    - **Other Systems**: You will need to have Docker installed and running.  
 
-#### Docker Compose Aliases  
-These aliases simplify working with `docker-compose` using the `docker-compose.yml` file:  
+#### Entering Development Environment
 
-- `dc` → Shortcut for `docker-compose -f docker-compose.yml`  
-- `dcbp` → Build the `platform.test` service: `docker-compose -f docker-compose.yml build platform.test`  
-- `dcup` → Start services in detached mode: `docker-compose -f docker-compose.yml up -d`  
-- `dcd` → Stop and remove containers: `docker-compose -f docker-compose.yml down`  
-- `dil` → List Docker images: `docker image ls`  
-- `dirm` → Remove Docker images: `docker image rm`  
-- `dvl` → List Docker volumes: `docker volume ls`  
-- `dvrm` → Remove Docker volumes: `docker volume rm`  
+Each time you want to have your terminal environment setup you will want to run `nix-shell` to make sure you have your aliases and packages setup.
 
-#### Kubernetes Aliases  
-These aliases simplify working with `kubectl` in different namespaces:  
+#### Aliases
 
-- `kcd` → Shortcut for `kubectl -n iris-accessibility-development`  
-- `kcs` → Shortcut for `kubectl -n iris-accessibility-staging`  
-- `kcp` → Shortcut for `kubectl -n iris-accessibility-production`  
+> ✅ All commands assume they're run from the project root directory where `docker-compose.yml` exists and the user has entered the nix shell by first running `nix-shell`.
 
-#### Pod Flushing Functions  
+##### 🧰 1. Docker Compose (`dc`, `dexit`, etc.)
 
-##### `kflush` Function  
-The `kflush` function executes Laravel deployment commands (`php artisan deploy:local` and `php artisan deploy:global`) inside running `app-` pods for a given namespace.  
+| Command | Description |
+|--------|-------------|
+| `dc <command>` | Runs any `docker-compose` command (e.g., `dc ps`, `dc exec...`) |
+| `dcbp` | Builds the `platform.test` service |
+| `dcupd` | Starts containers in detached mode |
+| `dcdn` | Stops and removes containers |
+| `dexit [options] <service> <cmd>` | Executes an interactive command in a running container |
+| `dexp` | Opens a Bash shell in `platform.test` as user `www-data` |
 
-###### Usage:  
-```sh
-kflush <namespace>
-```  
-Example:  
-```sh
-kflush development
-```  
-This will:  
-1. Find all running pods with the `app-` prefix in the `iris-accessibility-<namespace>` namespace.  
-2. Execute `php artisan deploy:local` in each pod.  
-3. Execute `php artisan deploy:global` in the first matching pod.  
+---
 
-##### `kflushall` Function  
-Flushes all `app-` pods in all environments (`development`, `staging`, `production`).  
+##### 🖼️ 2. Docker Images (`img`, `imgrm`, etc.)
 
-###### Usage:  
-```sh
-kflushall
-```  
-This iterates through all environments and runs `kflush` for each.  
+| Command | Description |
+|--------|-------------|
+| `img <command>` | Runs any `docker image` command |
+| `imgls` | Lists all Docker images |
+| `imglsp` | Lists only platform-related images (`platform*`) with their name:tag |
+| `imgrmp` | Prompts for confirmation before removing platform-related images |
+| `imgrm` | Removes specified Docker images manually |
+| `imgprune` | Removes all unused images (no confirmation) |
 
-##### Namespace-Specific Flush Aliases  
-For convenience, predefined aliases allow flushing without specifying the namespace:  
+---
 
-- `kdflush` → Runs `kflush development`  
-- `ksflush` → Runs `kflush staging`  
-- `kpflush` → Runs `kflush production`  
+##### 📄 3. Docker Logs (`log`, `logf`, `logt`, etc.)
+
+| Command | Description |
+|--------|-------------|
+| `log <container>` | Shows logs for a specific container |
+| `logf <container>` | Follows (tails) logs for a specific container |
+| `logt` | Tails logs for `platform.test` with last 100 lines |
+| `logp` | Tails logs for `platform.proxy` with last 100 lines |
+| `logsql` | Tails logs for `platform.mysql` with last 100 lines |
+| `tailt`, `tailp`, `tailsql` | Show static last 100 lines (not tailing) for respective containers |
+
+---
+
+##### 💾 4. Docker Volumes (`vol`, `volrmp`, etc.)
+
+| Command | Description |
+|--------|-------------|
+| `vol <command>` | Runs any `docker volume` command |
+| `vols` | Lists all volumes |
+| `volsp` | Lists only platform-specific volumes (e.g., `platform.mysql`, `platform.redis`) |
+| `volrmp` | Prompts for confirmation before removing matched platform volumes |
+| `volrm` | Removes specified volume manually |
+| `volprune` | Removes all unused volumes (no confirmation) |
+
+---
+
+##### 🌟 5. Laravel Artisan (`artisan`, `tinker`, etc.)
+
+| Command | Description |
+|--------|-------------|
+| `artisan <command>` | Runs any Laravel Artisan command inside `platform.test` container |
+| `tinker` | Shortcut for `artisan tinker` |
+| `test` | Shortcut for `artisan test` |
+
+Example:
+```bash
+artisan make:model User -mf
+```
+is equivalent to:
+```bash
+docker-compose exec -it --user www-data platform.test php artisan make:model User -mf
+```
+
+---
+
+##### ☸️ 6. Kubernetes (`kflush`, `kflushall`, etc.)
+
+These are custom deployment helpers that trigger Laravel `deploy:local` and `deploy:global` commands across Laravel pods in Kubernetes clusters.
+
+| Command | Description |
+|--------|-------------|
+| `kflush development` | Flushes all pods in `iris-accessibility-development` namespace |
+| `kflush staging` | Flushes all pods in `iris-accessibility-staging` namespace |
+| `kflush production` | Flushes all pods in `iris-accessibility-production` namespace |
+| `kflushall` | Flushes pods in all three environments (dev → stag → prod) |
+| `kflushd`, `kflushs`, `kflushp` | Shortcuts for flushing dev/stag/prod respectively |
+
+###### Internals of `kflush <env>`
+- Finds all `app-*` pods in the correct namespace
+- Runs `php artisan deploy:local` on each pod
+- Runs `php artisan deploy:global` only once (on the first pod)
+
+---
+
+##### 🧪 Example Usage Overview
+
+###### Docker Compose
+```bash
+dc ps                     # Show running services
+dcupd                     # Start environment
+dexp                      # Open shell in app
+```
+
+###### Docker Images
+```bash
+imglsp                    # List platform images
+imgrmp                    # Remove platform images after confirming
+```
+
+###### Docker Logs
+```bash
+logt                      # View recent logs for app
+logf platform.test        # Tail logs for app
+```
+
+###### Docker Volumes
+```bash
+volsp                     # List platform volumes
+volrmp                    # Remove them safely
+```
+
+###### Laravel
+```bash
+artisan migrate           # Run migrations
+artisan make:controller   # Generate controller
+tinker                    # Start Laravel Tinker
+```
+
+###### Kubernetes
+```bash
+kflushd                   # Run kflush in dev environment
+kflushall                 # Run kflush dev, staging, and prod environments
+```
+
+---
+
+##### 📝 Legend
+
+| Symbol | Meaning |
+|-------|----------|
+| `$@` | Passes all arguments received by a function |
+| `-r` | Prevents execution if no input is given to `xargs` |
+| `-p` | Prompts for confirmation before executing |
+| `| grep ...` | Filters output based on pattern matching |
 
 #### Environment Setup  
+
 If the `.env` file does not exist, the script automatically generates it using `.env.local.template` and random secrets:  
 - `CIPHERSWEET_KEY` (32-byte hex string)  
 - `DB_PASSWORD` (16-byte hex string)  
@@ -258,6 +356,7 @@ If the `.env` file does not exist, the script automatically generates it using `
 Ensure `.env.local.template` is available before running the script.  
 
 #### Rootless Docker Support  
+
 For users running `dockerd-rootless`, the script provides:  
 - Aliases:  
   ```sh

--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ Each time you want to have your terminal environment setup you will want to run 
 
 #### Aliases
 
-> ✅ All commands assume they're run from the project root directory where `docker-compose.yml` exists and the user has entered the nix shell by first running `nix-shell`.
+> :heavy_check_mark: All commands assume they're run from the project root directory where `docker-compose.yml` exists and the user has entered the nix shell by first running `nix-shell`.
 
-##### 🧰 1. Docker Compose (`dc`, `dexit`, etc.)
+##### :toolbox: 1. Docker Compose (`dc`, `dexit`, etc.)
 
 | Command | Description |
 |--------|-------------|
@@ -215,7 +215,7 @@ Each time you want to have your terminal environment setup you will want to run 
 
 ---
 
-##### 🖼️ 2. Docker Images (`img`, `imgrm`, etc.)
+##### :camera: 2. Docker Images (`img`, `imgrm`, etc.)
 
 | Command | Description |
 |--------|-------------|
@@ -228,7 +228,7 @@ Each time you want to have your terminal environment setup you will want to run 
 
 ---
 
-##### 📄 3. Docker Logs (`log`, `logf`, `logt`, etc.)
+##### :page_facing_up: 3. Docker Logs (`log`, `logf`, `logt`, etc.)
 
 | Command | Description |
 |--------|-------------|
@@ -241,7 +241,7 @@ Each time you want to have your terminal environment setup you will want to run 
 
 ---
 
-##### 💾 4. Docker Volumes (`vol`, `volrmp`, etc.)
+##### :floppy_disk: 4. Docker Volumes (`vol`, `volrmp`, etc.)
 
 | Command | Description |
 |--------|-------------|
@@ -254,7 +254,7 @@ Each time you want to have your terminal environment setup you will want to run 
 
 ---
 
-##### 🌟 5. Laravel Artisan (`artisan`, `tinker`, etc.)
+##### :star: 5. Laravel Artisan (`artisan`, `tinker`, etc.)
 
 | Command | Description |
 |--------|-------------|
@@ -273,7 +273,7 @@ docker-compose exec -it --user www-data platform.test php artisan make:model Use
 
 ---
 
-##### ☸️ 6. Kubernetes (`kflush`, `kflushall`, etc.)
+##### :atom_symbol: 6. Kubernetes (`kflush`, `kflushall`, etc.)
 
 These are custom deployment helpers that trigger Laravel `deploy:local` and `deploy:global` commands across Laravel pods in Kubernetes clusters.
 
@@ -292,7 +292,7 @@ These are custom deployment helpers that trigger Laravel `deploy:local` and `dep
 
 ---
 
-##### 🧪 Example Usage Overview
+##### :test_tube: Example Usage Overview
 
 ###### Docker Compose
 ```bash
@@ -334,7 +334,7 @@ kflushall                 # Run kflush dev, staging, and prod environments
 
 ---
 
-##### 📝 Legend
+##### :memo: Legend
 
 | Symbol | Meaning |
 |-------|----------|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - network.platform.proxy
     ports:
       - "${APP_PORT:-80}:80"
-      - 443:443
+      - "${APP_SSL_PORT:-443}:443" # Allows you to set dedicated IP and port locally in .env file
 
   platform.test:
     build:
@@ -50,7 +50,7 @@ services:
       platform.selenium:
         condition: service_started
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:8080/nginx_status"]
+      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:8080/status/nginx"] # Adjust to mirror production path
       retries: 3
       timeout: 5s
 

--- a/shell.nix
+++ b/shell.nix
@@ -17,24 +17,94 @@ pkgs.mkShell {
 
   shellHook =
     ''
-      # setup aliases
-      alias dc="docker-compose"
-      alias dcbp="docker-compose build platform.test"
-      alias dexp="docker-compose exec -it --user wwww-data platform.test bash"
-      alias dcup="docker-compose up -d"
-      alias dcd="docker-compose down"
-      alias dlt="docker-compose logs -f platform.test"
-      alias dlp="docker-compose logs -f platform.proxy"
-      alias dil="docker image ls platform*"
-      alias dirm="docker image ls platform* | sed '1d' | awk '{print $1}' | xargs docker image rm"
-      alias dvl="docker volume ls | grep platform"
-      alias dvrm="docker volume ls | grep platform | awk '{print $2}' | xargs docker volume rm"
-      alias kcd="kubectl -n iris-accessibility-development"
-      alias kcs="kubectl -n iris-accessibility-staging"
-      alias kcp="kubectl -n iris-accessibility-production"
-      alias kdflush="kflush development"
-      alias ksflush="kflush staging"
-      alias kpflush="kflush production"
+      # =====================
+      # == Docker Compose ==
+      # =====================
+      dc() {
+          docker-compose "$@"
+      }
+      alias dcbp='dc build platform.test'
+      alias dcupd='dc up -d'
+      alias dcdn='dc down'
+
+      dexit() {
+        dc exec -it "$@"
+      }
+      alias dexp='dexit --user www-data platform.test bash'
+
+      # ===================
+      # == Docker Images ==
+      # ===================
+
+      img() {
+        docker image "$@"
+      }
+
+      imglsp() {
+        img ls --format '{{.Repository}}:{{.Tag}}' 'platform*' "$@"
+      }
+      alias imgls='img ls'
+      alias imgrmp="imglsp | xargs -r -p docker image rm"
+      alias imgprune="img prune -af"
+
+      # Shortcuts for manual removal
+      alias imgrm='img rm'
+
+      # =================
+      # == Docker Logs ==
+      # =================
+
+      # Logs
+      log() {
+        docker logs "$@"
+      }
+      logf() {
+        log -f "$@"
+      }
+      alias logt='logf -n 100 platform.test'
+      alias logp='logf -n 100 platform.proxy'
+      alias logsql='logf -n 100 platform.mysql'
+      alias tailt='log -n 100 platform.test'
+      alias tailp='log -n 100 platform.proxy'
+      alias tailsql='log -n 100 platform.mysql'
+
+      # ====================
+      # == Docker Volumes ==
+      # ====================
+
+      vol() {
+        docker volume "$@"
+      }
+
+      volsp() {
+        vol ls --format '{{.Name}}' | grep -E 'platform\.(meilisearch|mysql|redis|test)$'
+      }
+
+      alias vols='vol ls'
+      alias volrmp="volsp | xargs -r -p docker volume rm"
+      alias volrm='vol rm'
+      alias volprune="vol prune -af"
+
+
+      # =============
+      # == Laravel ==
+      # =============
+
+      artisan() {
+        dexit --user www-data platform.test php artisan "$@"
+      }
+
+      alias tinker='artisan tinker'
+      alias test='artisan test'
+
+
+      # ==================
+      # == Kube Control ==
+      # ==================
+
+      alias kflushd="kflush development"
+      alias kflushs="kflush staging"
+      alias kflushp="kflush production"
 
       kflush() {
         namespace="$1"

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,6 @@
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 pkgs.mkShell {
   buildInputs = with pkgs; [
@@ -13,89 +15,97 @@ pkgs.mkShell {
     php84Packages.composer
   ];
 
-
-  shellHook = ''
-    # setup aliases
-    alias dc="docker-compose -f docker-compose.yml"
-    alias dcbp="docker-compose -f docker-compose.yml build platform.test"
-    alias dcup="docker-compose -f docker-compose.yml up -d"
-    alias dcd="docker-compose -f docker-compose.yml down"
-    alias dil="docker image ls"
-    alias dirm="docker image rm"
-    alias dvl="docker volume ls"
-    alias dvrm="docker volume rm"
-    alias kcd="kubectl -n iris-accessibility-development"
-    alias kcs="kubectl -n iris-accessibility-staging"
-    alias kcp="kubectl -n iris-accessibility-production"
-    alias kdflush="kflush development"
-    alias ksflush="kflush staging"
-    alias kpflush="kflush production"
-
-    kflush() {
-      namespace="$1"
-      if [ -z "$namespace" ]; then
-        echo "Namespace is required"
-        return 1
-      fi
-
-      # Get all pods matching app- prefix in the given namespace
-      pods=$(kubectl get pods -n "iris-accessibility-$namespace" --field-selector=status.phase=Running -o name | grep '^pod/app-')
-
-      # Process all pods with deploy:local
-      echo "$pods" | while read -r pod; do
-        echo "Running php artisan deploy:local in $pod"
-        kubectl exec -n "iris-accessibility-$namespace" "$pod" -- php artisan deploy:local
-      done
-
-      # Process first pod with deploy:global
-      first_pod=$(echo "$pods" | head -n 1)
-      if [ -n "$first_pod" ]; then
-        echo "Running php artisan deploy:global in first container ($first_pod)"
-        kubectl exec -n "iris-accessibility-$namespace" "$first_pod" -- php artisan deploy:global
-      fi
-    }
-
-    # Function to flush all app- pods in all environments
-    kflushall() {
-      namespaces=(development staging production)
-      for ns in "''${namespaces[@]}"; do
-        echo "Processing iris-accessibility-$ns namespace:"
-        kflush $ns;
-        echo
-      done
-    }
-
-    # make sure kube directory is available for setting up config
-    if [[ ! -d "~/.kube" ]]; then
-      mkdir -p ~/.kube
-    fi
-
-    # setup environment file
-    if [[ ! -f ".env" ]]; then
-      export CIPHERSWEET_KEY=$(openssl rand -hex 32)
-      export DB_PASSWORD=$(openssl rand -hex 16)
-      export DB_ROOT_PASSWORD=$(openssl rand -hex 24)
-      export REDIS_PASSWORD=$(openssl rand -hex 20)
-      export APP_KEY=$(php artisan key:generate --show)
-      export WWWUSER=$UID
-      envsubst < .env.local.template > .env
-    fi
-
-    # install composer packages if missing
-    if [[ ! -d "vendor" ]]; then
-      composer install
-    fi
-
-    # install node modules if missing
-    if [[ ! -d "node_modules" ]]; then
-      npm ci
-    fi
-  '' + (if pkgs.system == "x86_64-linux" then ''
-    # setup rootless docker sock path
-    alias dstart="dockerd-rootless&"
-    alias dstop="pkill dockerd"
-    echo -e "If using dockerd-rootless then run the following so that docker commands will run on the right socket.\nexport DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock"
-    echo -e "\nYou will also want to make sure that you are allowed to expose priveleged ports https://github.com/rootless-containers/rootlesskit/blob/master/docs/port.md#exposing-privileged-ports"
+  shellHook =
     ''
-    else '''');
+      # setup aliases
+      alias dc="docker-compose"
+      alias dcbp="docker-compose build platform.test"
+      alias dexp="docker-compose exec -it --user wwww-data platform.test bash"
+      alias dcup="docker-compose up -d"
+      alias dcd="docker-compose down"
+      alias dlt="docker-compose logs -f platform.test"
+      alias dlp="docker-compose logs -f platform.proxy"
+      alias dil="docker image ls platform*"
+      alias dirm="docker image ls platform* | sed '1d' | awk '{print $1}' | xargs docker image rm"
+      alias dvl="docker volume ls | grep platform"
+      alias dvrm="docker volume ls | grep platform | awk '{print $2}' | xargs docker volume rm"
+      alias kcd="kubectl -n iris-accessibility-development"
+      alias kcs="kubectl -n iris-accessibility-staging"
+      alias kcp="kubectl -n iris-accessibility-production"
+      alias kdflush="kflush development"
+      alias ksflush="kflush staging"
+      alias kpflush="kflush production"
+
+      kflush() {
+        namespace="$1"
+        if [ -z "$namespace" ]; then
+          echo "Namespace is required"
+          return 1
+        fi
+
+        # Get all pods matching app- prefix in the given namespace
+        pods=$(kubectl get pods -n "iris-accessibility-$namespace" --field-selector=status.phase=Running -o name | grep '^pod/app-')
+
+        # Process all pods with deploy:local
+        echo "$pods" | while read -r pod; do
+          echo "Running php artisan deploy:local in $pod"
+          kubectl exec -n "iris-accessibility-$namespace" "$pod" -- php artisan deploy:local
+        done
+
+        # Process first pod with deploy:global
+        first_pod=$(echo "$pods" | head -n 1)
+        if [ -n "$first_pod" ]; then
+          echo "Running php artisan deploy:global in first container ($first_pod)"
+          kubectl exec -n "iris-accessibility-$namespace" "$first_pod" -- php artisan deploy:global
+        fi
+      }
+
+      # Function to flush all app- pods in all environments
+      kflushall() {
+        namespaces=(development staging production)
+        for ns in "''${namespaces[@]}"; do
+          echo "Processing iris-accessibility-$ns namespace:"
+          kflush $ns;
+          echo
+        done
+      }
+
+      # make sure kube directory is available for setting up config
+      if [[ ! -d "~/.kube" ]]; then
+        mkdir -p ~/.kube
+      fi
+
+      # setup environment file
+      if [[ ! -f ".env" ]]; then
+        export CIPHERSWEET_KEY=$(openssl rand -hex 32)
+        export DB_PASSWORD=$(openssl rand -hex 16)
+        export DB_ROOT_PASSWORD=$(openssl rand -hex 24)
+        export REDIS_PASSWORD=$(openssl rand -hex 20)
+        export APP_KEY=$(php artisan key:generate --show)
+        export WWWUSER=$UID
+        envsubst < .env.local.template > .env
+      fi
+
+      # install composer packages if missing
+      if [[ ! -d "vendor" ]]; then
+        composer install
+      fi
+
+      # install node modules if missing
+      if [[ ! -d "node_modules" ]]; then
+        npm ci
+      fi
+    ''
+    + (
+      if pkgs.system == "x86_64-linux" then
+        ''
+          # setup rootless docker sock path
+          alias dstart="dockerd-rootless&"
+          alias dstop="pkill dockerd"
+          echo -e "If using dockerd-rootless then run the following so that docker commands will run on the right socket.\nexport DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock"
+          echo -e "\nYou will also want to make sure that you are allowed to expose priveleged ports https://github.com/rootless-containers/rootlesskit/blob/master/docs/port.md#exposing-privileged-ports"
+        ''
+      else
+        ''''
+    );
 }


### PR DESCRIPTION
- Adds user documentation for nix shell and aliases that are created when entering the nix shell.
- Improves speed of deployment by changing ownership in copy and rsync stream instead of changing afterwards. Drastically improved local build and deployment speed.
- Added more helpful aliases & bash functions to help with local development.

- [x] Flush local images and volumes and build containers from scratch `dcdn && imgrmp && volrmp && dcupd`.
  - [x] Verify ownership of all the files in the `/app` and `/opt/data` containers `find ./ ! -user www-data` & `find /opt/data/ ! -user www-data`.
  - [x] Verify site comes up and can be browsed without errors.
- [x] Run all aliases locally and verify they work as expected.
- [x] Comment out `USER_ID: $WWWUSER` in `docker-compose.yml` rebuild `dcbp` and bring back up `dcupd`. 
  - [x] Verify that www-data user runs as default id 33 and files have the same ownership.