### PR TITLE
fix: guard against empty inputs for authorization of block requests

### DIFF
--- a/app/Http/Requests/BlockRequest.php
+++ b/app/Http/Requests/BlockRequest.php
@@ -8,6 +8,10 @@ class BlockRequest extends FormRequest
 {
     public function authorize(): bool
     {
+        if (empty($this->input('blockable_type')) || empty($this->input('blockable_id'))) {
+            return false;
+        }
+
         $blockable = $this->input('blockable_type')::find($this->input('blockable_id'));
 
         return $blockable && $this->user()->can('block', $blockable);

--- a/app/Http/Requests/UnblockRequest.php
+++ b/app/Http/Requests/UnblockRequest.php
@@ -15,8 +15,17 @@ class UnblockRequest extends FormRequest
     {
         return [
             'blockable_type' => 'required|string|in:App\Models\Individual,App\Models\Organization,App\Models\RegulatedOrganization',
-            'blockable_id' => 'required|integer|exists:'.$this->input('blockable_type').',id',
+            'blockable_id' => 'required|integer',
         ];
+    }
+
+    public function withValidator($validator)
+    {
+        if ($this->input('blockable_type')) {
+            $validator->sometimes('blockable_id', 'exists:'.$this->input('blockable_type').',id', function () {
+                return true;
+            });
+        }
     }
 
     public function attributes(): array

--- a/tests/Datasets/BlockRequestValidationErrors.php
+++ b/tests/Datasets/BlockRequestValidationErrors.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\User;
+
+dataset('blockRequestValidationErrors', function () {
+    return [
+        'Blockable type is missing' => fn () => [
+            'state' => ['blockable_type' => null],
+        ],
+        'Blockable type is not a string' => fn () => [
+            'state' => ['blockable_type' => false],
+        ],
+        'Blockable type is invalid' => fn () => [
+            'state' => [
+                'blockable_type' => 'App\Models\User',
+                'blockable_id' => User::firstOr(function () {
+                    return User::factory()->create();
+                })->id,
+            ],
+            'errors' => ['blockable_type' => __('validation.exists', ['attribute' => __('blockable type')])],
+        ],
+        'Blockable id is missing' => fn () => [
+            'state' => ['blockable_id' => null],
+        ],
+        'Blockable id is not an integer' => fn () => [
+            'state' => ['blockable_id' => 'not an integer'],
+        ],
+        'Blockable id invalid' => fn () => [
+            'state' => ['blockable_id' => 1000],
+        ],
+    ];
+});

--- a/tests/Datasets/DestroyUserRequestValidationErrors.php
+++ b/tests/Datasets/DestroyUserRequestValidationErrors.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Enums\UserContext;
+
+dataset('destroyUserRequestValidationErrors', function () {
+    return [
+        'Current password is missing' => fn () => [
+            'state' => ['current_password' => null],
+            'errors' => ['current_password' => __('validation.required', ['attribute' => __('current password')])],
+        ],
+        'Current password is not a string' => fn () => [
+            'state' => ['current_password' => false],
+            'errors' => ['current_password' => __('validation.string', ['attribute' => __('current password')])],
+        ],
+        'Current password does not match' => fn () => [
+            'state' => ['current_password' => 'fake_password'],
+            'errors' => ['current_password' => __('auth.wrong_password')],
+        ],
+        'Is only administrator of organization' => fn () => [
+            'state' => ['current_password' => 'password'],
+            'errors' => ['organizations'],
+            'context' => UserContext::Organization->value,
+        ],
+        'Is only administrator of regulated organization' => fn () => [
+            'state' => ['current_password' => 'password'],
+            'errors' => ['organizations'],
+            'context' => UserContext::RegulatedOrganization->value,
+        ],
+    ];
+});

--- a/tests/Datasets/SaveUserContextRequestValidationErrors.php
+++ b/tests/Datasets/SaveUserContextRequestValidationErrors.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Enums\UserContext;
+
+dataset('saveUserContextRequestValidationErrors', function () {
+    return [
+        'Context is missing' => fn () => [
+            'state' => ['context' => null],
+            'errors' => ['context' => __('You must tell us who you’re joining as.')],
+        ],
+        'Context is not a string' => fn () => [
+            'state' => ['context' => false],
+            'errors' => ['context' => __('validation.string', ['attribute' => __('context')])],
+        ],
+        'Context is invalid' => fn () => [
+            'state' => ['context' => 'invalid'],
+            'errors' => ['context' => __('validation.exists', ['attribute' => __('context')])],
+        ],
+        'Context is an administrator' => fn () => [
+            'state' => ['context' => UserContext::Administrator->value],
+            'errors' => ['context' => __('validation.exists', ['attribute' => __('context')])],
+        ],
+    ];
+});

--- a/tests/Datasets/UnblockRequestValidationErrors.php
+++ b/tests/Datasets/UnblockRequestValidationErrors.php
@@ -1,0 +1,30 @@
+<?php
+
+dataset('unblockRequestValidationErrors', function () {
+    return [
+        'Blockable type is missing' => fn () => [
+            'state' => ['blockable_type' => null],
+            'errors' => ['blockable_type' => __('validation.required', ['attribute' => __('blockable type')])],
+        ],
+        'Blockable type is not a string' => fn () => [
+            'state' => ['blockable_type' => false],
+            'errors' => ['blockable_type' => __('validation.string', ['attribute' => __('blockable type')])],
+        ],
+        'Blockable type is invalid' => fn () => [
+            'state' => ['blockable_type' => 'App\Models\User'],
+            'errors' => ['blockable_type' => __('validation.exists', ['attribute' => __('blockable type')])],
+        ],
+        'Blockable id is missing' => fn () => [
+            'state' => ['blockable_id' => null],
+            'errors' => ['blockable_id' => __('validation.required', ['attribute' => __('blockable id')])],
+        ],
+        'Blockable id is not an integer' => fn () => [
+            'state' => ['blockable_id' => 'not an integer'],
+            'errors' => ['blockable_id' => __('validation.integer', ['attribute' => __('blockable id')])],
+        ],
+        'Blockable id invalid' => fn () => [
+            'state' => ['blockable_id' => 1000],
+            'errors' => ['blockable_id' => __('validation.exists', ['attribute' => __('blockable id')])],
+        ],
+    ];
+});

--- a/tests/Feature/BlocklistTest.php
+++ b/tests/Feature/BlocklistTest.php
@@ -233,3 +233,37 @@ test('individual warning when unblocking user not on block list', function () {
     expect(flash()->class)->toBe('warning|Could not be blocked because it was not on your block list.');
     expect(flash()->message)->toBe(__(':blockable could not be unblocked because it was not on your block list.', ['blockable' => $regulatedOrganization->name]));
 });
+
+test('block request validation errors', function (array $state, ?array $errors = null) {
+    $user = User::factory()->hasIndividual()->create();
+    $individual = Individual::factory()->create();
+
+    $base = [
+        'blockable_type' => 'App\Models\Individual',
+        'blockable_id' => $individual->id,
+    ];
+
+    if ($errors) {
+        actingAs($user)
+            ->post(localized_route('block-list.block'), array_merge($base, $state))
+            ->assertSessionHasErrors($errors);
+    } else {
+        actingAs($user)
+            ->post(localized_route('block-list.block'), array_merge($base, $state))
+            ->assertForbidden();
+    }
+})->with('blockRequestValidationErrors');
+
+test('unblock request validation errors', function (array $state, array $errors) {
+    $user = User::factory()->hasIndividual()->create();
+    $individual = Individual::factory()->create();
+
+    $base = [
+        'blockable_type' => 'App\Models\Individual',
+        'blockable_id' => $individual->id,
+    ];
+
+    actingAs($user)
+        ->post(localized_route('block-list.unblock'), array_merge($base, $state))
+        ->assertSessionHasErrors($errors);
+})->with('unblockRequestValidationErrors');

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -152,6 +152,10 @@ test('new users can not register without valid context', function () {
         ->assertSessionHasErrors();
 });
 
+test('save user context request validation errors', function (array $state, array $errors) {
+    post(localized_route('register-context'), $state)->assertSessionHasErrors($errors);
+})->with('saveUserContextRequestValidationErrors');
+
 test('users can register via invitation to (regulated) organization', function () {
     $regulatedOrganization = RegulatedOrganization::factory()->create();
     $invitation = Invitation::factory()->create([

--- a/tests/Feature/UserSettingsTest.php
+++ b/tests/Feature/UserSettingsTest.php
@@ -596,3 +596,23 @@ test('guests cannot delete accounts', function () {
     delete(localized_route('users.destroy'))
         ->assertRedirect(localized_route('login'));
 });
+
+test('destroy user request validation errors', function (array $state, array $errors, string $context = UserContext::Individual->value) {
+    if ($context === UserContext::Organization->value) {
+        $user = User::factory()->create(['context' => UserContext::Organization->value]);
+        Organization::factory()
+            ->hasAttached($user, ['role' => TeamRole::Administrator->value])
+            ->create();
+    } elseif ($context === UserContext::RegulatedOrganization->value) {
+        $user = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
+        RegulatedOrganization::factory()
+            ->hasAttached($user, ['role' => TeamRole::Administrator->value])
+            ->create();
+    } else {
+        $user = User::factory()->hasIndividual()->create();
+    }
+
+    actingAs($user)
+        ->delete(localized_route('users.destroy'), $state)
+        ->assertSessionHasErrorsIn('destroyAccount', $errors);
+})->with('destroyUserRequestValidationErrors');


### PR DESCRIPTION
<!-- Explain what this PR does. -->

- prevents some server side errors if inputs are missing for block requests
- adds tests for block and unblock request validation errors
- adds tests for destroy user request validation errors
- adds tests for save user context validation errors

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
