### PR TITLE
fix: not able to add Resource to a Resource Collection (resolves #3025)

### DIFF
--- a/app/Filament/Resources/ResourceCollections/RelationManagers/ResourcesRelationManager.php
+++ b/app/Filament/Resources/ResourceCollections/RelationManagers/ResourcesRelationManager.php
@@ -39,8 +39,8 @@ class ResourcesRelationManager extends RelationManager
             ->headerActions([
                 AttachAction::make()
                     ->preloadRecordSelect()
-                    ->recordSelectOptionsQuery(fn ($query) => $query->orderBy('title->'.locale()))
-                    ->recordSelectSearchColumns(['title->en', 'title->fr']),
+                    ->recordSelectOptionsQuery(fn ($query) => $query->orderBy('created_at', 'desc'))
+                    ->forceSearchCaseInsensitive(),
             ])
             ->recordActions([
                 DetachAction::make(),

--- a/app/Filament/Resources/ResourceCollections/RelationManagers/ResourcesRelationManager.php
+++ b/app/Filament/Resources/ResourceCollections/RelationManagers/ResourcesRelationManager.php
@@ -37,7 +37,10 @@ class ResourcesRelationManager extends RelationManager
             ])
             ->filters([])
             ->headerActions([
-                AttachAction::make()->preloadRecordSelect(),
+                AttachAction::make()
+                    ->preloadRecordSelect()
+                    ->recordSelectOptionsQuery(fn ($query) => $query->orderBy('title->'.locale()))
+                    ->recordSelectSearchColumns(['title->en', 'title->fr']),
             ])
             ->recordActions([
                 DetachAction::make(),


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Fix to resolve the issue where resources are not able to be attached to a resource collection, along with sorting the preloaded list.

Resolves #3025 

### Changes
- Added `forceSearchCaseInsensitive()` to fix case-sensitive search 
- Changed sorting by `created_at desc` to show newest resources first in the dropdown

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
