### PR TITLE
fix: do not force invited user to create organization

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -52,8 +52,8 @@ class UserController extends Controller
 
         $skipTo = match ($user->context) {
             UserContext::Individual->value => localized_route('dashboard'),
-            UserContext::Organization->value => $user->extra_attributes->get('invitation') ? localized_route('dashboard') : localized_route('organizations.show-type-selection'),
-            UserContext::RegulatedOrganization->value => $user->extra_attributes->get('invitation') ? localized_route('dashboard') : localized_route('regulated-organizations.show-type-selection'),
+            UserContext::Organization->value => $user->hasInvitation() ? localized_route('dashboard') : localized_route('organizations.show-type-selection'),
+            UserContext::RegulatedOrganization->value => $user->hasInvitation() ? localized_route('dashboard') : localized_route('regulated-organizations.show-type-selection'),
             default => localized_route('dashboard'),
         };
 
@@ -77,8 +77,8 @@ class UserController extends Controller
 
         $redirectTo = match (Auth::user()->context) {
             UserContext::Individual->value => localized_route('dashboard'),
-            UserContext::Organization->value => $user->extra_attributes->get('invitation') ? localized_route('dashboard') : localized_route('organizations.show-type-selection'),
-            UserContext::RegulatedOrganization->value => $user->extra_attributes->get('invitation') ? localized_route('dashboard') : localized_route('regulated-organizations.show-type-selection'),
+            UserContext::Organization->value => $user->hasInvitation() ? localized_route('dashboard') : localized_route('organizations.show-type-selection'),
+            UserContext::RegulatedOrganization->value => $user->hasInvitation() ? localized_route('dashboard') : localized_route('regulated-organizations.show-type-selection'),
             default => localized_route('dashboard'),
         };
 

--- a/app/Http/Controllers/UserEngagementsController.php
+++ b/app/Http/Controllers/UserEngagementsController.php
@@ -16,7 +16,7 @@ class UserEngagementsController extends Controller
     {
         $user = Auth::user();
 
-        if ($user->context === UserContext::Organization->value && ! $user->organization) {
+        if ($user->context === UserContext::Organization->value && ! $user->organization && ! $user->hasInvitation()) {
             return redirect(localized_route('organizations.show-type-selection'));
         }
 

--- a/app/Http/Controllers/UserProjectsController.php
+++ b/app/Http/Controllers/UserProjectsController.php
@@ -14,11 +14,11 @@ class UserProjectsController extends Controller
     {
         $user = Auth::user();
 
-        if ($user->context === UserContext::Organization->value && ! $user->organization) {
+        if ($user->context === UserContext::Organization->value && ! $user->organization && ! $user->hasInvitation()) {
             return redirect(localized_route('organizations.show-type-selection'));
         }
 
-        if ($user->context === UserContext::RegulatedOrganization->value && ! $user->regulatedOrganization) {
+        if ($user->context === UserContext::RegulatedOrganization->value && ! $user->regulatedOrganization && ! $user->hasInvitation()) {
             return redirect(localized_route('regulated-organizations.show-type-selection'));
         }
 

--- a/app/Http/Middleware/RedirectForOnboarding.php
+++ b/app/Http/Middleware/RedirectForOnboarding.php
@@ -15,7 +15,7 @@ class RedirectForOnboarding
     {
         $user = Auth::user();
 
-        if ($user->context === UserContext::RegulatedOrganization->value && ! $user->regulatedOrganization && $user->extra_attributes->get('invitation')) {
+        if ($user->context === UserContext::RegulatedOrganization->value && ! $user->regulatedOrganization && $user->hasInvitation()) {
             return $next($request);
         }
 
@@ -23,7 +23,7 @@ class RedirectForOnboarding
             return redirect(localized_route('regulated-organizations.show-type-selection'));
         }
 
-        if ($user->context === UserContext::Organization->value && ! $user->organization && $user->extra_attributes->get('invitation')) {
+        if ($user->context === UserContext::Organization->value && ! $user->organization && $user->hasInvitation()) {
             return $next($request);
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -358,6 +358,11 @@ class User extends Authenticatable implements CipherSweetEncrypted, FilamentUser
         return null;
     }
 
+    public function hasInvitation(): bool
+    {
+        return $this->extra_attributes->get('invitation') || Invitation::firstWhere('email', $this->email);
+    }
+
     public function blockedOrganizations(): MorphToMany
     {
         return $this->morphedByMany(Organization::class, 'blockable')->orderBy('name');

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -4,6 +4,7 @@ use App\Enums\IndividualRole;
 use App\Enums\UserContext;
 use App\Models\Engagement;
 use App\Models\Invitation;
+use App\Models\Organization;
 use App\Models\RegulatedOrganization;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
@@ -210,6 +211,50 @@ test('users can register via invitation to (regulated) organization', function (
 
     actingAs($user)->get(localized_route('dashboard'))
         ->assertSee('Invitation');
+});
+
+test('users with invitation are not prompted to create an organization or regulated organization', function () {
+    $organization = Organization::factory()->create();
+    $organizationUser = User::factory()->create(['context' => UserContext::Organization->value]);
+
+    actingAs($organizationUser)
+        ->get(localized_route('dashboard'))
+        ->assertRedirect(localized_route('organizations.show-type-selection'));
+
+    Invitation::factory()->create([
+        'invitationable_id' => $organization->id,
+        'invitationable_type' => get_class($organization),
+        'email' => $organizationUser->email,
+    ]);
+
+    $organizationUser->refresh();
+
+    expect($organizationUser->hasInvitation())->toBeTrue();
+
+    actingAs($organizationUser)
+        ->get(localized_route('dashboard'))
+        ->assertOk();
+
+    $regulatedOrganization = RegulatedOrganization::factory()->create();
+    $regulatedOrganizationUser = User::factory()->create(['context' => UserContext::RegulatedOrganization->value]);
+
+    actingAs($regulatedOrganizationUser)
+        ->get(localized_route('dashboard'))
+        ->assertRedirect(localized_route('regulated-organizations.show-type-selection'));
+
+    Invitation::factory()->create([
+        'invitationable_id' => $regulatedOrganization->id,
+        'invitationable_type' => get_class($regulatedOrganization),
+        'email' => $regulatedOrganizationUser->email,
+    ]);
+
+    $regulatedOrganizationUser->refresh();
+
+    expect($regulatedOrganizationUser->hasInvitation())->toBeTrue();
+
+    actingAs($regulatedOrganizationUser)
+        ->get(localized_route('dashboard'))
+        ->assertOk();
 });
 
 test('users can register via invitation to engagement', function () {


### PR DESCRIPTION
Resolves #2872.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

### Testing

1. Register a new Organization or Regulated Organization user but don't complete the onboarding process to create an Organization or Regulated Organization.
2. Log in as an existing Organization or Regulated Organization administrator.
3. Invite the user you registered in step 1 to join your Organization or Regulated Organization.
4. Log out and log in as the user you registered in step 1.
5. You should be redirected to your dashboard and should see the pending invitation.