### PR TITLE
fix: dashboard icon misalignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dev": "vite",
         "format": "run-s format:*",
         "format:blade": "prettier --write 'resources/views/**/*.blade.php'",
-        "format:css": "prettier --write resources/**/*.css",
+        "format:css": "prettier --write 'resources/**/*.css'",
         "lint:json": "eslint *.json database/seeders/data/*.json",
         "lint:scripts": "eslint *.js resources/js/**/*.js",
         "lint:styles": "stylelint resources/css/**/*.css",

--- a/resources/css/base/_typography.css
+++ b/resources/css/base/_typography.css
@@ -4,148 +4,150 @@
  * Basic typography style for copy text
  */
 
-body {
-    color: var(--body-color);
-    font-family: var(--font-base);
-    font-size: var(--text-base);
-    line-height: 1.5;
-}
-
-* + h1,
-* + .h1,
-* + h2,
-* + .h2,
-* + h3,
-* + .h3,
-* + h4,
-* + .h4,
-* + h5,
-* + .h5 {
-    margin-block-start: 1em;
-}
-
-h1,
-.h1,
-h2,
-.h2,
-h3,
-.h3 {
-    font-family: var(--font-display);
-}
-
-h1 a,
-.h1 a,
-h2 a,
-.h2 a,
-h3 a,
-.h3 a,
-h4 a,
-.h4 a,
-h5 a,
-.h5 a {
-    font-weight: inherit;
-}
-
-h1,
-.h1 {
-    color: var(--h1-color);
-    font-size: var(--text-4xl);
-    font-size: var(--text-fluid-3xl);
-    font-weight: var(--font-bold);
-}
-
-h2,
-.h2 {
-    color: var(--heading-color);
-    font-size: var(--text-3xl);
-    font-size: var(--text-fluid-2xl);
-    font-weight: var(--font-bold);
-}
-
-h3,
-.h3 {
-    color: var(--heading-color);
-    font-size: var(--text-xl);
-    font-size: var(--text-fluid-xl);
-    font-weight: var(--font-bold);
-}
-
-h4,
-.h4 {
-    color: var(--heading-color);
-    font-family: var(--font-base);
-    font-size: var(--text-lg);
-    font-size: var(--text-fluid-lg);
-    font-weight: var(--font-semibold);
-}
-
-h5,
-.h5 {
-    @apply text-base;
-
-    margin-block-end: 0;
-    margin-block-start: 0;
-}
-
-@media (min-width: 48rem) {
-    h1,
-    .h1 {
-        font-size: var(--text-6xl);
-        font-size: var(--text-fluid-3xl);
+@layer base {
+    body {
+        color: var(--body-color);
+        font-family: var(--font-base);
+        font-size: var(--text-base);
+        line-height: 1.5;
     }
 
+    * + h1,
+    * + .h1,
+    * + h2,
+    * + .h2,
+    * + h3,
+    * + .h3,
+    * + h4,
+    * + .h4,
+    * + h5,
+    * + .h5 {
+        margin-block-start: 1em;
+    }
+
+    h1,
+    .h1,
     h2,
-    .h2 {
+    .h2,
+    h3,
+    .h3 {
+        font-family: var(--font-display);
+    }
+
+    h1 a,
+    .h1 a,
+    h2 a,
+    .h2 a,
+    h3 a,
+    .h3 a,
+    h4 a,
+    .h4 a,
+    h5 a,
+    .h5 a {
+        font-weight: inherit;
+    }
+
+    h1,
+    .h1 {
+        color: var(--h1-color);
         font-size: var(--text-4xl);
-        font-size: var(--text-fluid-2xl);
-        font-weight: var(--font-medium);
-    }
-
-    h3,
-    .h3 {
-        font-size: var(--text-2xl);
-        font-size: var(--text-fluid-xl);
-        font-weight: var(--font-medium);
-    }
-
-    h4,
-    .h4 {
-        font-size: var(--text-xl);
-        font-size: var(--text-fluid-lg);
-    }
-}
-
-@media (min-width: 75rem) {
-    h1,
-    .h1 {
-        font-size: var(--text-7xl);
         font-size: var(--text-fluid-3xl);
+        font-weight: var(--font-bold);
     }
 
     h2,
     .h2 {
-        font-size: var(--text-5xl);
+        color: var(--heading-color);
+        font-size: var(--text-3xl);
         font-size: var(--text-fluid-2xl);
+        font-weight: var(--font-bold);
     }
 
     h3,
     .h3 {
-        font-size: var(--text-3xl);
+        color: var(--heading-color);
+        font-size: var(--text-xl);
         font-size: var(--text-fluid-xl);
+        font-weight: var(--font-bold);
     }
 
     h4,
     .h4 {
-        font-size: var(--text-2xl);
+        color: var(--heading-color);
+        font-family: var(--font-base);
+        font-size: var(--text-lg);
         font-size: var(--text-fluid-lg);
-        font-weight: var(--font-normal);
+        font-weight: var(--font-semibold);
     }
-}
 
-.text-error {
-    color: var(--color-error);
-}
+    h5,
+    .h5 {
+        @apply text-base;
 
-.text-success {
-    color: var(--color-success);
+        margin-block-end: 0;
+        margin-block-start: 0;
+    }
+
+    @media (min-width: 48rem) {
+        h1,
+        .h1 {
+            font-size: var(--text-6xl);
+            font-size: var(--text-fluid-3xl);
+        }
+
+        h2,
+        .h2 {
+            font-size: var(--text-4xl);
+            font-size: var(--text-fluid-2xl);
+            font-weight: var(--font-medium);
+        }
+
+        h3,
+        .h3 {
+            font-size: var(--text-2xl);
+            font-size: var(--text-fluid-xl);
+            font-weight: var(--font-medium);
+        }
+
+        h4,
+        .h4 {
+            font-size: var(--text-xl);
+            font-size: var(--text-fluid-lg);
+        }
+    }
+
+    @media (min-width: 75rem) {
+        h1,
+        .h1 {
+            font-size: var(--text-7xl);
+            font-size: var(--text-fluid-3xl);
+        }
+
+        h2,
+        .h2 {
+            font-size: var(--text-5xl);
+            font-size: var(--text-fluid-2xl);
+        }
+
+        h3,
+        .h3 {
+            font-size: var(--text-3xl);
+            font-size: var(--text-fluid-xl);
+        }
+
+        h4,
+        .h4 {
+            font-size: var(--text-2xl);
+            font-size: var(--text-fluid-lg);
+            font-weight: var(--font-normal);
+        }
+    }
+
+    .text-error {
+        color: var(--color-error);
+    }
+
+    .text-success {
+        color: var(--color-success);
+    }
 }


### PR DESCRIPTION
Because of the way Tailwind uses cascade layers, the `* + h2` top margin was overriding the `.mt-0` utility class which caused the icons on user dashboards to be vertically misaligned:

<img width="781" height="108" alt="Screenshot 2025-08-29 at 10 10 07 PM" src="https://github.com/user-attachments/assets/4b111ab7-7895-464e-8692-4267989d0d0b" />

This PR assigns the base typography styles to the `base` layer to ensure appropriate cascade behaviour and let the `.mt-0` class override the base rule. 

### Prerequisites

- [x] I've run `npm run lint` and fixed any linting issues.
- [x] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
