### PR TITLE
fix: restore app.fallback_locale config (resolves #2717)

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'fallback_locale' => 'en',
     'faker_locale' => 'en_CA',
     'features' => [
         'blocking' => false,


### PR DESCRIPTION
In #2636 the `app.fallback_locale` config value was removed, which caused a couple of errors. This PR restores it.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.