### PR TITLE
fix: remove attach files button from markdown editors

### DIFF
--- a/app/Filament/Resources/Pages/PageResource.php
+++ b/app/Filament/Resources/Pages/PageResource.php
@@ -48,7 +48,7 @@ class PageResource extends Resource
                                 ['bold', 'italic', 'strike', 'link'],
                                 ['heading'],
                                 ['blockquote', 'codeBlock', 'bulletList', 'orderedList'],
-                                ['table', 'attachFiles'],
+                                ['table'],
                                 ['undo', 'redo'],
                             ])
                             ->label(__('Content').' ('.get_language_exonym('en').')')
@@ -58,7 +58,7 @@ class PageResource extends Resource
                                 ['bold', 'italic', 'strike', 'link'],
                                 ['heading'],
                                 ['blockquote', 'codeBlock', 'bulletList', 'orderedList'],
-                                ['table', 'attachFiles'],
+                                ['table'],
                                 ['undo', 'redo'],
                             ])
                             ->label(__('Content').' ('.get_language_exonym('fr').')')

--- a/app/Filament/Resources/Pages/Pages/EditPage.php
+++ b/app/Filament/Resources/Pages/Pages/EditPage.php
@@ -34,7 +34,7 @@ class EditPage extends EditRecord
                                 ['bold', 'italic', 'strike', 'link'],
                                 ['heading'],
                                 ['blockquote', 'codeBlock', 'bulletList', 'orderedList'],
-                                ['table', 'attachFiles'],
+                                ['table'],
                                 ['undo', 'redo'],
                             ])
                             ->label(__('Content').' ('.get_language_exonym('en').')')
@@ -44,7 +44,7 @@ class EditPage extends EditRecord
                                 ['bold', 'italic', 'strike', 'link'],
                                 ['heading'],
                                 ['blockquote', 'codeBlock', 'bulletList', 'orderedList'],
-                                ['table', 'attachFiles'],
+                                ['table'],
                                 ['undo', 'redo'],
                             ])
                             ->label(__('Content').' ('.get_language_exonym('fr').')')


### PR DESCRIPTION
<!-- Explain what this PR does. -->

- Removes the `attachFiles` buttons from the markdown editors. 
  - this was missed while making fixes for #2997

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
