### PR TITLE
fix: error viewing tool when related document has no revisions (resolves #3031)

### DIFF
--- a/resources/views/tools/show.blade.php
+++ b/resources/views/tools/show.blade.php
@@ -27,7 +27,7 @@
         </div>
     </div>
 
-    @if ($tool->documents->count())
+    @if ($tool->revisions->count())
         <x-section class="full dark -mb-8" aria-labelledby="download-tool">
             <div class="center stack stack:xl py-20" x-data="{
                 open: false,


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #3031 

- Instead of checking the count of documents on a tool, checks the count of revisions before trying to render the list of available downloads.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
