### PR TITLE
feat: use description for meta description

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,7 +2,10 @@
 <html class="no-js" data-theme="@theme()" lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
 <head>
-    @include('partials.head', ['title' => $title ?? __('app.name')])
+    @include('partials.head', [
+        'title' => $title ?? __('app.name'),
+        'description' => $description ?? __('app.description')
+    ])
 </head>
 
 <body class="{{ $bodyClass }}">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -2,7 +2,10 @@
 <html class="no-js" data-theme="@theme()" lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
 <head>
-    @include('partials.head', ['title' => $title ?? __('app.name')])
+    @include('partials.head', [
+        'title' => $title ?? __('app.name'),
+        'description' => $description ?? __('app.description')
+    ])
 </head>
 
 <body class="guest">

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -1,9 +1,8 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
-
         <title>{{ $title ?? __('app.name') }} &mdash; {{ __('app.name') }}</title>
-        <meta name="description" content="{{ __('app.description') }}">
+        <meta name="description" content="{{ $description }}">
         <meta name="theme-color" content="#fff" media="(prefers-color-scheme: light)">
         <meta name="theme-color" content="#000" media="(prefers-color-scheme: dark)">
 

--- a/resources/views/tools/show.blade.php
+++ b/resources/views/tools/show.blade.php
@@ -1,5 +1,6 @@
 <x-app-layout body-class="page tool" page-width="wide" header-class="full header--tool">
     <x-slot name="title">{{ $tool->title }}</x-slot>
+    <x-slot name="description">{{ $tool->description }}</x-slot>
     <x-slot name="header">
         <div class="center center:wide welcome pb-32">
             <ol class="breadcrumbs" role="list">
@@ -25,6 +26,7 @@
             @endif
         </div>
     </div>
+
     @if ($tool->documents->count())
         <x-section class="full dark -mb-8" aria-labelledby="download-tool">
             <div class="center stack stack:xl py-20" x-data="{


### PR DESCRIPTION
Uses tool description (if present) for meta description tag.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.