### PR TITLE
chore(deps): set engines.npm to ^11

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
         "infusion": "^4.7.1",
         "luxon": "^3.5.0",
         "wicg-inert": "^3.1.2"
+    },
+    "engines": {
+        "npm": "^11"
     }
 }


### PR DESCRIPTION
See: https://docs.renovatebot.com/node/#configuring-which-version-of-npm-renovate-uses