### PR TITLE
fix: do not send new engagement notifications to suspended users (resolves #2714)

### DIFF
--- a/app/Http/Controllers/EngagementController.php
+++ b/app/Http/Controllers/EngagementController.php
@@ -426,13 +426,14 @@ class EngagementController extends Controller
                 flash(__('Your engagement has been published.'), 'success|'.__('Your engagement has been published.', [], 'en'));
 
                 if ($engagement->recruitment === EngagementRecruitment::OpenCall->value) {
-                    $users = User::where('context', 'individual')->withNotificationSettings('engagements', '1')->get();
+                    $users = User::where('context', 'individual')->whereNull('suspended_at')->withNotificationSettings('engagements', '1')->get();
                     FacadesNotification::send($users, new EngagementAdded($engagement));
                 }
 
                 $projectable = $engagement->project->projectable;
 
                 $otherOrgs = Organization::when($projectable instanceof Organization, fn ($query) => $query->whereNot(fn ($query) => $query->where('id', $projectable->id)))
+                    ->whereNull('suspended_at')
                     ->withNotificationSettings('engagements', '1')
                     ->get();
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -253,7 +253,6 @@ if (! function_exists('localized_route_for_locale')) {
      */
     function localized_route_for_locale(string $name, mixed $parameters, ?string $locale = null, bool $absolute = true): string
     {
-        // dd(is_null($locale), $locale === $locale);
         if (is_null($locale) || $locale === locale()) {
             return localized_route($name, $parameters, $locale, $absolute);
         }

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -227,6 +227,11 @@ test('notifications for Individual users are sent when new open-call engagements
         'context' => UserContext::Individual->value,
         'notification_settings' => ['engagements' => '0'],
     ]);
+    $suspendedUser = User::factory()->create([
+        'context' => UserContext::Individual->value,
+        'notification_settings' => ['engagements' => '1'],
+        'suspended_at' => now(),
+    ]);
 
     $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
@@ -267,6 +272,7 @@ test('notifications for Individual users are sent when new open-call engagements
     );
 
     Notification::assertNotSentTo($userWithoutNotifications, EngagementAdded::class);
+    Notification::assertNotSentTo($suspendedUser, EngagementAdded::class);
 });
 
 test('view notifications for Individual users about new open-call engagements', function () {
@@ -277,6 +283,11 @@ test('view notifications for Individual users about new open-call engagements', 
     $userWithoutNotifications = User::factory()->create([
         'context' => UserContext::Individual->value,
         'notification_settings' => ['engagements' => '0'],
+    ]);
+    $suspendedUser = User::factory()->create([
+        'context' => UserContext::Individual->value,
+        'notification_settings' => ['engagements' => '1'],
+        'suspended_at' => now(),
     ]);
 
     $user = User::factory()->create(['context' => UserContext::Organization->value]);
@@ -313,6 +324,10 @@ test('view notifications for Individual users about new open-call engagements', 
     actingAs($userWithoutNotifications)->get(localized_route('dashboard.notifications'))
         ->assertOk()
         ->assertDontSee(__('New engagement added'));
+
+    actingAs($suspendedUser)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertDontSee(__('New engagement added'));
 });
 
 test('notifications are not sent for Individual users when an non-open-call engagement is published', function () {
@@ -325,6 +340,11 @@ test('notifications are not sent for Individual users when an non-open-call enga
     $userWithoutNotifications = User::factory()->create([
         'context' => UserContext::Individual->value,
         'notification_settings' => ['engagements' => '0'],
+    ]);
+    $suspendedUser = User::factory()->create([
+        'context' => UserContext::Individual->value,
+        'notification_settings' => ['engagements' => '1'],
+        'suspended_at' => now(),
     ]);
 
     $user = User::factory()->create(['context' => UserContext::Organization->value]);
@@ -357,6 +377,7 @@ test('notifications are not sent for Individual users when an non-open-call enga
 
     Notification::assertNotSentTo($userWithNotifications, EngagementAdded::class);
     Notification::assertNotSentTo($userWithoutNotifications, EngagementAdded::class);
+    Notification::assertNotSentTo($suspendedUser, EngagementAdded::class);
 });
 
 test('notifications are sent for community org users when engagements are published', function () {
@@ -374,6 +395,16 @@ test('notifications are sent for community org users when engagements are publis
             ['role' => TeamRole::Administrator->value]
         )
         ->create(['notification_settings' => ['engagements' => '0']]);
+
+    $suspendedOrg = Organization::factory()
+        ->hasAttached(
+            User::factory()->state(['context' => UserContext::Organization->value]),
+            ['role' => TeamRole::Administrator->value]
+        )
+        ->create([
+            'notification_settings' => ['engagements' => '1'],
+            'suspended_at' => now(),
+        ]);
 
     $user = User::factory()->create(['context' => UserContext::Organization->value]);
     $organization = Organization::factory()
@@ -416,6 +447,7 @@ test('notifications are sent for community org users when engagements are publis
     );
 
     Notification::assertNotSentTo($orgWithoutNotifications, EngagementAdded::class);
+    Notification::assertNotSentTo($suspendedOrg, EngagementAdded::class);
     Notification::assertNotSentTo($organization, EngagementAdded::class);
 });
 
@@ -434,6 +466,18 @@ test('view notifications for community org users about new engagements', functio
         ->create([
             'notification_settings' => ['engagements' => '0'],
             'roles' => [OrganizationRole::ConsultationParticipant->value],
+        ]);
+
+    $userForSuspendedOrg = User::factory()->create([
+        'context' => UserContext::Organization->value,
+        'suspended_at' => now(),
+    ]);
+    Organization::factory()
+        ->hasAttached($userForSuspendedOrg, ['role' => TeamRole::Administrator->value])
+        ->create([
+            'notification_settings' => ['engagements' => '1'],
+            'roles' => [OrganizationRole::ConsultationParticipant->value],
+            'suspended_at' => now(),
         ]);
 
     $user = User::factory()->create(['context' => UserContext::Organization->value]);
@@ -474,6 +518,10 @@ test('view notifications for community org users about new engagements', functio
         ->assertSee(__('New engagement added'));
 
     actingAs($userWithoutNotifications)->get(localized_route('dashboard.notifications'))
+        ->assertOk()
+        ->assertDontSee(__('New engagement added'));
+
+    actingAs($userForSuspendedOrg)->get(localized_route('dashboard.notifications'))
         ->assertOk()
         ->assertDontSee(__('New engagement added'));
 


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #2714 

- no longer sends new engagement notifications to suspended users
- cleans up a commented debug statement

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
