### PR TITLE
fix: increase nginx client_max_body_size to match max_upload_filesize

### DIFF
--- a/.kube/app/nginx.conf
+++ b/.kube/app/nginx.conf
@@ -20,6 +20,7 @@ http {
 
     keepalive_timeout 65;
 
+    client_max_body_size 100M;
     client_body_temp_path /tmp/client_temp;
     proxy_temp_path /tmp/proxy_temp_path;
     fastcgi_temp_path /tmp/fastcgi_temp;


### PR DESCRIPTION
The [default value](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) for nginx's `client_max_body_size` is 1M, so this PR increases it to 100M to match PHP's `max_upload_filesize`. This should resolve the 413 errors I'm still getting even with the adjusted `max_upload_filesize`. FYI @JureUrsic and @marvinroman — I'm going to go ahead and merge this so I can test on dev and we can revise down if needed.
