### PR TITLE
fix: health probe returning 404

### DIFF
--- a/.kube/app/nginx.conf
+++ b/.kube/app/nginx.conf
@@ -51,20 +51,6 @@ http {
             log_not_found off;
         }
 
-        # Status endpoints in Laravel
-        location /status {
-            allow 10.0.0.0/8; # Internal K8 network
-            deny all;
-            try_files $uri $uri/ /index.php?$query_string;
-        }
-
-        # Status endpoint for NGINX
-        location /status/nginx {
-            allow 10.0.0.0/8; # Internal K8 network
-            deny all;
-            stub_status on;
-        }
-
         error_page 404 /index.php;
 
         location ~ \.php$ {

--- a/.kube/app/values.yaml
+++ b/.kube/app/values.yaml
@@ -1,5 +1,5 @@
 name: "IRIS Accessibility Exchange"
-health: /status/db
+health: /status/nginx # TODO revert to /status/db once it's fixed
 nodeHealth: /
 cronjobs:
   - name: schedule

--- a/.kube/app/values.yaml
+++ b/.kube/app/values.yaml
@@ -1,5 +1,5 @@
 name: "IRIS Accessibility Exchange"
-health: /status/nginx # TODO revert to /status/db once it's fixed
+health: /up
 nodeHealth: /
 cronjobs:
   - name: schedule

--- a/.local-deploy/accessibility-app/etc/nginx/nginx.conf
+++ b/.local-deploy/accessibility-app/etc/nginx/nginx.conf
@@ -31,11 +31,6 @@ http {
         listen 8080;
         server_name _;
 
-        # change to match production path
-        location /status/nginx {
-            stub_status on;
-        }
-
         include /etc/nginx/includes/laravel.conf;
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       platform.selenium:
         condition: service_started
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:8080/status/nginx"] # Adjust to mirror production path
+      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:8080/up"] # Adjust to mirror production path
       retries: 3
       timeout: 5s
 


### PR DESCRIPTION
Changed readiness probe to `/status/nginx` since `/status/db` is returning 404 due to Laravel upgrade.
