### PR TITLE
fix: deployment timeout failure related to Migrate Data (resolves #3051)

### DIFF
--- a/app/Console/Commands/MigrateData.php
+++ b/app/Console/Commands/MigrateData.php
@@ -20,7 +20,7 @@ class MigrateData extends Command implements Isolatable
      */
     protected $signature = 'app:migrate-data
                             {--list : lists out available migrations}
-                            {--from=1.6.0 : when running all migrations, indicate which version the application is being migrated from. Previous migrations will be skipped.}
+                            {--from=1.8.0 : when running all migrations, indicate which version the application is being migrated from. Previous migrations will be skipped.}
                             {--migration= : a specific migration to run}';
 
     /**
@@ -95,7 +95,7 @@ class MigrateData extends Command implements Isolatable
         }
     }
 
-    public function runMigrations($migrations, $from = '1.6.0', $verbose = false)
+    public function runMigrations($migrations, $from = '1.8.0', $verbose = false)
     {
         $from = str_starts_with($from, 'v') || str_starts_with($from, 'V') ? substr($from, 1) : $from;
         $migrationRunCount = 0;

--- a/tests/Feature/Console/MigrateDataTest.php
+++ b/tests/Feature/Console/MigrateDataTest.php
@@ -19,7 +19,7 @@ test('app:migrate-data command runs successfully', function () {
 });
 
 test('app:migrate-data command can list migrations', function () {
-    $this->artisan('app:migrate-data --list')
+    artisan('app:migrate-data --list')
         ->assertSuccessful()
         ->expectsOutputToContain('Version added');
 
@@ -43,7 +43,7 @@ test('app:migrate-data command can run migrations starting at a specific version
 });
 
 test('app:migrate-data command can run with verbose logging', function () {
-    artisan('app:migrate-data -v')
+    artisan('app:migrate-data --from=1.6.0 -v')
         ->assertSuccessful()
         ->expectsOutputToContain('Run migration -');
 
@@ -60,7 +60,7 @@ test('enableEngagementNotificationsMigration - Migrates Individual users and org
         'notification_settings' => ['other' => 'test'],
     ]);
 
-    artisan('app:migrate-data')->assertSuccessful();
+    artisan('app:migrate-data --migration=EnableEngagementNotifications')->assertSuccessful();
 
     $user->refresh();
     expect($user->notification_settings->get('other'))->toBeNull();
@@ -83,7 +83,7 @@ test('enableEngagementNotificationsMigration - Only migrates Individual users an
 
     $fro = RegulatedOrganization::factory()->create();
 
-    artisan('app:migrate-data')->assertSuccessful();
+    artisan('app:migrate-data --migration=EnableEngagementNotifications')->assertSuccessful();
 
     $user->refresh();
     expect($user->notification_settings->get('engagements'))->toBeNull();
@@ -106,7 +106,7 @@ test('enableEngagementNotificationsMigration - skips when notifications_settings
         'notification_settings' => ['engagements' => '0'],
     ]);
 
-    artisan('app:migrate-data')->assertSuccessful();
+    artisan('app:migrate-data --migration=EnableEngagementNotifications')->assertSuccessful();
 
     $user->refresh();
     expect($user->notification_settings->get('engagements'))->toBe('0');
@@ -135,7 +135,7 @@ test('schemalessPromptsMigration - migrates user data successfully', function ()
         'dismissed_invite_prompt_at' => $datetime,
     ]);
 
-    artisan('app:migrate-data')->assertSuccessful();
+    artisan('app:migrate-data --migration=SchemalessPrompts')->assertSuccessful();
 
     $user->refresh();
     $org->refresh();


### PR DESCRIPTION
<!-- Explain what this PR does. -->

Resolves #3051

- Adds more additional verbose outputs to Migrate Data
- Uses verbose output when running `app:migrate-data` from the entrypoint script
- Adds an environment variable to set the from version with when run from the entrypoint script
  - currently set to 1.8.0
- Makes the `app:migrate-data` call from the entrypoint script async 


### Prerequisites

If this PR changes PHP code or dependencies:

- [x] I've run `composer format` and fixed any code formatting issues.
- [x] I've run `composer analyze` and addressed any static analysis issues.
- [ ] I've run `php artisan test` and ensured that all tests pass.
- [ ] I've run `composer localize` to update localization source files and committed any changes.

If this PR changes CSS or JavaScript code or dependencies:

- [ ] I've run `npm run lint` and fixed any linting issues.
- [ ] I've run `npm run build` and ensured that CSS and JavaScript assets can be compiled.
