### PR TITLE
fix: add middleware to maintain locale across livewire requests (resolves #3037)

### DIFF
--- a/app/Http/Middleware/ResolveRequestLocale.php
+++ b/app/Http/Middleware/ResolveRequestLocale.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Livewire\LivewireManager;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Persist and restore the application locale across Livewire requests.
+ *
+ * This middleware stores the locale in the session on page requests and
+ * restores it on Livewire requests.
+ *
+ * @see https://github.com/spatie/laravel-sluggable/discussions/228
+ * @see https://github.com/chinleung/laravel-multilingual-routes/issues/70
+ * @see https://github.com/accessibility-exchange/platform/issues/3037
+ */
+class ResolveRequestLocale
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (app(LivewireManager::class)->isLivewireRequest()) {
+            $locale = session('locale');
+
+            if ($locale && in_array($locale, locales(), false)) {
+                app()->setLocale($locale);
+            }
+        } else {
+            session(['locale' => app()->getLocale()]);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -32,6 +32,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         $middleware->appendToGroup('web', [
+            \App\Http\Middleware\ResolveRequestLocale::class,
             \RalphJSmit\Livewire\Urls\Middleware\LivewireUrlsMiddleware::class,
             \App\Http\Middleware\ConfirmLanguage::class,
         ]);

--- a/tests/Feature/Livewire/LibraryResourcesTest.php
+++ b/tests/Feature/Livewire/LibraryResourcesTest.php
@@ -1,9 +1,100 @@
 <?php
 
 use App\Livewire\LibraryResources;
+use App\Models\Library;
+use App\Models\ResourceCollection;
 use Livewire\Livewire;
+
+use function Pest\Laravel\get;
 
 it('renders successfully', function () {
     Livewire::test(LibraryResources::class)
         ->assertStatus(200);
+});
+
+test('resource collections can be paginated in English', function () {
+    $library = Library::factory()->create([
+        'title' => ['en' => 'Inclusive Employment', 'fr' => 'Emploi Inclusif'],
+    ]);
+
+    $collections = ResourceCollection::factory(11)->create();
+    $library->resourceCollections()->attach($collections);
+
+    /** @var \Illuminate\Pagination\LengthAwarePaginator|null $firstPageResults */
+    $firstPageResults = null;
+
+    Livewire::test(LibraryResources::class, ['library' => $library])
+        ->assertStatus(200)
+        ->assertViewHas('resourceCollections', function ($resourceCollections) use (&$firstPageResults) {
+            $firstPageResults = $resourceCollections;
+
+            return $resourceCollections->count() === 10;
+        })
+        ->call('setPage', 2, pageName: __('collections-page'))
+        ->assertStatus(200)
+        ->assertViewHas('resourceCollections', function ($resourceCollections) use ($firstPageResults) {
+            return $resourceCollections->count() === 1
+                && ! $firstPageResults->contains('id', $resourceCollections->first()->id);
+        });
+});
+
+test('resource collections can be paginated in French', function () {
+    $library = Library::factory()->create([
+        'title' => ['en' => 'Inclusive Employment', 'fr' => 'Emploi Inclusif'],
+    ]);
+
+    $collections = ResourceCollection::factory(11)->create();
+    $library->resourceCollections()->attach($collections);
+
+    app()->setLocale('fr');
+    session(['locale' => 'fr']);
+
+    /** @var \Illuminate\Pagination\LengthAwarePaginator|null $firstPageResults */
+    $firstPageResults = null;
+
+    Livewire::test(LibraryResources::class, ['library' => $library])
+        ->assertStatus(200)
+        ->assertViewHas('resourceCollections', function ($resourceCollections) use (&$firstPageResults) {
+            $firstPageResults = $resourceCollections;
+
+            return $resourceCollections->count() === 10;
+        })
+        ->call('setPage', 2, pageName: __('collections-page'))
+        ->assertStatus(200)
+        ->assertViewHas('resourceCollections', function ($resourceCollections) use ($firstPageResults) {
+            return $resourceCollections->count() === 1
+                && ! $firstPageResults->contains('id', $resourceCollections->first()->id);
+        });
+});
+
+test('locale is stored in the session after visiting a French page', function () {
+    $library = Library::factory()->create([
+        'title' => ['en' => 'Inclusive Employment', 'fr' => 'Emploi Inclusif'],
+    ]);
+
+    app()->setLocale('fr');
+    $url = localized_route('libraries.show', $library);
+    app()->setLocale('en');
+
+    get($url)->assertOk();
+
+    expect(session('locale'))->toBe('fr');
+});
+
+test('session locale is updated when user switches from French to English', function () {
+    $library = Library::factory()->create([
+        'title' => ['en' => 'Inclusive Employment', 'fr' => 'Emploi Inclusif'],
+    ]);
+
+    app()->setLocale('fr');
+    $frenchUrl = localized_route('libraries.show', $library);
+
+    app()->setLocale('en');
+    $englishUrl = localized_route('libraries.show', $library);
+
+    get($frenchUrl)->assertOk();
+    expect(session('locale'))->toBe('fr');
+
+    get($englishUrl)->assertOk();
+    expect(session('locale'))->toBe('en');
 });


### PR DESCRIPTION
When searching or filtering on a page in a non-default locale, Livewire update requests fail with an error for pages that use translatable slugs. This middleware stores the locale in the session on page requests and restores it on Livewire requests.  
Resolves #3037 

### Changes

- Added `ResolveRequestLocale` middleware.

### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [x] I've run `php artisan test` and ensured that all tests pass.
- [x] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
