### PR TITLE
feat: prefill and prevent editing of UserContext and email

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -28,16 +28,18 @@ class UserController extends Controller
             session()->put('invitation', $data['invitation']);
         }
 
-        if (isset($data['context'])) {
-            session()->put('context', $data['context']);
-        }
-
         if (isset($data['email'])) {
             session()->put('email', $data['email']);
         }
 
         if (isset($data['role'])) {
             session()->put('invited_role', $data['role']);
+        }
+
+        if (isset($data['context'])) {
+            session()->put('context', $data['context']);
+
+            return redirect(localized_route('register', ['step' => 3]));
         }
 
         return redirect(localized_route('register', ['step' => 2]));

--- a/resources/views/auth/register/steps/3.blade.php
+++ b/resources/views/auth/register/steps/3.blade.php
@@ -16,16 +16,22 @@
         <x-hearth-error for="name" />
     </div>
 
-    <!-- Email Address -->
-    <div class="field @error('email') field--error @enderror stack">
-        <x-hearth-label for="email" :value="__('forms.label_email')" />
-        <x-interpretation name="forms.label_email" namespace="label_email" />
-        <x-hearth-hint for="email">
-            {{ __('This is the email address you will use to sign in to The Accessibility Exchange.') }}
-        </x-hearth-hint>
-        <x-hearth-input name="email" type="email" value="{{ old('email', session('email')) }}" required />
-        <x-hearth-error for="email" />
-    </div>
+    @if (session('email'))
+        <div class="field">
+            <x-hearth-input name="email" type="hidden" value="{{ session('email') }}" />
+        </div>
+    @else
+        <!-- Email Address -->
+        <div class="field @error('email') field--error @enderror stack">
+            <x-hearth-label for="email" :value="__('forms.label_email')" />
+            <x-interpretation name="forms.label_email" namespace="label_email" />
+            <x-hearth-hint for="email">
+                {{ __('This is the email address you will use to sign in to The Accessibility Exchange.') }}
+            </x-hearth-hint>
+            <x-hearth-input name="email" type="email" value="{{ old('email', session('email')) }}" required />
+            <x-hearth-error for="email" />
+        </div>
+    @endif
 
     <x-interpretation name="{{ __('Back', [], 'en') . '_' . __('Next', [], 'en') }}" namespace="back_next" />
     <p class="repel">


### PR DESCRIPTION
Resolves #2880.

If a user registers via the link from an invitation email, they will not see the context selection page (they will be registered as an Individual, Organization or RegulatedOrganization user depending on the nature of the invitation) and the email where they received the invitation will be prefilled and not editable.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.
