### PR TITLE
fix: remove unneeded CSRF token

### DIFF
--- a/resources/views/tools/show.blade.php
+++ b/resources/views/tools/show.blade.php
@@ -54,7 +54,6 @@
                                     @foreach ($revision->getTranslations('file') as $lang => $file)
                                         <form method="get"
                                             action="{{ localized_route('download', ['revision' => $revision->id], $lang) }}">
-                                            @csrf
                                             <input name="email" type="hidden" x-bind:value="email" />
                                             <button
                                                 type="submit">{{ count($revision->getTranslations('file')) > 1 ? __('Download (:lang)', ['lang' => Str::upper($lang)]) : __('Download') }}</button>
@@ -84,7 +83,6 @@
                                                     @foreach ($revision->getTranslations('file') as $lang => $file)
                                                         <form method="get"
                                                             action="{{ localized_route('download', ['revision' => $revision->id], $lang) }}">
-                                                            @csrf
                                                             <input name="email" type="hidden"
                                                                 x-bind:value="email" />
                                                             <button


### PR DESCRIPTION
The download forms use GET requests and so they don't need CSRF tokens, which are only required for POST, PUT, PATCH, DELETE requests: https://laravel.com/docs/12.x/csrf

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.