### PR TITLE
fix: dropdown search in AttachAction/AssociateAction returns no results. (resolves #3029)

### DIFF
--- a/app/Filament/Resources/Libraries/RelationManagers/ResourceCollectionsRelationManager.php
+++ b/app/Filament/Resources/Libraries/RelationManagers/ResourceCollectionsRelationManager.php
@@ -23,7 +23,10 @@ class ResourceCollectionsRelationManager extends RelationManager
             ])
             ->filters([])
             ->headerActions([
-                AttachAction::make()->preloadRecordSelect(),
+                AttachAction::make()
+                    ->preloadRecordSelect()
+                    ->recordSelectOptionsQuery(fn ($query) => $query->orderBy('created_at', 'desc'))
+                    ->forceSearchCaseInsensitive(),
             ])
             ->recordActions([
                 DetachAction::make(),

--- a/app/Filament/Resources/Tools/RelationManagers/DocumentsRelationManager.php
+++ b/app/Filament/Resources/Tools/RelationManagers/DocumentsRelationManager.php
@@ -23,7 +23,11 @@ class DocumentsRelationManager extends RelationManager
             ])
             ->filters([])
             ->headerActions([
-                AssociateAction::make()->preloadRecordSelect()->associateAnother(false),
+                AssociateAction::make()
+                    ->preloadRecordSelect()
+                    ->associateAnother(false)
+                    ->recordSelectOptionsQuery(fn ($query) => $query->orderBy('created_at', 'desc'))
+                    ->forceSearchCaseInsensitive(),
             ])
             ->recordActions([
                 DissociateAction::make(),


### PR DESCRIPTION
- Added forceSearchCaseInsensitive() to AttachAction and AssociateAction to resolve dropdown search returning no results.

Resolves #3029 

<!-- Explain what this PR does. -->

### Description
Dropdown search in AttachAction and AssociateAction returns no results when record titles have mixed casing. Added `forceSearchCaseInsensitive()` to ensure search works regardless of case and sorting by `created_at` `desc` to show newest records first in the dropdown.


### Changes
- Added `forceSearchCaseInsensitive()` to AssociateAction in `DocumentsRelationManager`
- Added `forceSearchCaseInsensitive()` to AttachAction in `ResourceCollectionsRelationManager`
- Added `recordSelectOptionsQuery()` to sort records by newest first in both relation managers

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
