### PR TITLE
fix: missing parameter with pagination (resolves #2944)

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -564,20 +564,3 @@ if (! function_exists('trans_current_route')) {
         return $url;
     }
 }
-
-if (! function_exists('append_required_param_to_route')) {
-    function append_required_param_to_route(string $route, array $params)
-    {
-        $additionalParams = [];
-
-        if (Str::endsWith($route, 'libraries.show')) {
-            $additionalParams = ['library' => request()->route('library')];
-        }
-
-        if (Str::endsWith($route, 'resource-collections.show')) {
-            $additionalParams = ['resourceCollection' => request()->route('resourceCollection')];
-        }
-
-        return array_merge($additionalParams, $params);
-    }
-}

--- a/resources/views/vendor/livewire/tailwind-custom.blade.php
+++ b/resources/views/vendor/livewire/tailwind-custom.blade.php
@@ -1,7 +1,4 @@
 <div class="mt-16">
-    @php
-        $route = RalphJSmit\Livewire\Urls\Facades\Url::currentRoute();
-    @endphp
     @if ($paginator->hasPages())
         <nav class="flex flex-col items-center justify-between" role="navigation" aria-label="Pagination Navigation">
             <div class="mb-2 w-full text-center" role="alert" aria-live="polite">
@@ -14,13 +11,13 @@
                 </p>
             </div>
 
-            <div class="flex w-full justify-between sm:hidden">
+            <div class="w-full justify-between max-sm:flex sm:hidden">
                 <ul class="pagination flex w-full flex-row items-center justify-between" role="list">
                     <li>
                         @if ($paginator->onFirstPage())
                             <span class="spacer"></span>
                         @else
-                            <a href="{{ route($route, append_required_param_to_route($route, ['page' => $paginator->currentPage() - 1])) }}"
+                            <a href="{{ uri($paginator->url($paginator->currentPage()), array_merge($paginator->resolveQueryString(), [$paginator->getPageName() => $paginator->currentPage() - 1])) }}"
                                 aria-label="{{ __('pagination.previous') }}"
                                 wire:click.prevent="previousPage('{{ $paginator->getPageName() }}')"
                                 wire:loading.attr="disabled" rel="prev">
@@ -31,7 +28,7 @@
 
                     <li>
                         @if ($paginator->hasMorePages())
-                            <a href="{{ route($route, append_required_param_to_route($route, ['page' => $paginator->currentPage() + 1])) }}"
+                            <a href="{{ uri($paginator->url($paginator->currentPage()), array_merge($paginator->resolveQueryString(), [$paginator->getPageName() => $paginator->currentPage() + 1])) }}"
                                 aria-label="{{ __('pagination.next') }}"
                                 wire:click.prevent="nextPage('{{ $paginator->getPageName() }}')"
                                 wire:loading.attr="disabled" rel="prev">
@@ -49,7 +46,7 @@
                     @if (!$paginator->onFirstPage())
                         {{-- Previous Page Link --}}
                         <li>
-                            <a href="{{ route($route, append_required_param_to_route($route, ['page' => $paginator->currentPage() - 1])) }}"
+                            <a href="{{ uri($paginator->url($paginator->currentPage()), array_merge($paginator->resolveQueryString(), [$paginator->getPageName() => $paginator->currentPage() - 1])) }}"
                                 aria-label="{{ __('pagination.previous') }}"
                                 wire:click.prevent="previousPage('{{ $paginator->getPageName() }}')"
                                 wire:loading.attr="disabled" rel="prev">
@@ -69,7 +66,7 @@
                         @if (is_array($element))
                             @foreach ($element as $page => $url)
                                 <li wire:key="paginator-{{ $paginator->getPageName() }}-page{{ $page }}">
-                                    <a href="{{ route($route, append_required_param_to_route($route, ['page' => $page])) }}"
+                                    <a href="{{ uri($paginator->url($paginator->currentPage()), array_merge($paginator->resolveQueryString(), [$paginator->getPageName() => $page])) }}"
                                         wire:click.prevent="gotoPage({{ $page }}, '{{ $paginator->getPageName() }}')"
                                         @if ($page == $paginator->currentPage()) aria-current="page" @endif>
                                         <span class="visually-hidden">{{ __('page') }}</span> {{ $page }}
@@ -82,7 +79,7 @@
                     @if ($paginator->hasMorePages())
                         {{-- Next Page Link --}}
                         <li>
-                            <a href="{{ route($route, append_required_param_to_route($route, ['page' => $paginator->currentPage() + 1])) }}"
+                            <a href="{{ uri($paginator->url($paginator->currentPage()), array_merge($paginator->resolveQueryString(), [$paginator->getPageName() => $paginator->currentPage() + 1])) }}"
                                 aria-label="{{ __('pagination.next') }}"
                                 wire:click.prevent="nextPage('{{ $paginator->getPageName() }}')"
                                 wire:loading.attr="disabled" rel="prev">


### PR DESCRIPTION
<!-- Explain what this PR does. -->

- modifies how the pagination links are set to use the paginators `url` method and appending the page query parameter
- uses the paginates `pageName` which should allow for multiple paginators on the same page
- fixes the small screen next/previous page links which were showing up at all screen sizes

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
