### PR TITLE
ci(kube): :wrench: align health checks to Laravel /up path

### DIFF
--- a/.kube/app/values.yaml
+++ b/.kube/app/values.yaml
@@ -1,6 +1,6 @@
 name: "IRIS Accessibility Exchange"
 health: /up
-nodeHealth: /
+nodeHealth: /up
 cronjobs:
   - name: schedule
     schedule: "* * * * *"


### PR DESCRIPTION
─ Standardize health check paths for app and node to use Laravel's /up endpoint ─ Ensure consistent monitoring behavior across services

