### PR TITLE
fix: :green_heart: permissions issue when vendor path is not part of …

### DIFF
--- a/.kube/app/Dockerfile
+++ b/.kube/app/Dockerfile
@@ -9,8 +9,7 @@ ENV APP_DIR /app
 ENV KUBE_DIR .kube/app
 
 ARG CIPHERSWEET_KEY
-# TODO attempt to duplicate issue that was happening in Gitlab CI/CD pipeline before reactivating this.
-# /app/vendor does not exist and could not be created:
+
 ARG USER_ID
 # If argument passed then swap out numerical id for www-data user to allow for mirroring volumes from local to host set via .env file variable WWWUSER and is auto-generate when starting nix-shell for the first time
 RUN [ -z "$USER_ID" ] || usermod -u $USER_ID www-data

--- a/.kube/app/Dockerfile
+++ b/.kube/app/Dockerfile
@@ -95,7 +95,7 @@ COPY $KUBE_DIR/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 WORKDIR $APP_DIR
 # Change ownership as the files are copied rather than having to change after
 COPY --chown=www-data:www-data . $APP_DIR
-# Prevents error on npm ci when directory doesn not yet exist
+# Prevents error on npm ci & composer install when directory doesn't exist yet
 RUN mkdir -p $APP_DIR/node_modules $APP_DIR/vendor
 # Set proper ownership to prevent errors when installed with php-fpm user
 RUN chown www-data:www-data $NVM_DIR/nvm.sh $APP_DIR/node_modules /var/www $APP_DIR/vendor

--- a/.kube/app/Dockerfile
+++ b/.kube/app/Dockerfile
@@ -9,6 +9,8 @@ ENV APP_DIR /app
 ENV KUBE_DIR .kube/app
 
 ARG CIPHERSWEET_KEY
+# TODO attempt to duplicate issue that was happening in Gitlab CI/CD pipeline before reactivating this.
+# /app/vendor does not exist and could not be created:
 ARG USER_ID
 # If argument passed then swap out numerical id for www-data user to allow for mirroring volumes from local to host set via .env file variable WWWUSER and is auto-generate when starting nix-shell for the first time
 RUN [ -z "$USER_ID" ] || usermod -u $USER_ID www-data
@@ -95,9 +97,9 @@ WORKDIR $APP_DIR
 # Change ownership as the files are copied rather than having to change after
 COPY --chown=www-data:www-data . $APP_DIR
 # Prevents error on npm ci when directory doesn not yet exist
-RUN mkdir -p $APP_DIR/node_modules
+RUN mkdir -p $APP_DIR/node_modules $APP_DIR/vendor
 # Set proper ownership to prevent errors when installed with php-fpm user
-RUN chown www-data:www-data $NVM_DIR/nvm.sh $APP_DIR/node_modules /var/www
+RUN chown www-data:www-data $NVM_DIR/nvm.sh $APP_DIR/node_modules /var/www $APP_DIR/vendor
 
 # run installers as the user that PHP runs under to keep ownership aligned
 USER www-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       dockerfile: ./.local-deploy/accessibility-app/Dockerfile
       args:
         CIPHERSWEET_KEY: "${CIPHERSWEET_KEY}"
-        USER_ID: $WWWUSER # change to your numerical user id so that you can work on files in real time and have write privileges
+        # USER_ID: $WWWUSER # change to your numerical user id so that you can work on files in real time and have write privileges
     container_name: platform.test
     # extra_hosts:
     #   - 'host.docker.internal:host-gateway'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       dockerfile: ./.local-deploy/accessibility-app/Dockerfile
       args:
         CIPHERSWEET_KEY: "${CIPHERSWEET_KEY}"
-        # USER_ID: $WWWUSER # change to your numerical user id so that you can work on files in real time and have write privileges
+        USER_ID: $WWWUSER # change to your numerical user id so that you can work on files in real time and have write privileges
     container_name: platform.test
     # extra_hosts:
     #   - 'host.docker.internal:host-gateway'


### PR DESCRIPTION
CI/CD error on composer install because `vendor` directory is missing.
Since we are running install under the www-data user it didn't have permission to add the directory to the root app directory.
This was missed in local testing since the `vendor` directory always exists and so gets copied into the docker build. By removing the directory and running the build I was able to duplicate the issue.
To fix we explicitly create the directory and fix ownership before `composer install`.
This fix was able to resolve the issue locally when `vendor` and `node_modules` where removed from my local system.
